### PR TITLE
Reduce msvc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
 
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.3</version>
+				<version>3.2.0</version>
 				<configuration>
 					<descriptors>
 						<descriptor>src/assembly/source.xml</descriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -314,8 +314,9 @@
 				</configuration>
 				<executions>
 					<execution>
+						<phase>package</phase>
 						<goals>
-							<goal>assembly</goal>
+							<goal>single</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/src/examples/cpp/delayedloop.cpp
+++ b/src/examples/cpp/delayedloop.cpp
@@ -93,7 +93,7 @@ public:
                         {
                                 apr_sleep(1000000);
                         }
-                        catch(std::exception& e)
+                        catch(std::exception&)
                         {
                         }
                 }

--- a/src/main/cpp/appenderattachableimpl.cpp
+++ b/src/main/cpp/appenderattachableimpl.cpp
@@ -73,7 +73,7 @@ int AppenderAttachableImpl::appendLoopOnAppenders(
 		(*it)->doAppend(event, p);
 	}
 
-	return appenderList.size();
+	return (int)appenderList.size();
 }
 
 AppenderList AppenderAttachableImpl::getAllAppenders() const

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -143,9 +143,9 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 
 		while (true)
 		{
-			int previousSize = buffer.size();
+			size_t previousSize = buffer.size();
 
-			if (previousSize < bufferSize)
+			if (previousSize < (size_t)bufferSize)
 			{
 				buffer.push_back(event);
 
@@ -175,7 +175,7 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 					bufferNotFull.await(bufferMutex);
 					discard = false;
 				}
-				catch (InterruptedException& e)
+				catch (InterruptedException&)
 				{
 					//
 					//  reset interrupt status so
@@ -442,7 +442,7 @@ void* LOG4CXX_THREAD_FUNC AsyncAppender::dispatch(apr_thread_t* /*thread*/, void
 			}
 		}
 	}
-	catch (InterruptedException& ex)
+	catch (InterruptedException&)
 	{
 		Thread::currentThreadInterrupt();
 	}

--- a/src/main/cpp/bytearrayinputstream.cpp
+++ b/src/main/cpp/bytearrayinputstream.cpp
@@ -57,6 +57,6 @@ int ByteArrayInputStream::read(ByteBuffer& dst)
 		memcpy(dst.current(), &buf[pos], bytesCopied);
 		pos += bytesCopied;
 		dst.position(dst.position() + bytesCopied);
-		return bytesCopied;
+		return (int)bytesCopied;
 	}
 }

--- a/src/main/cpp/cacheddateformat.cpp
+++ b/src/main/cpp/cacheddateformat.cpp
@@ -169,7 +169,7 @@ int CachedDateFormat::findMillisecondStart(
 				// the millis can occur everywhere in formatted. See LOGCXX-420 and following.
 				size_t  magicLength     = magicString.length();
 				size_t  overlapping     = magicString.find(plusMagic[i]);
-				int     possibleRetVal  = i - overlapping;
+				int     possibleRetVal  = int(i - overlapping);
 
 				if (plusZero.length() == formatted.length()
 					&& regionMatches(magicString,       0, plusMagic,   possibleRetVal, magicLength)

--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -471,7 +471,7 @@ class LocaleCharsetDecoder : public CharsetDecoder
 							Transcoder::decode(encoding, e);
 							decoder = getDecoder(e);
 						}
-						catch (IllegalArgumentException& ex)
+						catch (IllegalArgumentException&)
 						{
 							decoder = new USASCIICharsetDecoder();
 						}

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -501,7 +501,7 @@ class LocaleCharsetEncoder : public CharsetEncoder
 						{
 							encoder = CharsetEncoder::getEncoder(ename);
 						}
-						catch (IllegalArgumentException& ex)
+						catch (IllegalArgumentException&)
 						{
 							encoder = new USASCIICharsetEncoder();
 						}

--- a/src/main/cpp/classnamepatternconverter.cpp
+++ b/src/main/cpp/classnamepatternconverter.cpp
@@ -55,7 +55,7 @@ void ClassNamePatternConverter::format(
 	LogString& toAppendTo,
 	Pool& /* p */) const
 {
-	int initialLength = toAppendTo.length();
+	int initialLength = (int)toAppendTo.length();
 	append(toAppendTo, event->getLocationInformation().getClassName());
 	abbreviate(initialLength, toAppendTo);
 }

--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -306,7 +306,7 @@ void FileAppender::setFile(
 	{
 		outStream = new FileOutputStream(filename, append1);
 	}
-	catch (IOException& ex)
+	catch (IOException&)
 	{
 		LogString parentName = File().setPath(filename).getParent(p);
 
@@ -353,7 +353,7 @@ void FileAppender::setFile(
 	this->fileAppend = append1;
 	this->bufferedIO = bufferedIO1;
 	this->fileName = filename;
-	this->bufferSize = bufferSize1;
+	this->bufferSize = (int)bufferSize1;
 	writeHeader(p);
 
 }

--- a/src/main/cpp/fileinputstream.cpp
+++ b/src/main/cpp/fileinputstream.cpp
@@ -107,7 +107,7 @@ int FileInputStream::read(ByteBuffer& buf)
 		}
 
 		buf.position(buf.position() + bytesRead);
-		retval = bytesRead;
+		retval = (int)bytesRead;
 	}
 
 	return retval;

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -46,7 +46,7 @@ FileWatchdog::~FileWatchdog()
 		thread.interrupt();
 		thread.join();
 	}
