### PR TITLE
Mapfilter with non-C++11-support.

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -107,6 +107,7 @@
 			<action issue="LOGCXX-262" type="fix">socketappendertestcase and xmlsocketappendertestcase not run</action>
 			<action issue="LOGCXX-249" type="fix">Console appender crashes if layout is not set</action>
 
+			<action issue="24" system="GHPR" type="add">Implementation of map-based filter.</action>
 			<action issue="21" system="GHPR" type="add">Added support for building log4cxx as a statically linked library on Windows.</action>
 			<action issue="14" system="GHPR" type="add">Replaced ant build with cmake.</action>
 			<action issue="13" system="GHPR" type="add">JSONLayout</action>

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources(log4cxx
   logmanager.cpp
   logstream.cpp
   manualtriggeringpolicy.cpp
+  mapfilter.cpp
   mdc.cpp
   messagebuffer.cpp
   messagepatternconverter.cpp

--- a/src/main/cpp/Makefile.am
+++ b/src/main/cpp/Makefile.am
@@ -93,6 +93,7 @@ liblog4cxx_la_SOURCES = \
         logmanager.cpp \
         logstream.cpp \
         manualtriggeringpolicy.cpp \
+        mapfilter.cpp \
         messagebuffer.cpp \
         messagepatternconverter.cpp \
         methodlocationpatternconverter.cpp \

--- a/src/main/cpp/mapfilter.cpp
+++ b/src/main/cpp/mapfilter.cpp
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <log4cxx/logstring.h>
+#include <log4cxx/filter/mapfilter.h>
+#include <log4cxx/spi/loggingevent.h>
+#include <log4cxx/helpers/stringhelper.h>
+#include <log4cxx/helpers/optionconverter.h>
+
+using namespace log4cxx;
+using namespace log4cxx::filter;
+using namespace log4cxx::spi;
+using namespace log4cxx::helpers;
+
+IMPLEMENT_LOG4CXX_OBJECT(MapFilter)
+
+void MapFilter::setOption(const LogString& option,
+	const LogString& value)
+{
+
+	if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("ACCEPTONMATCH"), LOG4CXX_STR("acceptonmatch"))) {
+
+		acceptOnMatch = OptionConverter::toBoolean(value, acceptOnMatch);
+	}
+	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("OPERATOR"), LOG4CXX_STR("operator"))) {
+
+		mustMatchAll = StringHelper::equalsIgnoreCase(value, LOG4CXX_STR("AND"), LOG4CXX_STR("and")) ? true : false;
+	}
+	else if (!option.empty() && !value.empty()) {
+
+		mapKeyValList.emplace(option, value);
+	}
+}
+
+Filter::FilterDecision MapFilter::decide(
+	const log4cxx::spi::LoggingEventPtr& event) const
+{
+	if (mapKeyValList.empty()) {
+		return Filter::NEUTRAL;
+	}
+
+	bool	matched = true;
+	for (auto it = mapKeyValList.cbegin(); it != mapKeyValList.cend(); ++it) {
+		LogString curval;
+		event->getMDC(it->first, curval);
+
+		if (curval.empty() || curval != it->second) {
+			matched = false;
+		}
+		else {
+			matched = true;
+		}
+			
+		if (mustMatchAll != matched) {
+			break;
+		}
+	}
+
+	if (acceptOnMatch)	{
+		return matched ? Filter::ACCEPT : Filter::DENY;
+	}
+	else {
+		return matched ? Filter::DENY : Filter::ACCEPT;
+	}
+}

--- a/src/main/cpp/mapfilter.cpp
+++ b/src/main/cpp/mapfilter.cpp
@@ -32,48 +32,56 @@ void MapFilter::setOption(const LogString& option,
 	const LogString& value)
 {
 
-	if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("ACCEPTONMATCH"), LOG4CXX_STR("acceptonmatch"))) {
-
+	if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("ACCEPTONMATCH"), LOG4CXX_STR("acceptonmatch")))
+	{
 		acceptOnMatch = OptionConverter::toBoolean(value, acceptOnMatch);
 	}
