### PR TITLE
LOGCXX-494: windows cmake build for log4cxx against apr-2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,446 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+cmake_minimum_required(VERSION 3.1)
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(PROJECT_DESCRIPTION "Apache Logging Framework for C++")
+set(PROJECT_NAME        "log4cxx")
+set(PROJECT_LICENSE     "Apache Software License 2.0")
+set(PROJECT_LICURL      "http://www.apache.org/licenses/LICENSE-2.0")
+set(PROJECT_URL         "http://logging.apache.org/log4cxx/")
+
+include(ExtractVersion)
+extract_version(PROJECT_VERSION)
+
+message(STATUS "Configuring build environment for ${PROJECT_NAME} version ${PROJECT_VERSION}")
+
+### project
+
+project(${PROJECT_NAME} VERSION ${PROJECT_VERSION})
+
+### options
+
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static" ON)
+option(MSVC_SHARED_RUNTIME "Build using shared Microsoft Runtime (MSVC-only)" ON)
+
+### dependencies
+
+# The APR CMake build drops static and shared libraries into the same location
+# when processing the install target and they have different names on Windows.
+if (MSVC AND BUILD_SHARED_LIBS)
+  set(APR2_LIBNAMES "libapr-2")
+endif ()
+
+find_package(APR2 REQUIRED)
+
+### includes
+
+include(LanguageSpecific)
+include(PlatformSpecific)
+include(Summary)
+
+### targets
+
+set(LOG4CXX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/main")
+
+configure_file("${LOG4CXX_DIR}/include/log4cxx/log4cxx.hw"
+  "${CMAKE_CURRENT_BINARY_DIR}/include/log4cxx/log4cxx.h"
+  COPYONLY
+)
+
+configure_file("${LOG4CXX_DIR}/include/log4cxx/private/log4cxx_private.hw"
+  "${CMAKE_CURRENT_BINARY_DIR}/include/log4cxx/private/log4cxx_private.h"
+  COPYONLY
+)
+
+set(LOG4CXX_INCLUDE_DIRECTORIES
+  ${LOG4CXX_DIR}/include
+  ${CMAKE_CURRENT_BINARY_DIR}/include
+  ${APR2_INCLUDE_DIRS}
+  )
+
+set(LOG4CXX_HEADERS
+  ${LOG4CXX_DIR}/include/log4cxx/appender.h
+  ${LOG4CXX_DIR}/include/log4cxx/appenderskeleton.h
+  ${LOG4CXX_DIR}/include/log4cxx/asyncappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/basicconfigurator.h
+  ${LOG4CXX_DIR}/include/log4cxx/config/propertysetter.h
+  ${LOG4CXX_DIR}/include/log4cxx/consoleappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/dailyrollingfileappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/db/odbcappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/defaultconfigurator.h
+  ${LOG4CXX_DIR}/include/log4cxx/defaultloggerfactory.h
+  ${LOG4CXX_DIR}/include/log4cxx/fileappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/file.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/andfilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/denyallfilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/expressionfilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/levelmatchfilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/levelrangefilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/locationinfofilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/loggermatchfilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/mapfilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/propertyfilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/filter/stringmatchfilter.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/absolutetimedateformat.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/appenderattachableimpl.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/aprinitializer.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/bufferedoutputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/bufferedwriter.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/bytearrayinputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/bytearrayoutputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/bytebuffer.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/cacheddateformat.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/charsetdecoder.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/charsetencoder.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/class.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/classregistration.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/condition.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/cyclicbuffer.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/datagrampacket.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/datagramsocket.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/dateformat.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/date.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/datelayout.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/datetimedateformat.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/exception.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/fileinputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/fileoutputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/filewatchdog.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/inetaddress.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/inputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/inputstreamreader.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/integer.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/iso8601dateformat.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/loader.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/locale.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/loglog.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/messagebuffer.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/mutex.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/object.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/objectimpl.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/objectoutputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/objectptr.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/onlyonceerrorhandler.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/optionconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/outputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/outputstreamwriter.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/pool.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/properties.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/propertyresourcebundle.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/reader.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/relativetimedateformat.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/resourcebundle.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/serversocket.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/simpledateformat.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/socket.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/socketoutputstream.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/strftimedateformat.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/strictmath.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/stringhelper.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/stringtokenizer.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/synchronized.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/syslogwriter.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/systemerrwriter.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/system.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/systemoutwriter.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/tchar.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/thread.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/threadlocal.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/threadspecificdata.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/timezone.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/transcoder.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/transform.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/writer.h
+  ${LOG4CXX_DIR}/include/log4cxx/helpers/xml.h
+  ${LOG4CXX_DIR}/include/log4cxx/hierarchy.h
+  ${LOG4CXX_DIR}/include/log4cxx/htmllayout.h
+  ${LOG4CXX_DIR}/include/log4cxx/layout.h
+  ${LOG4CXX_DIR}/include/log4cxx/level.h
+  ${LOG4CXX_DIR}/include/log4cxx/logger.h
+  ${LOG4CXX_DIR}/include/log4cxx/logmanager.h
+  ${LOG4CXX_DIR}/include/log4cxx/logstring.h
+  ${LOG4CXX_DIR}/include/log4cxx/mdc.h
+  ${LOG4CXX_DIR}/include/log4cxx/ndc.h
+  ${LOG4CXX_DIR}/include/log4cxx/net/smtpappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/net/socketappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/net/socketappenderskeleton.h
+  ${LOG4CXX_DIR}/include/log4cxx/net/sockethubappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/net/syslogappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/net/telnetappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/net/xmlsocketappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/nt/nteventlogappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/nt/outputdebugstringappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/classnamepatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/datepatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/filedatepatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/filelocationpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/formattinginfo.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/fulllocationpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/integerpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/patternlayout.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/levelpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/linelocationpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/lineseparatorpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/literalpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/loggerpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/loggingeventpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/messagepatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/methodlocationpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/nameabbreviator.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/namepatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/ndcpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/patternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/patternparser.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/propertiespatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/relativetimepatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/threadpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/pattern/throwableinformationpatternconverter.h
+  ${LOG4CXX_DIR}/include/log4cxx/portability.h
+  ${LOG4CXX_DIR}/include/log4cxx/propertyconfigurator.h
+  ${LOG4CXX_DIR}/include/log4cxx/provisionnode.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/action.h
+  ${LOG4CXX_DIR}/include/log4cxx/rollingfileappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/filerenameaction.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/filterbasedtriggeringpolicy.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/fixedwindowrollingpolicy.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/gzcompressaction.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/manualtriggeringpolicy.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/rollingfileappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/rollingfileappenderskeleton.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/rollingpolicybase.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/rollingpolicy.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/rolloverdescription.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/sizebasedtriggeringpolicy.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/timebasedrollingpolicy.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/triggeringpolicy.h
+  ${LOG4CXX_DIR}/include/log4cxx/rolling/zipcompressaction.h
+  ${LOG4CXX_DIR}/include/log4cxx/simplelayout.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/appenderattachable.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/configurator.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/defaultrepositoryselector.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/errorhandler.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/filter.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/hierarchyeventlistener.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/location/locationinfo.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/loggerfactory.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/loggerrepository.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/loggingevent.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/optionhandler.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/repositoryselector.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/rootlogger.h
+  ${LOG4CXX_DIR}/include/log4cxx/spi/triggeringeventevaluator.h
+  ${LOG4CXX_DIR}/include/log4cxx/stream.h
+  ${LOG4CXX_DIR}/include/log4cxx/ttcclayout.h
+  ${LOG4CXX_DIR}/include/log4cxx/varia/fallbackerrorhandler.h
+  ${LOG4CXX_DIR}/include/log4cxx/writerappender.h
+  ${LOG4CXX_DIR}/include/log4cxx/xml/domconfigurator.h
+  ${LOG4CXX_DIR}/include/log4cxx/xml/xmllayout.h
+)
+
+set(LOG4CXX_SRC
+  ${LOG4CXX_DIR}/cpp/action.cpp
+  ${LOG4CXX_DIR}/cpp/andfilter.cpp
+  ${LOG4CXX_DIR}/cpp/appenderattachableimpl.cpp
+  ${LOG4CXX_DIR}/cpp/appenderskeleton.cpp
+  ${LOG4CXX_DIR}/cpp/aprinitializer.cpp
+  ${LOG4CXX_DIR}/cpp/asyncappender.cpp
+  ${LOG4CXX_DIR}/cpp/basicconfigurator.cpp
+  ${LOG4CXX_DIR}/cpp/bufferedwriter.cpp
+  ${LOG4CXX_DIR}/cpp/bytearrayinputstream.cpp
+  ${LOG4CXX_DIR}/cpp/bytearrayoutputstream.cpp
+  ${LOG4CXX_DIR}/cpp/bytebuffer.cpp
+  ${LOG4CXX_DIR}/cpp/cacheddateformat.cpp
+  ${LOG4CXX_DIR}/cpp/charsetdecoder.cpp
+  ${LOG4CXX_DIR}/cpp/charsetencoder.cpp
+  ${LOG4CXX_DIR}/cpp/class.cpp
+  ${LOG4CXX_DIR}/cpp/classnamepatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/classregistration.cpp
+  ${LOG4CXX_DIR}/cpp/condition.cpp
+  ${LOG4CXX_DIR}/cpp/configurator.cpp
+  ${LOG4CXX_DIR}/cpp/consoleappender.cpp
+  ${LOG4CXX_DIR}/cpp/cyclicbuffer.cpp
+  ${LOG4CXX_DIR}/cpp/dailyrollingfileappender.cpp
+  ${LOG4CXX_DIR}/cpp/datagrampacket.cpp
+  ${LOG4CXX_DIR}/cpp/datagramsocket.cpp
+  ${LOG4CXX_DIR}/cpp/date.cpp
+  ${LOG4CXX_DIR}/cpp/dateformat.cpp
+  ${LOG4CXX_DIR}/cpp/datelayout.cpp
+  ${LOG4CXX_DIR}/cpp/datepatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/defaultconfigurator.cpp
+  ${LOG4CXX_DIR}/cpp/defaultloggerfactory.cpp
+  ${LOG4CXX_DIR}/cpp/defaultrepositoryselector.cpp
+  ${LOG4CXX_DIR}/cpp/domconfigurator.cpp
+  ${LOG4CXX_DIR}/cpp/exception.cpp
+  ${LOG4CXX_DIR}/cpp/fallbackerrorhandler.cpp
+  ${LOG4CXX_DIR}/cpp/fileappender.cpp
+  ${LOG4CXX_DIR}/cpp/file.cpp
+  ${LOG4CXX_DIR}/cpp/filedatepatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/fileinputstream.cpp
+  ${LOG4CXX_DIR}/cpp/filelocationpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/fileoutputstream.cpp
+  ${LOG4CXX_DIR}/cpp/filerenameaction.cpp
+  ${LOG4CXX_DIR}/cpp/filewatchdog.cpp
+  ${LOG4CXX_DIR}/cpp/filterbasedtriggeringpolicy.cpp
+  ${LOG4CXX_DIR}/cpp/filter.cpp
+  ${LOG4CXX_DIR}/cpp/fixedwindowrollingpolicy.cpp
+  ${LOG4CXX_DIR}/cpp/formattinginfo.cpp
+  ${LOG4CXX_DIR}/cpp/fulllocationpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/gzcompressaction.cpp
+  ${LOG4CXX_DIR}/cpp/hierarchy.cpp
+  ${LOG4CXX_DIR}/cpp/htmllayout.cpp
+  ${LOG4CXX_DIR}/cpp/inetaddress.cpp
+  ${LOG4CXX_DIR}/cpp/inputstream.cpp
+  ${LOG4CXX_DIR}/cpp/inputstreamreader.cpp
+  ${LOG4CXX_DIR}/cpp/integer.cpp
+  ${LOG4CXX_DIR}/cpp/integerpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/layout.cpp
+  ${LOG4CXX_DIR}/cpp/level.cpp
+  ${LOG4CXX_DIR}/cpp/levelmatchfilter.cpp
+  ${LOG4CXX_DIR}/cpp/levelpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/levelrangefilter.cpp
+  ${LOG4CXX_DIR}/cpp/linelocationpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/lineseparatorpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/literalpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/loader.cpp
+  ${LOG4CXX_DIR}/cpp/locale.cpp
+  ${LOG4CXX_DIR}/cpp/locationinfo.cpp
+  ${LOG4CXX_DIR}/cpp/logger.cpp
+  ${LOG4CXX_DIR}/cpp/loggermatchfilter.cpp
+  ${LOG4CXX_DIR}/cpp/loggerpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/loggingevent.cpp
+  ${LOG4CXX_DIR}/cpp/loggingeventpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/loglog.cpp
+  ${LOG4CXX_DIR}/cpp/logmanager.cpp
+  ${LOG4CXX_DIR}/cpp/logstream.cpp
+  ${LOG4CXX_DIR}/cpp/manualtriggeringpolicy.cpp
+  ${LOG4CXX_DIR}/cpp/mdc.cpp
+  ${LOG4CXX_DIR}/cpp/messagebuffer.cpp
+  ${LOG4CXX_DIR}/cpp/messagepatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/methodlocationpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/mutex.cpp
+  ${LOG4CXX_DIR}/cpp/nameabbreviator.cpp
+  ${LOG4CXX_DIR}/cpp/namepatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/ndc.cpp
+  ${LOG4CXX_DIR}/cpp/ndcpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/nteventlogappender.cpp
+  ${LOG4CXX_DIR}/cpp/objectimpl.cpp
+  ${LOG4CXX_DIR}/cpp/objectoutputstream.cpp
+  ${LOG4CXX_DIR}/cpp/objectptr.cpp
+  ${LOG4CXX_DIR}/cpp/obsoleterollingfileappender.cpp
+  ${LOG4CXX_DIR}/cpp/odbcappender.cpp
+  ${LOG4CXX_DIR}/cpp/onlyonceerrorhandler.cpp
+  ${LOG4CXX_DIR}/cpp/optionconverter.cpp
+  ${LOG4CXX_DIR}/cpp/outputdebugstringappender.cpp
+  ${LOG4CXX_DIR}/cpp/outputstream.cpp
+  ${LOG4CXX_DIR}/cpp/outputstreamwriter.cpp
+  ${LOG4CXX_DIR}/cpp/patternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/patternlayout.cpp
+  ${LOG4CXX_DIR}/cpp/patternparser.cpp
+  ${LOG4CXX_DIR}/cpp/pool.cpp
+  ${LOG4CXX_DIR}/cpp/properties.cpp
+  ${LOG4CXX_DIR}/cpp/propertiespatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/propertyconfigurator.cpp
+  ${LOG4CXX_DIR}/cpp/propertyresourcebundle.cpp
+  ${LOG4CXX_DIR}/cpp/propertysetter.cpp
+  ${LOG4CXX_DIR}/cpp/reader.cpp
+  ${LOG4CXX_DIR}/cpp/relativetimedateformat.cpp
+  ${LOG4CXX_DIR}/cpp/relativetimepatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/resourcebundle.cpp
+  ${LOG4CXX_DIR}/cpp/rollingfileappender.cpp
+  ${LOG4CXX_DIR}/cpp/rollingpolicybase.cpp
+  ${LOG4CXX_DIR}/cpp/rollingpolicy.cpp
+  ${LOG4CXX_DIR}/cpp/rolloverdescription.cpp
+  ${LOG4CXX_DIR}/cpp/rootlogger.cpp
+  ${LOG4CXX_DIR}/cpp/serversocket.cpp
+  ${LOG4CXX_DIR}/cpp/simpledateformat.cpp
+  ${LOG4CXX_DIR}/cpp/simplelayout.cpp
+  ${LOG4CXX_DIR}/cpp/sizebasedtriggeringpolicy.cpp
+  ${LOG4CXX_DIR}/cpp/smtpappender.cpp
+  ${LOG4CXX_DIR}/cpp/socketappender.cpp
+  ${LOG4CXX_DIR}/cpp/socketappenderskeleton.cpp
+  ${LOG4CXX_DIR}/cpp/socket.cpp
+  ${LOG4CXX_DIR}/cpp/sockethubappender.cpp
+  ${LOG4CXX_DIR}/cpp/socketoutputstream.cpp
+  ${LOG4CXX_DIR}/cpp/strftimedateformat.cpp
+  ${LOG4CXX_DIR}/cpp/stringhelper.cpp
+  ${LOG4CXX_DIR}/cpp/stringmatchfilter.cpp
+  ${LOG4CXX_DIR}/cpp/stringtokenizer.cpp
+  ${LOG4CXX_DIR}/cpp/synchronized.cpp
+  ${LOG4CXX_DIR}/cpp/syslogappender.cpp
+  ${LOG4CXX_DIR}/cpp/syslogwriter.cpp
+  ${LOG4CXX_DIR}/cpp/system.cpp
+  ${LOG4CXX_DIR}/cpp/systemerrwriter.cpp
+  ${LOG4CXX_DIR}/cpp/systemoutwriter.cpp
+  ${LOG4CXX_DIR}/cpp/telnetappender.cpp
+  ${LOG4CXX_DIR}/cpp/threadcxx.cpp
+  ${LOG4CXX_DIR}/cpp/threadlocal.cpp
+  ${LOG4CXX_DIR}/cpp/threadpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/threadspecificdata.cpp
+  ${LOG4CXX_DIR}/cpp/throwableinformationpatternconverter.cpp
+  ${LOG4CXX_DIR}/cpp/timebasedrollingpolicy.cpp
+  ${LOG4CXX_DIR}/cpp/timezone.cpp
+  ${LOG4CXX_DIR}/cpp/transcoder.cpp
+  ${LOG4CXX_DIR}/cpp/transform.cpp
+  ${LOG4CXX_DIR}/cpp/triggeringpolicy.cpp
+  ${LOG4CXX_DIR}/cpp/ttcclayout.cpp
+  ${LOG4CXX_DIR}/cpp/writerappender.cpp
+  ${LOG4CXX_DIR}/cpp/writer.cpp
+  ${LOG4CXX_DIR}/cpp/xmllayout.cpp
+  ${LOG4CXX_DIR}/cpp/xmlsocketappender.cpp
+  ${LOG4CXX_DIR}/cpp/zipcompressaction.cpp
+)
+
+add_library(${PROJECT_NAME} ${LOG4CXX_SRC} ${LOG4CXX_HEADERS})
+target_include_directories(${PROJECT_NAME} PUBLIC ${LOG4CXX_INCLUDE_DIRECTORIES})
+target_link_libraries(${PROJECT_NAME}
+  ${APR2_LIBRARIES}
+  odbc32
+# rpcrt4
+# ws2_32
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/include/log4cxx/log4cxx.h"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/include/log4cxx/"
+  PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
+)
+
+install(
+  DIRECTORY "${LOG4CXX_DIR}/include/"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/include/"
+  DIRECTORY_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
+  FILES_MATCHING PATTERN "*.h"
+                 PATTERN "*/private/*" EXCLUDE
+  PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
+)
+
+#if(MSVC)
+#  install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/${PROJECT_NAME}*.pdb" DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS Debug RelWithDebInfo)
+#endif()
+
+summary()

--- a/cmake/ExtractVersion.cmake
+++ b/cmake/ExtractVersion.cmake
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# extract_version(varname)
+#
+# Read the configure.ac file and extract the software version
+# and place it into the variable defined by varname
+#
+
+function(extract_version varname)
+    file (STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGURE_AC REGEX "AC_INIT\\(.*\\)" )
+    string(REGEX REPLACE "AC_INIT\\(\\[.*\\], \\[([0-9]+\\.[0-9]+\\.[0-9]+(-dev)?)\\]\\)" "\\1" RESULT_VERSION ${CONFIGURE_AC})
+	set(${varname} ${RESULT_VERSION} PARENT_SCOPE)
+endfunction()

--- a/cmake/FindAPR2.cmake
+++ b/cmake/FindAPR2.cmake
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Locates APR Version 2
+#
+# APR Version 2 contains APRUTIL. 
+# In previous APR releases they were separate libraries.
+#
+# Usage of this module as follows:
+#
+#  find_package(APR2)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  APR2_LIBNAMES           Allows the caller to distinguish static vs. shared
+#                          libraries when searching, by specifying the full
+#                          filename of the library to look for.
+#  APR2_ROOT_DIR           Set this variable to the root installation of Apache 
+#                          Portable Runtime/Util Library if the module has 
+#                          problems finding the proper installation path.
+#
+# Variables defined by this module:
+#
+#  APR2_FOUND              System has Apache Portable Runtime 2 libs/headers
+#  APR2_INCLUDE_DIRS       The location of Apache Portable Runtime 2 headers
+#  APR2_LIBRARIES          The Apache Portable Runtime 2 libraries
+#
+
+find_path(APR2_INCLUDE_DIRS
+  NAMES apr.h apu.h
+  HINTS ${APR2_ROOT_DIR}/include
+)
+
+find_library(APR2_LIBRARIES
+  NAMES ${APR2_LIBNAMES} apr-2
+  HINTS ${APR2_ROOT_DIR}/lib
+)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(APR2
+        "Could not find APR2 - try setting APR2_ROOT_DIR"
+        APR2_INCLUDE_DIRS
+        APR2_LIBRARIES
+)
+
+mark_as_advanced(
+  APR2_FOUND
+  APR2_INCLUDE_DIR
+  APR2_LIBRARIES
+)

--- a/cmake/LanguageSpecific.cmake
+++ b/cmake/LanguageSpecific.cmake
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# C++ Language Defaults:
+#
+# CMAKE_CXX_STANDARD           98     (c++98)
+# CMAKE_CXX_STANDARD_REQUIRED  ON
+# CMAKE_CXX_EXTENSIONS         OFF    (i.e. not gnu++98)
+#
+
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 98)
+endif()
+
+if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+
+set(CXX_LANGUAGE_LEVEL "c++${CMAKE_CXX_STANDARD}")
+
+if (CMAKE_CXX_STANDARD_REQUIRED)
+  string(CONCAT CXX_LANGUAGE_LEVEL "${CXX_LANGUAGE_LEVEL} [compiler must support it]")
+else()
+  string(CONCAT CXX_LANGUAGE_LEVEL "${CXX_LANGUAGE_LEVEL} [fallback to earlier revision allowed]")
+endif()
+if (CMAKE_CXX_EXTENSIONS)
+  string(CONCAT CXX_LANGUAGE_LEVEL "${CXX_LANGUAGE_LEVEL} [with compiler-specific extensions]")
+endif()