-	catch (Exception& e)
+	catch (Exception&)
 	{
 	}
 }
@@ -91,7 +91,7 @@ void* APR_THREAD_FUNC FileWatchdog::run(apr_thread_t* /* thread */, void* data)
 			Thread::sleep(pThis->delay);
 			pThis->checkAndConfigure();
 		}
-		catch (InterruptedException& ex)
+		catch (InterruptedException&)
 		{
 			interrupted = apr_atomic_read32(&pThis->interrupted);
 		}

--- a/src/main/cpp/fixedwindowrollingpolicy.cpp
+++ b/src/main/cpp/fixedwindowrollingpolicy.cpp
@@ -332,7 +332,7 @@ bool FixedWindowRollingPolicy::purge(int lowIndex, int highIndex, Pool& p) const
 				return false;
 			}
 		}
-		catch (std::exception& ex)
+		catch (std::exception&)
 		{
 			LogLog::warn(LOG4CXX_STR("Exception during purge in RollingFileAppender"));
 

--- a/src/main/cpp/formattinginfo.cpp
+++ b/src/main/cpp/formattinginfo.cpp
@@ -56,7 +56,7 @@ FormattingInfoPtr FormattingInfo::getDefault()
  */
 void FormattingInfo::format(const int fieldStart, LogString& buffer) const
 {
-	int rawLength = buffer.length() - fieldStart;
+	int rawLength = int(buffer.length() - fieldStart);
 
 	if (rawLength > maxLength)
 	{

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -345,7 +345,7 @@ void Hierarchy::updateParents(LoggerPtr logger)
 {
 	synchronized sync(mutex);
 	const LogString name(logger->getName());
-	int length = name.size();
+	size_t length = name.size();
 	bool parentFound = false;
 
 

--- a/src/main/cpp/loader.cpp
+++ b/src/main/cpp/loader.cpp
@@ -67,7 +67,7 @@ InputStreamPtr Loader::getResourceAsStream(const LogString& name)
 	{
 		return new FileInputStream(name);
 	}
-	catch (const IOException& ioex)
+	catch (const IOException&)
 	{
 	}
 

--- a/src/main/cpp/loggerpatternconverter.cpp
+++ b/src/main/cpp/loggerpatternconverter.cpp
@@ -54,7 +54,7 @@ void LoggerPatternConverter::format(
 	LogString& toAppendTo,
 	Pool& /* p */ ) const
 {
-	int initialLength = toAppendTo.length();
+	int initialLength = (int)toAppendTo.length();
 	toAppendTo.append(event->getLoggerName());
 	abbreviate(initialLength, toAppendTo);
 }

--- a/src/main/cpp/logstream.cpp
+++ b/src/main/cpp/logstream.cpp
@@ -109,7 +109,7 @@ int log4cxx::logstream_base::precision(int p)
 {
 	get_stream_state(initclear, initset, fillchar, fillset);
 	initset.precision(p);
-	int oldVal = initclear.precision(p);
+	int oldVal = (int)initclear.precision(p);
 	refresh_stream_state();
 	return oldVal;
 }
@@ -117,14 +117,14 @@ int log4cxx::logstream_base::precision(int p)
 int log4cxx::logstream_base::precision()
 {
 	get_stream_state(initclear, initset, fillchar, fillset);
-	return initclear.precision();
+	return (int)initclear.precision();
 }
 
 int log4cxx::logstream_base::width(int w)
 {
 	get_stream_state(initclear, initset, fillchar, fillset);
 	initset.width(w);
-	int oldVal = initclear.width(w);
+	int oldVal = (int)initclear.width(w);
 	refresh_stream_state();
 	return oldVal;
 }
@@ -132,7 +132,7 @@ int log4cxx::logstream_base::width(int w)
 int log4cxx::logstream_base::width()
 {
 	get_stream_state(initclear, initset, fillchar, fillset);
-	return initclear.width();
+	return (int)initclear.width();
 }
 
 int log4cxx::logstream_base::fill(int newfill)
@@ -306,10 +306,10 @@ void logstream::get_stream_state(std::ios_base& base,
 		std::ios_base::fmtflags flags = stream->flags();
 		base.flags(flags);
 		mask.flags(flags);
-		int width = stream->width();
+		int width = (int)stream->width();
 		base.width(width);
 		mask.width(width);
-		int precision = stream->precision();
+		int precision = (int)stream->precision();
 		base.precision(precision);
 		mask.precision(precision);
 		fill = stream->fill();
@@ -435,10 +435,10 @@ void wlogstream::get_stream_state(std::ios_base& base,
 		std::ios_base::fmtflags flags = stream->flags();
 		base.flags(flags);
 		mask.flags(flags);
-		int width = stream->width();
+		int width = (int)stream->width();
 		base.width(width);
 		mask.width(width);
-		int precision = stream->precision();
+		int precision = (int)stream->precision();
 		base.precision(precision);
 		mask.precision(precision);
 		fill = stream->fill();

--- a/src/main/cpp/ndc.cpp
+++ b/src/main/cpp/ndc.cpp
@@ -119,7 +119,7 @@ int NDC::getDepth()
 
 	if (data != 0)
 	{
-		size = data->getStack().size();
+		size = (int)data->getStack().size();
 
 		if (size == 0)
 		{

--- a/src/main/cpp/odbcappender.cpp
+++ b/src/main/cpp/odbcappender.cpp
@@ -187,7 +187,7 @@ void ODBCAppender::execute(const LogString& sql, log4cxx::helpers::Pool& p)
 			throw SQLException(SQL_HANDLE_STMT, stmt, "Failed to execute sql statement.", p);
 		}
 	}
-	catch (SQLException& e)
+	catch (SQLException&)
 	{
 		if (stmt != SQL_NULL_HSTMT)
 		{

--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -187,14 +187,13 @@ LogString OptionConverter::substVars(const LogString& val, Properties& props)
 	const size_t DELIM_START_LEN = 2;
 	const size_t DELIM_STOP_LEN = 1;
 
-	int i = 0;
-	int j, k;
+	size_t i = 0;
 
 	while (true)
 	{
-		j = val.find(delimStart, i);
+		size_t j = val.find(delimStart, i);
 
-		if (j == -1)
+		if (j == val.npos)
 		{
 			// no more variables
 			if (i == 0)
@@ -212,9 +211,9 @@ LogString OptionConverter::substVars(const LogString& val, Properties& props)
 		else
 		{
 			sbuf.append(val.substr(i, j - i));
-			k = val.find(delimStop, j);
+			size_t k = val.find(delimStop, j);
 
-			if (k == -1)
+			if (k == val.npos)
 			{
 				LogString msg(1, (logchar) 0x22 /* '\"' */);
 				msg.append(val);

--- a/src/main/cpp/patternlayout.cpp
+++ b/src/main/cpp/patternlayout.cpp
@@ -89,7 +89,7 @@ void PatternLayout::format(LogString& output,
 		converterIter != patternConverters.end();
 		converterIter++, formatterIter++)
 	{
-		int startField = output.length();
+		int startField = (int)output.length();
 		(*converterIter)->format(event, output, pool);
 		(*formatterIter)->format(startField, output);
 	}

--- a/src/main/cpp/patternparser.cpp
+++ b/src/main/cpp/patternparser.cpp
@@ -55,7 +55,7 @@ bool PatternParser::isUnicodeIdentifierPart(logchar ch)
 		|| (ch == 0x5F /* '_' */);
 }
 
-int PatternParser::extractConverter(
+size_t PatternParser::extractConverter(
 	logchar lastChar, const LogString& pattern,
 	LogString::size_type i, LogString& convBuf,
 	LogString& currentLiteral)
@@ -92,14 +92,14 @@ int PatternParser::extractConverter(
 }
 
 
-int PatternParser::extractOptions(const LogString& pattern, LogString::size_type i,
+size_t PatternParser::extractOptions(const LogString& pattern, LogString::size_type i,
 	std::vector<LogString>& options)
 {
 	while ((i < pattern.length()) && (pattern[i] == 0x7B /* '{' */))
 	{
-		int end = pattern.find(0x7D /* '}' */, i);
+		size_t end = pattern.find(0x7D /* '}' */, i);
 
-		if (end == -1)
+		if (end == pattern.npos)
 		{
 			break;
 		}
@@ -121,10 +121,10 @@ void PatternParser::parse(
 
 	LogString currentLiteral;
 
-	int patternLength = pattern.length();
+	size_t patternLength = pattern.length();
 	int state = LITERAL_STATE;
 	logchar c;
-	int i = 0;
+	size_t i = 0;
 	FormattingInfoPtr formattingInfo(FormattingInfo::getDefault());
 
 	while (i < patternLength)
@@ -318,7 +318,7 @@ PatternConverterPtr PatternParser::createConverter(
 
 	LogString converterName(converterId);
 
-	for (int i = converterId.length(); i > 0; i--)
+	for (size_t i = converterId.length(); i > 0; i--)
 	{
 		converterName = converterName.substr(0, i);
 		PatternMap::const_iterator iter = rules.find(converterName);
@@ -337,8 +337,8 @@ PatternConverterPtr PatternParser::createConverter(
 	return converterObj;
 }
 
-int PatternParser::finalizeConverter(
-	logchar c, const LogString& pattern, int i,
+size_t PatternParser::finalizeConverter(
+	logchar c, const LogString& pattern, size_t i,
 	LogString& currentLiteral, const FormattingInfoPtr& formattingInfo,
 	const PatternMap&  rules,
 	std::vector<PatternConverterPtr>& patternConverters,

--- a/src/main/cpp/propertyconfigurator.cpp
+++ b/src/main/cpp/propertyconfigurator.cpp
@@ -111,7 +111,7 @@ void PropertyConfigurator::doConfigure(const File& configFileName,
 		InputStreamPtr inputStream = new FileInputStream(configFileName);
 		props.load(inputStream);
 	}
-	catch (const IOException& ie)
+	catch (const IOException&)
 	{
 		LogLog::error(((LogString) LOG4CXX_STR("Could not read configuration file ["))
 			+ configFileName.getPath() + LOG4CXX_STR("]."));

--- a/src/main/cpp/propertysetter.cpp
+++ b/src/main/cpp/propertysetter.cpp
@@ -48,7 +48,7 @@ void PropertySetter::setProperties(helpers::Properties& properties,
 	const LogString& prefix,
 	Pool& p)
 {
-	int len = prefix.length();
+	size_t len = prefix.length();
 
 	std::vector<LogString> names = properties.propertyNames();
 	std::vector<LogString>::iterator it;

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -139,7 +139,7 @@ void RollingFileAppenderSkeleton::activateOptions(Pool& p)
 
 			FileAppender::activateOptions(p);
 		}
-		catch (std::exception& ex)
+		catch (std::exception&)
 		{
 			LogLog::warn(
 				LogString(LOG4CXX_STR("Exception will initializing RollingFileAppender named "))
@@ -301,7 +301,7 @@ bool RollingFileAppenderSkeleton::rollover(Pool& p)
 								{
 									success = rollover1->getSynchronous()->execute(p);
 								}
-								catch (std::exception& ex)
+								catch (std::exception&)
 								{
 									LogLog::warn(LOG4CXX_STR("Exception on rollover"));
 								}
@@ -357,7 +357,7 @@ bool RollingFileAppenderSkeleton::rollover(Pool& p)
 								{
 									success = rollover1->getSynchronous()->execute(p);
 								}
-								catch (std::exception& ex)
+								catch (std::exception&)
 								{
 									LogLog::warn(LOG4CXX_STR("Exception during rollover"));
 								}
@@ -394,7 +394,7 @@ bool RollingFileAppenderSkeleton::rollover(Pool& p)
 						return true;
 					}
 				}
-				catch (std::exception& ex)
+				catch (std::exception&)
 				{
 					LogLog::warn(LOG4CXX_STR("Exception during rollover"));
 				}
@@ -452,7 +452,7 @@ void RollingFileAppenderSkeleton::subAppend(const LoggingEventPtr& event, Pool& 
 			_event = &(const_cast<LoggingEventPtr&>(event));
 			rollover(p);
 		}
-		catch (std::exception& ex)
+		catch (std::exception&)
 		{
 			LogLog::warn(LOG4CXX_STR("Exception during rollover attempt."));
 		}

--- a/src/main/cpp/socketappender.cpp
+++ b/src/main/cpp/socketappender.cpp
@@ -96,7 +96,7 @@ void SocketAppender::cleanUp(Pool& p)
 		oos->close(p);
 		oos = 0;
 	}
-	catch (std::exception& e)
+	catch (std::exception&)
 	{}
 }
 

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -137,7 +137,7 @@ void TelnetAppender::close()
 	{
 		sh.join();
 	}
-	catch (Exception& ex)
+	catch (Exception&)
 	{
 	}
 
@@ -158,7 +158,7 @@ void TelnetAppender::write(ByteBuffer& buf)
 				ByteBuffer b(buf.current(), buf.remaining());
 				(*iter)->write(b);
 			}
-			catch (Exception& ex)
+			catch (Exception&)
 			{
 				// The client has closed the connection, remove it from our list:
 				*iter = 0;
@@ -279,7 +279,7 @@ void* APR_THREAD_FUNC TelnetAppender::acceptConnections(apr_thread_t* /* thread 
 				pThis->writeStatus(newClient, oss, p);
 			}
 		}
-		catch (InterruptedIOException& e)
+		catch (InterruptedIOException&)
 		{
 			if (pThis->closed)
 			{

--- a/src/main/cpp/xmlsocketappender.cpp
+++ b/src/main/cpp/xmlsocketappender.cpp
@@ -99,7 +99,7 @@ void XMLSocketAppender::cleanUp(Pool& p)
 			writer->close(p);
 			writer = 0;
 		}
-		catch (std::exception& e)
+		catch (std::exception&)
 		{
 		}
 	}

--- a/src/main/include/log4cxx/consoleappender.h
+++ b/src/main/include/log4cxx/consoleappender.h
@@ -20,6 +20,11 @@
 
 #include <log4cxx/writerappender.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 
@@ -73,6 +78,10 @@ class LOG4CXX_EXPORT ConsoleAppender : public WriterAppender
 };
 LOG4CXX_PTR_DEF(ConsoleAppender);
 }  //namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif //_LOG4CXX_CONSOLE_APPENDER_H
 

--- a/src/main/include/log4cxx/file.h
+++ b/src/main/include/log4cxx/file.h
@@ -21,6 +21,11 @@
 #include <log4cxx/logger.h>
 #include <log4cxx/logstring.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 extern "C" {
 	struct apr_file_t;
 	struct apr_finfo_t;
@@ -183,6 +188,10 @@ class LOG4CXX_EXPORT File
 };
 } // namespace log4cxx
 
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #define LOG4CXX_FILE(name) log4cxx::File(name)
 

--- a/src/main/include/log4cxx/fileappender.h
+++ b/src/main/include/log4cxx/fileappender.h
@@ -24,6 +24,11 @@
 #include <log4cxx/file.h>
 #include <log4cxx/helpers/pool.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace helpers
@@ -235,5 +240,9 @@ class LOG4CXX_EXPORT FileAppender : public WriterAppender
 LOG4CXX_PTR_DEF(FileAppender);
 
 }  // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif

--- a/src/main/include/log4cxx/filter/stringmatchfilter.h
+++ b/src/main/include/log4cxx/filter/stringmatchfilter.h
@@ -20,6 +20,11 @@
 
 #include <log4cxx/spi/filter.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace filter
@@ -96,5 +101,9 @@ class LOG4CXX_EXPORT StringMatchFilter : public spi::Filter
 LOG4CXX_PTR_DEF(StringMatchFilter);
 }  // namespace filter
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_FILTER_STRING_MATCH_FILTER_H

--- a/src/main/include/log4cxx/helpers/bufferedwriter.h
+++ b/src/main/include/log4cxx/helpers/bufferedwriter.h
@@ -20,6 +20,11 @@
 
 #include <log4cxx/helpers/writer.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 
@@ -60,5 +65,9 @@ class LOG4CXX_EXPORT BufferedWriter : public Writer
 } // namespace helpers
 
 }  //namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif //_LOG4CXX_HELPERS_BUFFEREDWRITER_H

--- a/src/main/include/log4cxx/helpers/cacheddateformat.h
+++ b/src/main/include/log4cxx/helpers/cacheddateformat.h
@@ -20,6 +20,11 @@
 
 #include <log4cxx/helpers/dateformat.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace pattern
@@ -222,5 +227,9 @@ class LOG4CXX_EXPORT CachedDateFormat : public log4cxx::helpers::DateFormat
 
 }  // namespace helpers
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_HELPERS_SIMPLE_DATE_FORMAT_H

--- a/src/main/include/log4cxx/helpers/datelayout.h
+++ b/src/main/include/log4cxx/helpers/datelayout.h
@@ -22,6 +22,11 @@
 #include <log4cxx/helpers/dateformat.h>
 #include <log4cxx/helpers/timezone.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace helpers
@@ -95,5 +100,9 @@ class LOG4CXX_EXPORT DateLayout : public Layout
 };
 }  // namespace helpers
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_HELPERS_DATE_LAYOUT_H

--- a/src/main/include/log4cxx/helpers/exception.h
+++ b/src/main/include/log4cxx/helpers/exception.h
@@ -22,6 +22,11 @@
 #include <log4cxx/log4cxx.h>
 #include <log4cxx/logstring.h>
 
+#ifdef _MSC_VER
+	#pragma warning ( push )
+	#pragma warning (disable : 4251 4275) // ::std::exception needs to have dll-interface
+#endif
+
 namespace log4cxx
 {
 namespace helpers
@@ -287,5 +292,9 @@ class LOG4CXX_EXPORT SocketTimeoutException : public InterruptedIOException
 
 }  // namespace helpers
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+	#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_HELPERS_EXCEPTION_H

--- a/src/main/include/log4cxx/helpers/locale.h
+++ b/src/main/include/log4cxx/helpers/locale.h
@@ -20,6 +20,11 @@
 
 #include <log4cxx/logstring.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace helpers
@@ -45,5 +50,9 @@ class LOG4CXX_EXPORT Locale
 }; // class Locale
 }  // namespace helpers
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_HELPERS_LOCALE_H

--- a/src/main/include/log4cxx/helpers/messagebuffer.h
+++ b/src/main/include/log4cxx/helpers/messagebuffer.h
@@ -22,6 +22,11 @@
 #include <log4cxx/logstring.h>
 #include <sstream>
 
+#if defined(_MSC_VER)
+	#pragma warning ( push )
+	#pragma warning ( disable: 4251 4275 )
+#endif
+
 namespace log4cxx
 {
 
@@ -837,5 +842,10 @@ typedef CharMessageBuffer LogCharMessageBuffer;
 
 }
 }
+
+#if defined(_MSC_VER)
+	#pragma warning (pop)
+#endif
+
 #endif
 

--- a/src/main/include/log4cxx/helpers/onlyonceerrorhandler.h
+++ b/src/main/include/log4cxx/helpers/onlyonceerrorhandler.h
@@ -21,6 +21,11 @@
 #include <log4cxx/spi/errorhandler.h>
 #include <log4cxx/helpers/objectimpl.h>
 
+#ifdef _MSC_VER
+#pragma warning ( push )
+#pragma warning (disable : 4251) // ::std::exception needs to have dll-interface
+#endif
+
 namespace log4cxx
 {
 namespace helpers
@@ -98,6 +103,10 @@ class LOG4CXX_EXPORT OnlyOnceErrorHandler :
 };
 }  // namespace helpers
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif //_LOG4CXX_HELPERS_ONLY_ONCE_ERROR_HANDLER_H
 

--- a/src/main/include/log4cxx/helpers/strftimedateformat.h
+++ b/src/main/include/log4cxx/helpers/strftimedateformat.h
@@ -20,6 +20,11 @@
 
 #include <log4cxx/helpers/dateformat.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace helpers
@@ -64,5 +69,9 @@ class LOG4CXX_EXPORT StrftimeDateFormat : public DateFormat
 
 }  // namespace helpers
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_HELPERS_STRFTIME_DATE_FORMAT_H

--- a/src/main/include/log4cxx/helpers/stringtokenizer.h
+++ b/src/main/include/log4cxx/helpers/stringtokenizer.h
@@ -21,6 +21,11 @@
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/exception.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace helpers
@@ -45,5 +50,9 @@ class LOG4CXX_EXPORT StringTokenizer
 }; // class StringTokenizer
 }  // namespace helpers;
 } // namespace log4cxx;
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif //_LOG4CXX_HELPERS_STRING_TOKENIZER_H

--- a/src/main/include/log4cxx/helpers/syslogwriter.h
+++ b/src/main/include/log4cxx/helpers/syslogwriter.h
@@ -23,6 +23,11 @@
 #include <log4cxx/helpers/inetaddress.h>
 #include <log4cxx/helpers/datagramsocket.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace helpers
@@ -46,5 +51,9 @@ class LOG4CXX_EXPORT SyslogWriter
 };
 }  // namespace helpers
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif

--- a/src/main/include/log4cxx/helpers/threadspecificdata.h
+++ b/src/main/include/log4cxx/helpers/threadspecificdata.h
@@ -21,6 +21,10 @@
 #include <log4cxx/ndc.h>
 #include <log4cxx/mdc.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
 
 namespace log4cxx
 {
@@ -63,5 +67,9 @@ class LOG4CXX_EXPORT ThreadSpecificData
 
 }  // namespace helpers
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif

--- a/src/main/include/log4cxx/helpers/timezone.h
+++ b/src/main/include/log4cxx/helpers/timezone.h
@@ -22,6 +22,11 @@
 #include <log4cxx/helpers/objectimpl.h>
 #include <log4cxx/helpers/objectptr.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 struct apr_time_exp_t;
 
 namespace log4cxx
@@ -67,5 +72,9 @@ class LOG4CXX_EXPORT TimeZone : public helpers::ObjectImpl
 
 }
 }
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif //_LOG4CXX_HELPERS_TIMEZONE_H

--- a/src/main/include/log4cxx/jsonlayout.h
+++ b/src/main/include/log4cxx/jsonlayout.h
@@ -22,6 +22,10 @@
 #include <log4cxx/helpers/iso8601dateformat.h>
 #include <log4cxx/spi/loggingevent.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
 
 
 namespace log4cxx
@@ -135,5 +139,8 @@ class LOG4CXX_EXPORT JSONLayout : public Layout
 LOG4CXX_PTR_DEF(JSONLayout);
 }  // namespace log4cxx
 
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_JSON_LAYOUT_H

--- a/src/main/include/log4cxx/level.h
+++ b/src/main/include/log4cxx/level.h
@@ -24,6 +24,10 @@
 #include <log4cxx/helpers/objectimpl.h>
 #include <log4cxx/helpers/objectptr.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
 
 namespace log4cxx
 {
@@ -330,5 +334,8 @@ template<> inline bool LevelPtr::operator!=(const LevelPtr& rhs) const
 #define IMPLEMENT_LOG4CXX_LEVEL(level) \
 	IMPLEMENT_LOG4CXX_OBJECT_WITH_CUSTOM_CLASS(level, Class##level)
 
+#if defined(_MSC_VER)
+ #pragma warning (pop)
+#endif
 
 #endif //_LOG4CXX_LEVEL_H

--- a/src/main/include/log4cxx/logstring.h
+++ b/src/main/include/log4cxx/logstring.h
@@ -37,8 +37,6 @@ extern "C" {
 }
 #endif
 
-
-
 namespace log4cxx
 {
 

--- a/src/main/include/log4cxx/mdc.h
+++ b/src/main/include/log4cxx/mdc.h
@@ -18,17 +18,18 @@
 #ifndef _LOG4CXX_MDC_H
 #define _LOG4CXX_MDC_H
 
+#include <log4cxx/log4cxx.h>
+#include <log4cxx/logstring.h>
+#include <map>
+
 #if defined(_MSC_VER)
 	#pragma warning (push)
 	#pragma warning ( disable: 4231 4251 4275 4786 )
 #endif
 
-#include <log4cxx/log4cxx.h>
-#include <log4cxx/logstring.h>
-#include <map>
-
 namespace log4cxx
 {
+
 /**
 The MDC class is similar to the {@link log4cxx::NDC NDC} class except that it is
 based on a map instead of a stack. It provides <em>mapped

--- a/src/main/include/log4cxx/ndc.h
+++ b/src/main/include/log4cxx/ndc.h
@@ -18,17 +18,18 @@
 #ifndef _LOG4CXX_NDC_H
 #define _LOG4CXX_NDC_H
 
+#include <log4cxx/log4cxx.h>
+#include <log4cxx/logstring.h>
+#include <stack>
+
 #if defined(_MSC_VER)
 	#pragma warning ( push )
 	#pragma warning ( disable: 4231 4251 4275 4786 )
 #endif
 
-#include <log4cxx/log4cxx.h>
-#include <log4cxx/logstring.h>
-#include <stack>
-
 namespace log4cxx
 {
+
 /**
 the ndc class implements <i>nested diagnostic contexts</i> as
 defined by neil harrison in the article "patterns for logging

--- a/src/main/include/log4cxx/net/smtpappender.h
+++ b/src/main/include/log4cxx/net/smtpappender.h
@@ -23,6 +23,11 @@
 #include <log4cxx/helpers/cyclicbuffer.h>
 #include <log4cxx/spi/triggeringeventevaluator.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace net
@@ -281,5 +286,9 @@ LOG4CXX_PTR_DEF(SMTPAppender);
 
 }  // namespace net
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_NET_SMTP_H

--- a/src/main/include/log4cxx/net/socketappenderskeleton.h
+++ b/src/main/include/log4cxx/net/socketappenderskeleton.h
@@ -23,6 +23,11 @@
 #include <log4cxx/helpers/thread.h>
 #include <log4cxx/helpers/objectoutputstream.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 
@@ -192,6 +197,10 @@ class LOG4CXX_EXPORT SocketAppenderSkeleton : public AppenderSkeleton
 }; // class SocketAppenderSkeleton
 } // namespace net
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_NET_SOCKET_APPENDER_SKELETON_H
 

--- a/src/main/include/log4cxx/net/syslogappender.h
+++ b/src/main/include/log4cxx/net/syslogappender.h
@@ -21,6 +21,11 @@
 #include <log4cxx/appenderskeleton.h>
 #include <log4cxx/helpers/syslogwriter.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace net
@@ -147,6 +152,10 @@ class LOG4CXX_EXPORT SyslogAppender : public AppenderSkeleton
 LOG4CXX_PTR_DEF(SyslogAppender);
 } // namespace net
 } // namespace log4cxx
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 #endif // _LOG4CXX_NET_SYSLOG_APPENDER_H
 

--- a/src/main/include/log4cxx/nt/nteventlogappender.h
+++ b/src/main/include/log4cxx/nt/nteventlogappender.h
@@ -20,6 +20,11 @@
 
 #include <log4cxx/appenderskeleton.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 
 namespace log4cxx
 {
@@ -122,4 +127,7 @@ LOG4CXX_PTR_DEF(NTEventLogAppender);
 }  // namespace nt
 } // namespace log4cxx
 
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 #endif //_LOG4CXX_NT_EVENT_LOG_APPENDER_HEADER_

--- a/src/main/include/log4cxx/pattern/literalpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/literalpatternconverter.h
@@ -20,6 +20,11 @@
 
 #include <log4cxx/pattern/loggingeventpatternconverter.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace pattern
@@ -68,5 +73,10 @@ class LOG4CXX_EXPORT LiteralPatternConverter : public LoggingEventPatternConvert
 
 }
 }
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
+
 #endif
 

--- a/src/main/include/log4cxx/pattern/patternparser.h
+++ b/src/main/include/log4cxx/pattern/patternparser.h
@@ -90,7 +90,7 @@ class LOG4CXX_EXPORT PatternParser
 		 * @param currentLiteral literal to be output in case format specifier in unrecognized.
 		 * @return position in pattern after converter.
 		 */
-		static int extractConverter(
+		static size_t extractConverter(
 			logchar lastChar, const LogString& pattern,
 			LogString::size_type i, LogString& convBuf,
 			LogString& currentLiteral);
@@ -102,7 +102,7 @@ class LOG4CXX_EXPORT PatternParser
 		 * @param options array to receive extracted options
 		 * @return position in pattern after options.
 		 */
-		static int extractOptions(const LogString& pattern, LogString::size_type i,
+		static size_t extractOptions(const LogString& pattern, LogString::size_type i,
 			std::vector<LogString>& options);
 
 	public:
@@ -150,8 +150,8 @@ class LOG4CXX_EXPORT PatternParser
 		 * @param formattingInfos list to receive corresponding field specifier.
 		 * @return position after format specifier sequence.
 		 */
-		static int finalizeConverter(
-			logchar c, const LogString& pattern, int i,
+		static size_t finalizeConverter(
+			logchar c, const LogString& pattern, size_t i,
 			LogString& currentLiteral, const FormattingInfoPtr& formattingInfo,
 			const PatternMap&  rules,
 			std::vector<PatternConverterPtr>& patternConverters,

--- a/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
+++ b/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
@@ -26,6 +26,11 @@
 #include <log4cxx/helpers/outputstream.h>
 #include <apr_mmap.h>
 
+#if defined(_MSC_VER)
+#pragma warning ( push )
+#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 
@@ -291,6 +296,10 @@ LOG4CXX_PTR_DEF(TimeBasedRollingPolicy);
 
 }
 }
+
+#if defined(_MSC_VER)
+#pragma warning ( pop )
+#endif
 
 #endif
 

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -216,7 +216,7 @@ public:
         try {
            LOG4CXX_INFO(root, "Message");
            LOGUNIT_FAIL("Should have thrown exception");
-        } catch(NullPointerException& ex) {
+        } catch(NullPointerException&) {
         }
     }
     

--- a/src/test/cpp/util/serializationtesthelper.cpp
+++ b/src/test/cpp/util/serializationtesthelper.cpp
@@ -64,7 +64,7 @@ bool SerializationTestHelper::compare(
           return false;
       }
 
-      int endScan = actual.size();
+      size_t endScan = actual.size();
 
       if (endScan > endCompare) {
         endScan = endCompare;


### PR DESCRIPTION
Suppress "needs to have dll-interface" warnings for std::basic_string, std::map and std::stack.

Use size_t instead of int where appropriate