-	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("OPERATOR"), LOG4CXX_STR("operator"))) {
-
+	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("OPERATOR"), LOG4CXX_STR("operator")))
+	{
 		mustMatchAll = StringHelper::equalsIgnoreCase(value, LOG4CXX_STR("AND"), LOG4CXX_STR("and")) ? true : false;
 	}
-	else if (!option.empty() && !value.empty()) {
-
-		mapKeyValList.emplace(option, value);
+	else if (!option.empty() && !value.empty())
+	{
+		mapKeyValList[option] = value;
 	}
 }
 
 Filter::FilterDecision MapFilter::decide(
 	const log4cxx::spi::LoggingEventPtr& event) const
 {
-	if (mapKeyValList.empty()) {
+	if (mapKeyValList.empty())
+	{
 		return Filter::NEUTRAL;
 	}
 
-	bool	matched = true;
-	for (auto it = mapKeyValList.cbegin(); it != mapKeyValList.cend(); ++it) {
+	bool    matched = true;
+
+	for (auto it = mapKeyValList.cbegin(); it != mapKeyValList.cend(); ++it)
+	{
 		LogString curval;
 		event->getMDC(it->first, curval);
 
-		if (curval.empty() || curval != it->second) {
+		if (curval.empty() || curval != it->second)
+		{
 			matched = false;
 		}
-		else {
+		else
+		{
 			matched = true;
 		}
-			
-		if (mustMatchAll != matched) {
+
+		if (mustMatchAll != matched)
+		{
 			break;
 		}
 	}
 
-	if (acceptOnMatch)	{
+	if (acceptOnMatch)
+	{
 		return matched ? Filter::ACCEPT : Filter::DENY;
 	}
-	else {
+	else
+	{
 		return matched ? Filter::DENY : Filter::ACCEPT;
 	}
 }

--- a/src/main/cpp/mapfilter.cpp
+++ b/src/main/cpp/mapfilter.cpp
@@ -28,10 +28,14 @@ using namespace log4cxx::helpers;
 
 IMPLEMENT_LOG4CXX_OBJECT(MapFilter)
 
-void MapFilter::setOption(const LogString& option,
-	const LogString& value)
+MapFilter::MapFilter() : acceptOnMatch(true), mustMatchAll(false)
 {
 
+}
+
+void MapFilter::setOption(	const LogString& option,
+							const LogString& value)
+{
 	if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("ACCEPTONMATCH"), LOG4CXX_STR("acceptonmatch")))
 	{
 		acceptOnMatch = OptionConverter::toBoolean(value, acceptOnMatch);
@@ -42,21 +46,21 @@ void MapFilter::setOption(const LogString& option,
 	}
 	else if (!option.empty() && !value.empty())
 	{
-		mapKeyValList[option] = value;
+		keyVals[option] = value;
 	}
 }
 
 Filter::FilterDecision MapFilter::decide(
 	const log4cxx::spi::LoggingEventPtr& event) const
 {
-	if (mapKeyValList.empty())
+	if (keyVals.empty())
 	{
 		return Filter::NEUTRAL;
 	}
 
-	bool    matched = true;
+	bool matched = true;
 
-	for (auto it = mapKeyValList.cbegin(); it != mapKeyValList.cend(); ++it)
+	for (KeyVals::const_iterator it = keyVals.begin(); it != keyVals.end(); ++it)
 	{
 		LogString curval;
 		event->getMDC(it->first, curval);

--- a/src/main/include/log4cxx/filter/mapfilter.h
+++ b/src/main/include/log4cxx/filter/mapfilter.h
@@ -28,18 +28,18 @@ namespace log4cxx
 {
 namespace filter
 {
+
 /**
  * A Filter that operates on a Map.
  */
-
 class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 {
-	typedef std::map < LogString, LogString > KeyValList;
+	typedef std::map < LogString, LogString > KeyVals;
 
 	private:
-		bool acceptOnMatch = true;
-		bool mustMatchAll = false;  // true = AND; false = OR
-		KeyValList mapKeyValList;
+		bool	acceptOnMatch;
+		bool	mustMatchAll; // true = AND; false = OR
+		KeyVals	keyVals;
 
 	public:
 		DECLARE_LOG4CXX_OBJECT(MapFilter)
@@ -48,7 +48,7 @@ class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 		LOG4CXX_CAST_ENTRY_CHAIN(log4cxx::spi::Filter)
 		END_LOG4CXX_CAST_MAP()
 
-		MapFilter() {}
+		MapFilter();
 
 		/**
 		Set options
@@ -58,14 +58,15 @@ class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 
 		inline void setKeyValue(const LogString& strKey, const LogString& strValue)
 		{
-			this->mapKeyValList[strKey] = strValue;
+			this->keyVals[strKey] = strValue;
 		}
 
 		inline const LogString& getValue(const LogString& strKey) const
 		{
-			static const LogString empty{};
-			auto it = mapKeyValList.find(strKey);
-			return (it != mapKeyValList.end() ? it->second : empty);
+			static	const LogString					empty;
+					const KeyVals::const_iterator	it(this->keyVals.find(strKey));
+
+			return (it != keyVals.end() ? it->second : empty);
 		}
 
 		inline void setAcceptOnMatch(bool acceptOnMatch1)
@@ -94,8 +95,10 @@ class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 		*/
 		FilterDecision decide(const spi::LoggingEventPtr& event) const;
 }; // class MapFilter
+
 LOG4CXX_PTR_DEF(MapFilter);
-}  // namespace filter
+
+} // namespace filter
 } // namespace log4cxx
 
 #if defined(_MSC_VER)

--- a/src/main/include/log4cxx/filter/mapfilter.h
+++ b/src/main/include/log4cxx/filter/mapfilter.h
@@ -32,14 +32,14 @@ namespace filter
  * A Filter that operates on a Map.
  */
 
- using keyvallist = std::map<LogString, LogString>;
+using KeyValList = std::map<LogString, LogString>;
 
 class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 {
 	private:
-		bool acceptOnMatch{true};
-		bool mustMatchAll{false};	// true = AND; false = OR
-		keyvallist mapKeyValList;
+		bool acceptOnMatch = true;
+		bool mustMatchAll = false;  // true = AND; false = OR
+		KeyValList mapKeyValList;
 
 	public:
 		DECLARE_LOG4CXX_OBJECT(MapFilter)
@@ -48,7 +48,7 @@ class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 		LOG4CXX_CAST_ENTRY_CHAIN(log4cxx::spi::Filter)
 		END_LOG4CXX_CAST_MAP()
 
-		MapFilter(){}
+		MapFilter() {}
 
 		/**
 		Set options

--- a/src/main/include/log4cxx/filter/mapfilter.h
+++ b/src/main/include/log4cxx/filter/mapfilter.h
@@ -19,26 +19,87 @@
 
 #include <log4cxx/spi/filter.h>
 
+#if defined(_MSC_VER)
+	#pragma warning ( push )
+	#pragma warning ( disable: 4251 )
+#endif
+
 namespace log4cxx
 {
 namespace filter
 {
+/**
+ * A Filter that operates on a Map.
+ */
 
+ using keyvallist = std::map<LogString, LogString>;
 
 class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 {
+	private:
+		bool acceptOnMatch{true};
+		bool mustMatchAll{false};	// true = AND; false = OR
+		keyvallist mapKeyValList;
+
 	public:
 		DECLARE_LOG4CXX_OBJECT(MapFilter)
 		BEGIN_LOG4CXX_CAST_MAP()
-		LOG4CXX_CAST_ENTRY(log4cxx::spi::Filter)
+		LOG4CXX_CAST_ENTRY(MapFilter)
+		LOG4CXX_CAST_ENTRY_CHAIN(log4cxx::spi::Filter)
 		END_LOG4CXX_CAST_MAP()
 
-		MapFilter();
+		MapFilter(){}
 
+		/**
+		Set options
+		*/
+		virtual void setOption(const LogString& option,
+			const LogString& value);
 
+		inline void setKeyValue(const LogString& strKey, const LogString& strValue)
+		{
+			this->mapKeyValList[strKey] = strValue;
+		}
+
+		inline const LogString& getValue(const LogString& strKey) const
+		{
+			static const LogString empty{};
+			auto it = mapKeyValList.find(strKey);
+			return (it != mapKeyValList.end() ? it->second : empty);
+		}
+
+		inline void setAcceptOnMatch(bool acceptOnMatch1)
+		{
+			this->acceptOnMatch = acceptOnMatch1;
+		}
+
+		inline bool getAcceptOnMatch() const
+		{
+			return acceptOnMatch;
+		}
+
+		inline bool getMustMatchAll() const
+		{
+			return mustMatchAll;
+		}
+
+		inline void setMustMatchAll(bool mustMatchAll1)
+		{
+			this->mustMatchAll = mustMatchAll1;
+		}
+
+		/**
+		Returns {@link log4cxx::spi::Filter#NEUTRAL NEUTRAL}
+		is there is no string match.
+		*/
 		FilterDecision decide(const spi::LoggingEventPtr& event) const;
+}; // class MapFilter
+LOG4CXX_PTR_DEF(MapFilter);
+}  // namespace filter
+} // namespace log4cxx
 
-};
-}
-}
+#if defined(_MSC_VER)
+	#pragma warning (pop)
 #endif
+
+#endif // _LOG4CXX_FILTER_MAPFILTER_H

--- a/src/main/include/log4cxx/filter/mapfilter.h
+++ b/src/main/include/log4cxx/filter/mapfilter.h
@@ -32,10 +32,10 @@ namespace filter
  * A Filter that operates on a Map.
  */
 
-using KeyValList = std::map<LogString, LogString>;
-
 class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 {
+	typedef std::map < LogString, LogString > KeyValList;
+
 	private:
 		bool acceptOnMatch = true;
 		bool mustMatchAll = false;  // true = AND; false = OR

--- a/src/main/include/log4cxx/filter/mapfilter.h
+++ b/src/main/include/log4cxx/filter/mapfilter.h
@@ -30,7 +30,15 @@ namespace filter
 {
 
 /**
- * A Filter that operates on a Map.
+ * A Filter that operates on a Map and can be used like in the following example:
+ * <pre>
+ * &lt;filter class="MapFilter"&gt;
+ *     &lt;param name="user.ip"       value="127.0.0.1" /&gt;
+ *     &lt;param name="user.name"     value="test2"     /&gt;
+ *     &lt;param name="Operator"      value="AND"       /&gt;
+ *     &lt;param name="AcceptOnMatch" value="false"     /&gt;
+ * &lt;/filter&gt;
+ * </pre>
  */
 class LOG4CXX_EXPORT MapFilter: public log4cxx::spi::Filter
 {

--- a/src/test/cpp/Makefile.am
+++ b/src/test/cpp/Makefile.am
@@ -67,6 +67,7 @@ filter_tests = \
     filter/levelmatchfiltertest.cpp \
     filter/levelrangefiltertest.cpp \
     filter/loggermatchfiltertest.cpp \
+    filter/mapfiltertest.cpp \
     filter/stringmatchfiltertest.cpp
 
 helpers = \

--- a/src/test/cpp/filter/CMakeLists.txt
+++ b/src/test/cpp/filter/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(filtertests
     levelmatchfiltertest.cpp
     levelrangefiltertest.cpp
     loggermatchfiltertest.cpp
+    mapfiltertest.cpp
     stringmatchfiltertest.cpp
 )
 set(ALL_LOG4CXX_TESTS ${ALL_LOG4CXX_TESTS} filtertests PARENT_SCOPE)

--- a/src/test/cpp/filter/mapfiltertest.cpp
+++ b/src/test/cpp/filter/mapfiltertest.cpp
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <log4cxx/filter/mapfilter.h>
+#include <log4cxx/logger.h>
+#include <log4cxx/spi/filter.h>
+#include <log4cxx/spi/loggingevent.h>
+#include "../logunit.h"
+
+using namespace log4cxx;
+using namespace log4cxx::filter;
+using namespace log4cxx::spi;
+using namespace log4cxx::helpers;
+
+/**
+ * Unit tests for MapFilter.
+ */
+LOGUNIT_CLASS(MapFilterTest)
+{
+	LOGUNIT_TEST_SUITE(MapFilterTest);
+	LOGUNIT_TEST(test1);
+	LOGUNIT_TEST(test2);
+	LOGUNIT_TEST(test3);
+	LOGUNIT_TEST(test4);
+	LOGUNIT_TEST_SUITE_END();
+
+public:
+
+	/**
+	 * Check that MapFilter.decide() returns Filter.NEUTRAL
+	 *   when there are no map entries specified.
+	 */
+	void test1()
+	{
+		LoggingEventPtr event(new LoggingEvent(
+				LOG4CXX_STR("MapFilterTest"),
+				Level::getInfo(),
+				LOG4CXX_STR("Hello, World"),
+				LOG4CXX_LOCATION));
+		FilterPtr filter(new MapFilter());
+		Pool p;
+		filter->activateOptions(p);
+		LOGUNIT_ASSERT_EQUAL(Filter::NEUTRAL, filter->decide(event));
+	}
+
+	/**
+	 * Check that MapFilter.decide() returns Filter.ACCEPT or Filter.DENY
+	 *   based on Accept on Match setting when key/value does not match
+	 */
+	void test2()
+	{
+		LoggingEventPtr event(new LoggingEvent(
+				LOG4CXX_STR("MapFilterTest"),
+				Level::getInfo(),
+				LOG4CXX_STR("Hello, World"),
+				LOG4CXX_LOCATION));
+		MDC::put(LOG4CXX_STR("my.ip"), LOG4CXX_STR("localhost"));
+		MapFilterPtr filter(new MapFilter());
+		filter->setKeyValue(LOG4CXX_STR("my.ip"), LOG4CXX_STR("127.0.0.1"));
+		Pool p;
+		filter->activateOptions(p);
+
+		filter->setAcceptOnMatch(true);
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));
+
+		filter->setAcceptOnMatch(false);
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));
+	}
+
+	/**
+	 * Check that MapFilter.decide() returns Filter.ACCEPT or Filter.DENY
+	 *   based on Accept on Match setting when key/value matches
+	 */
+	void test3()
+	{
+		LoggingEventPtr event(new LoggingEvent(
+				LOG4CXX_STR("MapFilterTest"),
+				Level::getInfo(),
+				LOG4CXX_STR("Hello, World"),
+				LOG4CXX_LOCATION));
+		MDC::put(LOG4CXX_STR("my.ip"), LOG4CXX_STR("127.0.0.1"));
+		MapFilterPtr filter(new MapFilter());
+		filter->setKeyValue(LOG4CXX_STR("my.ip"), LOG4CXX_STR("127.0.0.1"));
+		Pool p;
+		filter->activateOptions(p);
+
+		filter->setAcceptOnMatch(true);
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));
+
+		filter->setAcceptOnMatch(false);
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));
+	}
+
+	/**
+	 * Check that MapFilter.decide() ANDs or ORs multiple key/values
+	 *   based on operator setting
+	 */
+	void test4()
+	{
+		LoggingEventPtr event(new LoggingEvent(
+				LOG4CXX_STR("MapFilterTest"),
+				Level::getInfo(),
+				LOG4CXX_STR("Hello, World"),
+				LOG4CXX_LOCATION));
+		MDC::put(LOG4CXX_STR("my.ip"), LOG4CXX_STR("127.0.0.1"));
+		MDC::put(LOG4CXX_STR("my.name"), LOG4CXX_STR("Test"));
+		MapFilterPtr filter(new MapFilter());
+		filter->setKeyValue(LOG4CXX_STR("my.ip"), LOG4CXX_STR("127.0.0.1"));
+		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Unknown"));
+		filter->setAcceptOnMatch(true);
+		Pool p;
+		filter->activateOptions(p);
+
+		filter->setMustMatchAll(true);		// AND T/F
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));		// does not match second
+
+		filter->setMustMatchAll(false);	// OR T/F
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));	// matches first
+
+		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Test"));	
+
+		filter->setMustMatchAll(true);		// AND T/T
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));	// matches all
+
+		filter->setMustMatchAll(false);	// OR T/T
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));	// matches first
+
+		filter->setKeyValue(LOG4CXX_STR("my.ip"), LOG4CXX_STR("localhost"));	
+
+		filter->setMustMatchAll(true);		// AND F/T
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));		// does not match first
+
+		filter->setMustMatchAll(false);	// OR F/T
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));	// matches second
+
+		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Unkonwn"));	
+
+		filter->setMustMatchAll(true);		// AND F/F
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));		// does not match first
+
+		filter->setMustMatchAll(false);	// OR F/F
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));		// matches none
+	}
+
+};
+
+
+LOGUNIT_TEST_SUITE_REGISTRATION(MapFilterTest);
+
+

