### PR TITLE
Prevent filenamepatterntestcase from failing

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -97,6 +97,7 @@
 			<action issue="LOGCXX-277" type="fix">Reconnection not working for sockets</action>
 			<action issue="LOGCXX-276" type="fix">AndFilter and others defined but not implemented</action>
 			<action issue="LOGCXX-275" type="fix">Headers cannot be included with very strict warning settings</action>
+			<action issue="LOGCXX-273" type="fix">Prevent filenamepatterntestcase from failing in some timezones</action>
 			<action issue="LOGCXX-272" type="update">Apache log4cxx 0.11.0 release</action>
 			<action issue="LOGCXX-271" type="fix">MDC::put will not overwrite existing key value pair</action>
 			<action issue="LOGCXX-270" type="fix">Add ability to compile out logging by logging level.</action>

--- a/src/test/cpp/rolling/filenamepatterntestcase.cpp
+++ b/src/test/cpp/rolling/filenamepatterntestcase.cpp
@@ -99,13 +99,14 @@ public:
 	{
 		apr_time_exp_t tm;
 		memset(&tm, 0, sizeof(tm));
+		apr_time_exp_lt(&tm, 0); // set tm_gmtoff
 		tm.tm_min = min;
 		tm.tm_hour = hour;
 		tm.tm_mday = day;
 		tm.tm_mon = month;
 		tm.tm_year = year - 1900;
 		apr_time_t n;
-		/*apr_status_t stat = */apr_time_exp_get(&n, &tm);
+		apr_time_exp_gmt_get(&n, &tm);
 		ObjectPtr obj(new Date(n));
 		LOGUNIT_ASSERT_EQUAL(expected, format(pattern, obj));
 	}


### PR DESCRIPTION
when the test is run in a time zone east of the prime meridian