--- a/cmake/NewPlatformDebug.cmake
+++ b/cmake/NewPlatformDebug.cmake
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# For debugging new platforms, just to see what some environment flags are...
+#
+macro(SHOWFLAG flag)
+  message(STATUS "${flag} = ${${flag}}")
+endmacro(SHOWFLAG)
+
+set(NEWPLATFORMDEBUG ON)
+
+if(NEWPLATFORMDEBUG)
+  SHOWFLAG("APPLE")
+  SHOWFLAG("BORLAND")
+  SHOWFLAG("CMAKE_C_COMPILER_ID")
+  SHOWFLAG("CMAKE_CXX_COMPILER_ID")
+  SHOWFLAG("CMAKE_COMPILER_IS_GNUCC")
+  SHOWFLAG("CMAKE_COMPILER_IS_GNUCXX")
+  SHOWFLAG("CYGWIN")
+  SHOWFLAG("MINGW")
+  SHOWFLAG("MSVC")
+  SHOWFLAG("MSVC_VERSION")
+  SHOWFLAG("MSYS")
+  SHOWFLAG("UNIX")
+  SHOWFLAG("WATCOM")
+  SHOWFLAG("WIN32")
+endif(NEWPLATFORMDEBUG)

--- a/cmake/PlatformSpecific.cmake
+++ b/cmake/PlatformSpecific.cmake
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Uncomment this to show some basic cmake variables about platforms
+# include (NewPlatformDebug)
+
+if(MSVC)
+     add_definitions("/MP") # parallel build
+#    add_definitions("/W3") # warning level 3
+
+# These are set in log4cxx/private/log4cxx.h(w), so not set here (for now)
+#    add_definitions("/DLOG4CXX_HAVE_LIBESMTP=0")
+#    add_definitions("/DLOG4CXX_HAVE_ODBC=1")      # technically it is better to add FindODBC.cmake but
+#    add_definitions("/DLOG4CXX_HAVE_SYSLOG=0")    #   we can do that when the cmake builds support unix too
+
+    if(BUILD_SHARED_LIBS)
+        add_definitions("/DLOG4CXX")
+    else()
+        add_definitions("/DAPR_DECLARE_STATIC")
+        add_definitions("/DLOG4CXX_STATIC")
+		add_definitions("/Z7")
+    endif()
+
+    # For Debug build types, append a "d" to the library names.
+    set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix" FORCE)
+    set(CMAKE_RELEASE_POSTFIX "" CACHE STRING "Set release library postfix" FORCE)
+    set(CMAKE_RELWITHDEBINFO_POSTFIX "" CACHE STRING "Set release library postfix" FORCE)
+
+    # For visual studio the library naming is as following:
+    # Dynamic libraries:
+    #  - log4cxx.dll  for release library
+    #  - log4cxxd.dll for debug library
+    #
+    # Static libraries:
+    #  - log4cxxmd.lib for /MD build (release shared runtime)
+    #  - log4cxxmt.lib for /MT build (release static runtime)
+    #  - log4cxxmdd.lib for /MDd build (debug shared runtime)
+    #  - log4cxxmtd.lib for /MTd build (debug static runtime)
+    #
+
+    if(NOT MSVC_SHARED_RUNTIME)
+        set(CompilerFlags
+                CMAKE_CXX_FLAGS
+                CMAKE_CXX_FLAGS_DEBUG
+                CMAKE_CXX_FLAGS_RELEASE
+                CMAKE_CXX_FLAGS_RELWITHDEBINFO
+                CMAKE_C_FLAGS
+                CMAKE_C_FLAGS_DEBUG
+                CMAKE_C_FLAGS_RELEASE
+                CMAKE_C_FLAGS_RELWITHDEBINFO
+                )
+        foreach(CompilerFlag ${CompilerFlags})
+          string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+        endforeach()
+        set(STATIC_POSTFIX "mt" CACHE STRING "Set static library postfix" FORCE)
+    else()
+        set(STATIC_POSTFIX "md" CACHE STRING "Set static library postfix" FORCE)
+    endif()
+
+elseif(UNIX)
+
+    message(WARNING "The log4cxx CMake build environment is currently designed for windows builds...")
+    message(WARNING "Use at your own risk!")
+
+    ##find_program( MEMORYCHECK_COMMAND valgrind )
+    ##set( MEMORYCHECK_COMMAND_OPTIONS "--gen-suppressions=all --leak-check=full" )
+    ##set( MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/test/valgrind.suppress" )
+
+endif()

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# summary()
+#
+# Emit a summary of the build options, etc.
+#
+
+function(summary)
+    if (BUILD_SHARED_LIBS)
+        set(LINK_STRATEGY "Shared")
+    else()
+        set(LINK_STRATEGY "Static")
+    endif()
+
+    if (MSVC)
+        if (MSVC_SHARED_RUNTIME)
+            set(MSVCRT_STRATEGY " with shared runtime")
+        else()
+            set(MSVCRT_STRATEGY " with static runtime")
+        endif()
+    endif()
+
+    message(STATUS "")
+    message(STATUS "Configuration Summary for ${PROJECT_NAME}:")
+    message(STATUS "")
+    message(STATUS "  APR2_FOUND           ${APR2_FOUND}")
+    message(STATUS "  APR2_INCLUDE_DIRS    ${APR2_INCLUDE_DIRS}")
+    message(STATUS "  APR2_LIBRARIES       ${APR2_LIBRARIES}")
+    message(STATUS "")
+    message(STATUS "  PROJECT_DESCRIPTION  ${PROJECT_DESCRIPTION}")
+    message(STATUS "  PROJECT_NAME         ${PROJECT_NAME}")
+    message(STATUS "  PROJECT_LICENSE      ${PROJECT_LICENSE}")
+    message(STATUS "  PROJECT_LICURL       ${PROJECT_LICURL}")
+    message(STATUS "  PROJECT_URL          ${PROJECT_URL}")
+    message(STATUS "  PROJECT_VERSION      ${PROJECT_VERSION}")
+    message(STATUS "")
+  if (NOT MSVC)
+    message(STATUS "  Build Type           ${CMAKE_BUILD_TYPE}")
+  endif()
+    message(STATUS "  Install Prefix       ${CMAKE_INSTALL_PREFIX}")
+    message(STATUS "  Language Level       ${CXX_LANGUAGE_LEVEL}")
+    message(STATUS "  Link Strategy        ${LINK_STRATEGY}${MSVCRT_STRATEGY}")
+    message(STATUS "")
+
+# Uncomment to dump all variables out to console    
+# include (NewPlatformDebug)
+
+endfunction()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOGCXX-494