--- a/src/test/cpp/filter/mapfiltertest.cpp
+++ b/src/test/cpp/filter/mapfiltertest.cpp
@@ -124,35 +124,35 @@ public:
 		Pool p;
 		filter->activateOptions(p);
 
-		filter->setMustMatchAll(true);		// AND T/F
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));		// does not match second
+		filter->setMustMatchAll(true);      // AND T/F
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));      // does not match second
 
-		filter->setMustMatchAll(false);	// OR T/F
-		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));	// matches first
+		filter->setMustMatchAll(false); // OR T/F
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));    // matches first
 
-		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Test"));	
+		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Test"));
 
-		filter->setMustMatchAll(true);		// AND T/T
-		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));	// matches all
+		filter->setMustMatchAll(true);      // AND T/T
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));    // matches all
 
-		filter->setMustMatchAll(false);	// OR T/T
-		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));	// matches first
+		filter->setMustMatchAll(false); // OR T/T
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));    // matches first
 
-		filter->setKeyValue(LOG4CXX_STR("my.ip"), LOG4CXX_STR("localhost"));	
+		filter->setKeyValue(LOG4CXX_STR("my.ip"), LOG4CXX_STR("localhost"));
 
-		filter->setMustMatchAll(true);		// AND F/T
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));		// does not match first
+		filter->setMustMatchAll(true);      // AND F/T
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));      // does not match first
 
-		filter->setMustMatchAll(false);	// OR F/T
-		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));	// matches second
+		filter->setMustMatchAll(false); // OR F/T
+		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));    // matches second
 
-		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Unkonwn"));	
+		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Unkonwn"));
 
-		filter->setMustMatchAll(true);		// AND F/F
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));		// does not match first
+		filter->setMustMatchAll(true);      // AND F/F
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));      // does not match first
 
-		filter->setMustMatchAll(false);	// OR F/F
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));		// matches none
+		filter->setMustMatchAll(false); // OR F/F
+		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));      // matches none
 	}
 
 };


### PR DESCRIPTION
This is slightly customized PR based on #24 adding support for non-C++11 compilers like `bcc32`. Once @pm-cfs things the PR is still OK, it can be merged in favour of #24.

https://github.com/apache/logging-log4cxx/pull/24