### PR TITLE
Fix missing const in method getThreshold

### DIFF
--- a/src/main/include/log4cxx/appenderskeleton.h
+++ b/src/main/include/log4cxx/appenderskeleton.h
@@ -173,7 +173,7 @@ class LOG4CXX_EXPORT AppenderSkeleton :
 		Returns this appenders threshold level. See the #setThreshold
 		method for the meaning of this option.
 		*/
-		const LevelPtr& getThreshold()
+		const LevelPtr& getThreshold() const
 		{
 			return threshold;
 		}


### PR DESCRIPTION
The method getThreshold wasn't const so it wasn't possible to call getThreshold on a const object and const cast was needed.