### PR TITLE
reorder find_package to build SO correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,17 @@ include(CTest)
 # FindAPR and FindAPR-util are not provided by APR and APR-Util so source them locally
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/cmake")
 
-# Find Apache Runtime
-find_package(APR REQUIRED)
-
-# Find Apache Runtime Utilities
-find_package(APR-Util REQUIRED)
-
 # Add support for linking statically
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 if(NOT BUILD_SHARED_LIBS)
   set(LOG4CXX_COMPILE_DEFINITIONS LOG4CXX_STATIC)
 endif()
+
+# Find Apache Runtime
+find_package(APR REQUIRED)
+
+# Find Apache Runtime Utilities
+find_package(APR-Util REQUIRED)
 
 # Building
 add_subdirectory(src)


### PR DESCRIPTION
When building log4cxx with CMake, the BUILD_SHARED_LIBS option must be defined before finding APR and APR-util, as those use this variable.