### PR TITLE
Fix missing const

### DIFF
--- a/src/main/cpp/dailyrollingfileappender.cpp
+++ b/src/main/cpp/dailyrollingfileappender.cpp
@@ -53,7 +53,7 @@ void DailyRollingFileAppender::setDatePattern(const LogString& newPattern)
 	datePattern = newPattern;
 }
 
-LogString DailyRollingFileAppender::getDatePattern()
+LogString DailyRollingFileAppender::getDatePattern() const
 {
 	return datePattern;
 }

--- a/src/main/include/log4cxx/dailyrollingfileappender.h
+++ b/src/main/include/log4cxx/dailyrollingfileappender.h
@@ -183,7 +183,7 @@ class LOG4CXX_EXPORT DailyRollingFileAppender : public log4cxx::rolling::Rolling
 		void setDatePattern(const LogString& pattern);
 
 		/** Returns the value of the <b>DatePattern</b> option. */
-		LogString getDatePattern();
+		LogString getDatePattern() const;
 
 		void setOption(const LogString& option,
 			const LogString& value);


### PR DESCRIPTION
Const was missing for method getDatePattern and a const_cast was needed if the object instance was const.