I've used log4cxx for quite some time and I was surprised to find there are no project or cmake files for windows builds in the trunk.  In the past I have cobbled together various sources and made visual studio projects to wrap apr, apr-util, and log4cxx into a single build.  

Today, I spent the day making a cmake build environment that leverages the latest apr-2 development trunk.

When you build apr-2 with cmake on Windows you get a static and a shared library in the prefix output directory.  The static library is named `apr-2.lib` and the dynamic link library is `libapr-2.{dll,lib}`.  I accounted for this in the cmake, expecting folks to set `-DBUILD_SHARED_LIBS={ON|OFF}`.  There are a number of build warnings when building dynamic, and it looks like some dllexport declarations are missing.  This PR does not correct those shortcomings.

I pulled some concepts from cmake files in the Apache Thrift project.

Here is an example configuration run and the output for configuring a Static, Release, VS2010 build.  The out-of-tree build directory is `c:\Temp\log4cxx-build\Static\Release`.  The source tree is `c:\temp\logging-log4cxx`.  Files will be installed into `C:\temp\log4cxx-install\Static\Release`.

In the build directory you get a full Visual Studio project that you can use if you want.

```
c:\Temp\log4cxx-build\Static\Release>cmake -G"Visual Studio 10 2010 Win64" c:\temp\logging-log4cxx -DCMAKE_INSTALL_PREFIX=C:\temp\log4cxx-install\Static\Release -DAPR2_ROOT_DIR=C:\Build\org.apache\apr\install\Static\Release
-- Configuring build environment for log4cxx version 0.11.1
-- The C compiler identification is MSVC 16.0.40219.1
-- The CXX compiler identification is MSVC 16.0.40219.1
-- Check for working C compiler: c:/Program Files (x86)/Microsoft Visual Studio 10.0/VC/bin/x86_amd64/cl.exe
-- Check for working C compiler: c:/Program Files (x86)/Microsoft Visual Studio 10.0/VC/bin/x86_amd64/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: c:/Program Files (x86)/Microsoft Visual Studio 10.0/VC/bin/x86_amd64/cl.exe
-- Check for working CXX compiler: c:/Program Files (x86)/Microsoft Visual Studio 10.0/VC/bin/x86_amd64/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found APR2: C:/build/org.apache/apr/install/Static/Release/include
--
-- Configuration Summary for log4cxx:
--
--   APR2_FOUND           TRUE
--   APR2_INCLUDE_DIRS    C:/build/org.apache/apr/install/Static/Release/include
--   APR2_LIBRARIES       C:/build/org.apache/apr/install/Static/Release/lib/libapr-2.lib
--
--   PROJECT_DESCRIPTION  Apache Logging Framework for C++
--   PROJECT_NAME         log4cxx
--   PROJECT_LICENSE      Apache Software License 2.0
--   PROJECT_LICURL       http://www.apache.org/licenses/LICENSE-2.0
--   PROJECT_URL          http://logging.apache.org/log4cxx/
--   PROJECT_VERSION      0.11.1
--
--   Install Prefix       C:/Temp/log4cxx-install/Static/Release
--   Language Level       c++98 [compiler must support it]
--   Link Strategy        Shared with shared runtime
--
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Temp/log4cxx-build/Static/Release
```

It can then be built with:

```
c:\Temp\log4cxx-build\Static\Release>cmake --build . --target install --config Release
```
