### PR TITLE
mbsrtowcs() returns the number of wide char,but not the source in str…

### DIFF
--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -177,7 +177,7 @@ namespace log4cxx
                                break;
                            } else {
                                stat = append(out, buf);
-                               in.position(in.position() + converted);
+                               in.position(in.position() + requested);
                            }
                       }
                   }


### PR DESCRIPTION
mbsrtowcs() returns the number of wide char,but not the source length.

If there have n chinese characters,the log will output more last n characters.

src/main/cpp/charsetdecoder.cpp
@@ -175,11 +175,11 @@ namespace log4cxx
                                stat = APR_BADARG;
                                in.position(src - in.data());
                                break;
                            } else {
                                stat = append(out, buf);
-                               in.position(in.position() + converted);
+                               in.position(in.position() + requested);
                            }
                       }
                   }
                   return stat;
               }
