### PR TITLE
Fix support for find_package(log4cxx) in consuming CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ IF(WIN32 AND LOG4CXX_INSTALL_PDB)
 ENDIF(WIN32 AND LOG4CXX_INSTALL_PDB)
 
 if(UNIX)
+  # Support for pkg-config in consuming projects
   set(prefix "${CMAKE_INSTALL_PREFIX}")
   set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
   set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
@@ -54,12 +55,21 @@ if(UNIX)
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
 endif(UNIX)
 
-
-# create export file which can be imported by other cmake projects
+# Support for find_package(log4cxx) in consuming CMake projects using
+# target_include_directories(myApplication PRIVATE $<TARGET_PROPERTY:log4cxx,INTERFACE_INCLUDE_DIRECTORIES>)
+# target_link_libraries( myApplication PRIVATE $<TARGET_PROPERTY:log4cxx,IMPORTED_IMPLIB_${CMAKE_BUILD_TYPE}>)
 install(EXPORT log4cxxTargets
-  FILE log4cxx-targets.cmake
-  NAMESPACE log4cxx::
+  FILE        log4cxxConfig.cmake
   DESTINATION share/cmake/log4cxx
+)
+# Support for find_package(log4cxx 0.11) in consuming CMake projects
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/log4cxxConfigVersion.cmake"
+  VERSION       ${PROJECT_VERSION}
+  COMPATIBILITY SameMinorVersion
+)
+install(FILES   "${CMAKE_CURRENT_BINARY_DIR}/log4cxxConfigVersion.cmake"
+  DESTINATION   share/cmake/log4cxx
 )
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif(UNIX)
 
 # Support for find_package(log4cxx) in consuming CMake projects using
 # target_include_directories(myApplication PRIVATE $<TARGET_PROPERTY:log4cxx,INTERFACE_INCLUDE_DIRECTORIES>)
-# target_link_libraries( myApplication PRIVATE $<TARGET_PROPERTY:log4cxx,IMPORTED_IMPLIB_${CMAKE_BUILD_TYPE}>)
+# target_link_libraries( myApplication PRIVATE log4cxx)
 install(EXPORT log4cxxTargets
   FILE        log4cxxConfig.cmake
   DESTINATION share/cmake/log4cxx

--- a/src/site/apt/building/cmake.apt
+++ b/src/site/apt/building/cmake.apt
@@ -110,8 +110,9 @@ $ make install
 
 * Using log4cxx in a CMake build
 
-A log4cxxConfig.cmake and log4cxxConfigVersion.cmake is installed to allow use of find_package() in your CMakeLists.txt.
-Below are example cmake commands that compile and link 'myApplication" with log4cxx.
+   A log4cxxConfig.cmake and log4cxxConfigVersion.cmake is installed to allow use of find_package() in your CMakeLists.txt.
+   
+   Below are example cmake commands that compile and link 'myApplication" with log4cxx.
 
 +----+
 find_package(log4cxx 0.11)

--- a/src/site/apt/building/cmake.apt
+++ b/src/site/apt/building/cmake.apt
@@ -107,3 +107,17 @@ $ cd /usr/ports/devel/apr
 $ make
 $ make install
 +----+
+
+* Using log4cxx in a CMake build
+
+A log4cxxConfig.cmake and log4cxxConfigVersion.cmake is installed to allow use of find_package() in your CMakeLists.txt.
+Below are example cmake commands that compile and link 'myApplication" with log4cxx.
+
++----+
+find_package(log4cxx 0.11)
+add_executable(myApplication myMain.cpp)
+target_include_directories(myApplication PRIVATE $<TARGET_PROPERTY:log4cxx,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries( myApplication PRIVATE log4cxx)
++----+
+
+


### PR DESCRIPTION
Install using a standard CMake file name that is found by find_package()