### PR TITLE
Make "quietMode" ignore exceptions as well.

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -39,6 +39,7 @@
 			<action issue="LOGCXX-483" type="update">Not able to see hebrew values when logging in log4cxx</action>
 			<action issue="LOGCXX-482" type="fix">Build failure with GCC-6</action>
 			<action issue="LOGCXX-464" type="fix">TimeBasedRollingPolicy should append as configured on rollover</action>
+			<action issue="LOGCXX-455" type="fix">LogLog::setQuietMode(true) does not suppress exception reporting</action>
 			<action issue="LOGCXX-446" type="fix">make install fails, trying to overwrite header files</action>
 			<action issue="LOGCXX-443" type="fix">Return by const reference in Logger::getName()</action>
 			<action issue="LOGCXX-433" type="fix">Autoconf 2.69 needs 'ACLOCAL_AMFLAGS= -I .'</action>

--- a/src/main/cpp/loglog.cpp
+++ b/src/main/cpp/loglog.cpp
@@ -34,8 +34,8 @@ LogLog::LogLog() : mutex(APRInitializer::getRootPool())
 {
 	synchronized sync(mutex);
 
-	debugEnabled    = false;
-	quietMode       = false;
+	debugEnabled	= false;
+	quietMode		= false;
 }
 
 LogLog& LogLog::getInstance()
@@ -54,16 +54,23 @@ void LogLog::setInternalDebugging(bool debugEnabled1)
 
 void LogLog::debug(const LogString& msg)
 {
+	if (!getInstance().debugEnabled)
+	{
+		return;
+	}
+
 	synchronized sync(getInstance().mutex);
 
-	if (getInstance().debugEnabled && !getInstance().quietMode)
-	{
-		emit(msg);
-	}
+	emit(msg);
 }
 
 void LogLog::debug(const LogString& msg, const std::exception& e)
 {
+	if (!getInstance().debugEnabled)
+	{
+		return;
+	}
+
 	synchronized sync(getInstance().mutex);
 
 	debug(msg);
@@ -75,10 +82,7 @@ void LogLog::error(const LogString& msg)
 {
 	synchronized sync(getInstance().mutex);
 
-	if (!getInstance().quietMode)
-	{
-		emit(msg);
-	}
+	emit(msg);
 }
 
 void LogLog::error(const LogString& msg, const std::exception& e)
@@ -100,10 +104,7 @@ void LogLog::warn(const LogString& msg)
 {
 	synchronized sync(getInstance().mutex);
 
-	if (!getInstance().quietMode)
-	{
-		emit(msg);
-	}
+	emit(msg);
 }
 
 void LogLog::warn(const LogString& msg, const std::exception& e)
@@ -116,6 +117,11 @@ void LogLog::warn(const LogString& msg, const std::exception& e)
 
 void LogLog::emit(const LogString& msg)
 {
+	if (getInstance().quietMode)
+	{
+		return;
+	}
+
 	LogString out(LOG4CXX_STR("log4cxx: "));
 
 	out.append(msg);
@@ -126,6 +132,11 @@ void LogLog::emit(const LogString& msg)
 
 void LogLog::emit(const std::exception& ex)
 {
+	if (getInstance().quietMode)
+	{
+		return;
+	}
+
 	LogString out(LOG4CXX_STR("log4cxx: "));
 	const char* raw = ex.what();
 


### PR DESCRIPTION
Changed the implementation to handle "quietMode" always. That has been the requested behaviour in LOGCXX-455 and it seems to simply make sense to handle that always at one place.

https://issues.apache.org/jira/projects/LOGCXX/issues/LOGCXX-455