### PR TITLE
Build with autotools+maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 target/
+
+*.o
+*.lo
+Makefile
+Makefile.in
+*.m4
+.deps
+.dirstamp
+*.swp
+config**
+autom4te.cache

--- a/pom.xml
+++ b/pom.xml
@@ -173,19 +173,40 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.7</version>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.6.0</version>
 				<executions>
+					<execution>
+						<phase>generate-resources</phase>
+						<id>generate-resources</id>
+						<configuration>
+							<executable>./autogen.sh</executable>
+						</configuration>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+					</execution>
+
+					<execution>
+						<phase>generate-resources</phase>
+						<id>generate-resources-configure</id>
+						<configuration>
+							<executable>./configure</executable>
+						</configuration>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+					</execution>
+
 					<execution>
 						<phase>compile</phase>
 						<id>compile</id>
 						<configuration>
-							<target>
-								<ant target="build" />
-							</target>
+							<executable>make</executable>
 						</configuration>
 						<goals>
-							<goal>run</goal>
+							<goal>exec</goal>
 						</goals>
 					</execution>
 
@@ -193,25 +214,13 @@
 						<phase>test-compile</phase>
 						<id>test-compile</id>
 						<configuration>
-							<target unless="${maven.test.skip}">
-								<ant target="test-compile" />
-							</target>
+							<executable>make</executable>
+							<arguments>
+								<argument>check</argument>
+							</arguments>
 						</configuration>
 						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-
-					<execution>
-						<phase>test</phase>
-						<id>test</id>
-						<configuration>
-							<target unless="${maven.test.skip}">
-								<ant target="check" />
-							</target>
-						</configuration>
-						<goals>
-							<goal>run</goal>
+							<goal>exec</goal>
 						</goals>
 					</execution>
 
@@ -219,15 +228,18 @@
 						<phase>package</phase>
 						<id>autogen</id>
 						<configuration>
-							<target>
-								<ant target="autogen" />
-							</target>
+							<executable>make</executable>
+							<arguments>
+								<argument>dist</argument>
+								<argument>dist-zip</argument>
+							</arguments>
 						</configuration>
 						<goals>
-							<goal>run</goal>
+							<goal>exec</goal>
 						</goals>
 					</execution>
 
+<!--
 					<execution>
 						<phase>site</phase>
 						<id>site</id>
@@ -266,8 +278,10 @@
 							<goal>run</goal>
 						</goals>
 					</execution>
+-->
 				</executions>
 
+<!--
 				<dependencies>
 					<dependency>
 						<groupId>org.apache.ant</groupId>
@@ -287,16 +301,16 @@
 						<version>1.0b5</version>
 					</dependency>
 				</dependencies>
+-->
 			</plugin>
 
+<!--
 			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.6.0</version>
 				<configuration>
-					<descriptors>
-						<descriptor>src/assembly/source.xml</descriptor>
-					</descriptors>
-					<appendAssemblyId>false</appendAssemblyId>
-					<tarLongFileMode>gnu</tarLongFileMode>
+					<executable></executable>
 				</configuration>
 				<executions>
 					<execution>
@@ -306,11 +320,12 @@
 					</execution>
 				</executions>
 			</plugin>
+-->
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>rat-maven-plugin</artifactId>
-				<version>1.0-alpha-3</version>
+				<groupId>org.apache.rat</groupId>
+				<artifactId>apache-rat-plugin</artifactId>
+				<version>0.12</version>
 			</plugin>
 
 			<plugin>
@@ -323,7 +338,7 @@
 
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.3</version>
+				<version>2.5</version>
 				<configuration>
 					<goals>site-deploy assembly:assembly</goals>
 				</configuration>


### PR DESCRIPTION
This fix updates the log4cxx maven file to build with Maven properly when running on Linux.

It is rather simplistic at this point, and it will break on Windows.  There was some discussion earlier on using CMake for the build system instead of autotools.