### PR TITLE
treat "SSSSSS" in SimpleDateFormat as microseconds

### DIFF
--- a/src/main/cpp/simpledateformat.cpp
+++ b/src/main/cpp/simpledateformat.cpp
@@ -497,6 +497,21 @@ public:
 
 
 
+class MicrosecondToken : public NumericToken
+{
+public:
+  MicrosecondToken( int width1 ) : NumericToken( width1 )
+  {
+  }
+
+  int getField( const apr_time_exp_t & tm ) const
+  {
+    return tm.tm_usec;
+  }
+};
+
+
+
 class AMPMToken : public PatternToken
 {
 public:
@@ -683,7 +698,21 @@ void SimpleDateFormat::addToken(const logchar spec, const int repeat, const std:
                break;
 
                case 0x53: // 'S'
-                 token = ( new MillisecondToken( repeat ) );
+                 if ( repeat == 3 )
+                 {
+                   token = ( new MillisecondToken( repeat ) );
+                 }
+                 else if ( repeat == 6 )
+                 {
+                   token = ( new MicrosecondToken( repeat ) );
+                 }
+                 else
+                 {
+                   // It would be nice to support patterns with arbitrary
+                   // subsecond precision (like "s.S" or "s.SSSS"), but we
+                   // don't; make sure the user is not misled.
+                   token = ( new LiteralToken( spec, repeat ) );
+                 }
                break;
 
                case 0x7A: // 'z'


### PR DESCRIPTION
This patch allows users to choose timestamp precision in a simple
manner.  The SimpleDateFormat pattern "SSS" will be replaced with the
fractional second part of the entry's timestamp with millisecond
precision (as before), and "SSSSSS" with microsecond precision.

Since runs of "S" characters other than 3 or 6 would not render
correctly (without this patch, "s.SSSS" will render 3 seconds, 123
milliseconds as "3.0123"), such patterns are passed through verbatim so
the user can realize there is a problem.

Signed-off-by: Nathaniel W. Turner <nate@houseofnate.net>