### PR TITLE
Don't remove generated files on clean

### DIFF
--- a/src/main/include/CMakeLists.txt
+++ b/src/main/include/CMakeLists.txt
@@ -10,9 +10,6 @@ add_custom_target(configure_log4cxx
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/log4cxx/log4cxx.hw
     ${CMAKE_CURRENT_SOURCE_DIR}/log4cxx/private/log4cxx_private.hw
-  BYPRODUCTS
-    ${CMAKE_CURRENT_BINARY_DIR}/log4cxx/log4cxx.h
-    ${CMAKE_CURRENT_BINARY_DIR}/log4cxx/private/log4cxx_private.h
 )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/log4cxx/version_info.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/log4cxx/version_info.h
@@ -112,8 +109,5 @@ add_custom_target(configure_log4cxx
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/log4cxx/log4cxx.h.in
     ${CMAKE_CURRENT_SOURCE_DIR}/log4cxx/private/log4cxx_private.h.in
-  BYPRODUCTS
-    ${CMAKE_CURRENT_BINARY_DIR}/log4cxx/log4cxx.h
-    ${CMAKE_CURRENT_BINARY_DIR}/log4cxx/private/log4cxx_private.h
 )
 endif()


### PR DESCRIPTION
When generated files are removed on clean, the build will
fail because log4cxx.h is not found, and cmake must be run
again.  The files still get regenrated anyway.