### PR TITLE
fix build without wchar

### DIFF
--- a/src/main/cpp/odbcappender.cpp
+++ b/src/main/cpp/odbcappender.cpp
@@ -357,10 +357,12 @@ void ODBCAppender::setSql(const LogString& s)
 	}
 }
 
+#if LOG4CXX_WCHAR_T_API || LOG4CXX_LOGCHAR_IS_WCHAR_T || defined(WIN32) || defined(_WIN32)
 void ODBCAppender::encode(wchar_t** dest, const LogString& src, Pool& p)
 {
 	*dest = Transcoder::wencode(src, p);
 }
+#endif
 
 void ODBCAppender::encode(unsigned short** dest,
 	const LogString& src, Pool& p)

--- a/src/main/include/log4cxx/db/odbcappender.h
+++ b/src/main/include/log4cxx/db/odbcappender.h
@@ -300,8 +300,10 @@ class LOG4CXX_EXPORT ODBCAppender : public AppenderSkeleton
 	private:
 		ODBCAppender(const ODBCAppender&);
 		ODBCAppender& operator=(const ODBCAppender&);
+#if LOG4CXX_WCHAR_T_API || LOG4CXX_LOGCHAR_IS_WCHAR_T || defined(WIN32) || defined(_WIN32)
 		static void encode(wchar_t** dest, const LogString& src,
 			log4cxx::helpers::Pool& p);
+#endif
 		static void encode(unsigned short** dest, const LogString& src,
 			log4cxx::helpers::Pool& p);
 }; // class ODBCAppender


### PR DESCRIPTION
Disable wencode without wchar or the build will fail on:

```
odbcappender.cpp: In static member function 'static void log4cxx::db::ODBCAppender::encode(wchar_t**, const LogString&, log4cxx::helpers::Pool&)':
odbcappender.cpp:362:22: error: 'wencode' is not a member of 'log4cxx::helpers::Transcoder'
  *dest = Transcoder::wencode(src, p);
                      ^~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/bab5329fdeb894471bfd5192ce04d3fbd2f9be5c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>