### PR TITLE
Set SONAME in cmake like autotools based buildsystem would do.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ include(src/cmake/projectVersionDetails.cmake)
 project(log4cxx VERSION ${log4cxx_VER} LANGUAGES CXX)
 include(CTest)
 
+# define the SO Version of the library. Version of the log4cxx project is subtly different than the version of the library
+# (at least in the past it was project vesion: 0.a.b.c and the library so vesion a.b.c.0
+set(LIBLOG4CXX_LIB_VERSION ${log4cxx_VERSION_MINOR}.${log4cxx_VERSION_PATCH}.${log4cxx_VERSION_TWEAK})
+set(LIBLOG4CXX_LIB_SOVERSION ${log4cxx_VERSION_MINOR})
+
 # FindAPR and FindAPR-util are not provided by APR and APR-Util so source them locally
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/cmake")
 

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -165,6 +165,6 @@ target_sources(log4cxx
   zipcompressaction.cpp
 )
 set_target_properties(log4cxx PROPERTIES
-  VERSION ${log4cxx_VERSION_MAJOR}.${log4cxx_VERSION_MINOR}.${log4cxx_VERSION_PATCH}
-  SOVERSION ${log4cxx_VERSION_MAJOR}
+  VERSION ${LIBLOG4CXX_LIB_VERSION}
+  SOVERSION ${LIBLOG4CXX_LIB_SOVERSION}
 )


### PR DESCRIPTION
This should fix LOGCXX-512…

Other alternative would be to change project versioning to match the SONAME. In this case the autotools would need fixing (or retirement).

Cheer,
tobi 