### PR TITLE
Configuration output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ message(STATUS "log4cxx configuration summary:")
 message(STATUS "")
 
 message(STATUS "  Build type ...................... : ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Build tests ..................... : ${BUILD_TESTING}")
 message(STATUS "  Install prefix .................. : ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "  C++ compiler .................... : ${CMAKE_CXX_COMPILER}")
 message(STATUS "  log4cxx char API ................ : ${LOG4CXX_CHAR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,3 +61,43 @@ install(EXPORT log4cxxTargets
   NAMESPACE log4cxx::
   DESTINATION share/cmake/log4cxx
 )
+
+#
+# Get the varaibles from the subdirectories
+#
+get_directory_property( HAS_LIBESMTP DIRECTORY src/main/include DEFINITION HAS_LIBESMTP )
+get_directory_property( HAS_ODBC DIRECTORY src/main/include DEFINITION HAS_ODBC )
+get_directory_property( HAS_SYSLOG DIRECTORY src/main/include DEFINITION HAS_SYSLOG )
+
+foreach(varName HAS_STD_LOCALE  HAS_ODBC  HAS_MBSRTOWCS  HAS_WCSTOMBS  HAS_FWIDE  HAS_LIBESMTP  HAS_SYSLOG)
+  if(${varName} EQUAL 0)
+    set(${varName} "OFF" )
+  elseif(${varName} EQUAL 1)
+    set(${varName} "ON" )
+  else()
+    set(${varName} "UNKNOWN" )
+  endif()
+endforeach()
+
+#
+# Output configuration information
+# Similar to APR CMake configuration
+#
+message(STATUS "")
+message(STATUS "")
+message(STATUS "log4cxx configuration summary:")
+message(STATUS "")
+
+message(STATUS "  Build type ...................... : ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Install prefix .................. : ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "  C++ compiler .................... : ${CMAKE_CXX_COMPILER}")
+message(STATUS "  log4cxx char API ................ : ${LOG4CXX_CHAR}")
+message(STATUS "  log4cxx wchar API ............... : ${LOG4CXX_WCHAR_T}")
+message(STATUS "  log4cxx unichar API ............. : ${LOG4CXX_UNICHAR}")
+if(APPLE)
+message(STATUS "  log4cxx cfstring API ............ : ${LOG4CXX_CFSTRING}")
+endif()
+message(STATUS "  logchar type .................... : ${LOG4CXX_CHAR}")
+message(STATUS "  Using libESMTP .................. : ${HAS_LIBESMTP}")
+message(STATUS "  ODBC library .................... : ${HAS_ODBC}")
+message(STATUS "  syslog .......................... : ${HAS_SYSLOG}")

--- a/src/site/apt/building/cmake.apt
+++ b/src/site/apt/building/cmake.apt
@@ -43,6 +43,8 @@ $ sudo make install
 *------------------------+---------------------------------------------------------------------------------------------+
 | -DLOG4CXX_CFSTRING=yes | Enable CFString API methods, requires Mac OS/X CoreFoundation, choice of yes, no (default). |
 *------------------------+---------------------------------------------------------------------------------------------+
+| -DBUILD_TESTING=off    | Disable tests.  Tests are enabled by default                                                |
+*------------------------+---------------------------------------------------------------------------------------------+
 
    Building and testing log4cxx on a Microsoft Windows with APR, Expat and APR-Util built from source
    extracted into apr-1.7.0, libexpat(from github) and apr-util-1.6.1 in %HOMEPATH%\Libraries.


### PR DESCRIPTION
Add a small configuration output to help the user see how log4cxx is configured.

Document how to disable tests.