### PR TITLE
fix log4cxx mapfilter chaining

### DIFF
--- a/src/main/cpp/mapfilter.cpp
+++ b/src/main/cpp/mapfilter.cpp
@@ -82,10 +82,10 @@ Filter::FilterDecision MapFilter::decide(
 
 	if (acceptOnMatch)
 	{
-		return matched ? Filter::ACCEPT : Filter::DENY;
+		return matched ? Filter::ACCEPT : Filter::NEUTRAL;
 	}
 	else
 	{
-		return matched ? Filter::DENY : Filter::ACCEPT;
+		return matched ? Filter::DENY : Filter::NEUTRAL;
 	}
 }

--- a/src/test/cpp/filter/mapfiltertest.cpp
+++ b/src/test/cpp/filter/mapfiltertest.cpp
@@ -57,8 +57,8 @@ public:
 	}
 
 	/**
-	 * Check that MapFilter.decide() returns Filter.ACCEPT or Filter.DENY
-	 *   based on Accept on Match setting when key/value does not match
+	 * Check that MapFilter.decide() returns Filter.NEUTRAL
+	 *   when key/value does not match
 	 */
 	void test2()
 	{
@@ -74,10 +74,10 @@ public:
 		filter->activateOptions(p);
 
 		filter->setAcceptOnMatch(true);
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));
+		LOGUNIT_ASSERT_EQUAL(Filter::NEUTRAL, filter->decide(event));
 
 		filter->setAcceptOnMatch(false);
-		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));
+		LOGUNIT_ASSERT_EQUAL(Filter::NEUTRAL, filter->decide(event));
 	}
 
 	/**
@@ -125,9 +125,9 @@ public:
 		filter->activateOptions(p);
 
 		filter->setMustMatchAll(true);      // AND T/F
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));      // does not match second
+		LOGUNIT_ASSERT_EQUAL(Filter::NEUTRAL, filter->decide(event));   // does not match second
 
-		filter->setMustMatchAll(false); // OR T/F
+		filter->setMustMatchAll(false);     // OR T/F
 		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));    // matches first
 
 		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Test"));
@@ -135,29 +135,26 @@ public:
 		filter->setMustMatchAll(true);      // AND T/T
 		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));    // matches all
 
-		filter->setMustMatchAll(false); // OR T/T
+		filter->setMustMatchAll(false);     // OR T/T
 		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));    // matches first
 
 		filter->setKeyValue(LOG4CXX_STR("my.ip"), LOG4CXX_STR("localhost"));
 
 		filter->setMustMatchAll(true);      // AND F/T
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));      // does not match first
+		LOGUNIT_ASSERT_EQUAL(Filter::NEUTRAL, filter->decide(event));   // does not match first
 
-		filter->setMustMatchAll(false); // OR F/T
+		filter->setMustMatchAll(false);     // OR F/T
 		LOGUNIT_ASSERT_EQUAL(Filter::ACCEPT, filter->decide(event));    // matches second
 
 		filter->setKeyValue(LOG4CXX_STR("my.name"), LOG4CXX_STR("Unkonwn"));
 
 		filter->setMustMatchAll(true);      // AND F/F
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));      // does not match first
+		LOGUNIT_ASSERT_EQUAL(Filter::NEUTRAL, filter->decide(event));   // does not match first
 
-		filter->setMustMatchAll(false); // OR F/F
-		LOGUNIT_ASSERT_EQUAL(Filter::DENY, filter->decide(event));      // matches none
+		filter->setMustMatchAll(false);     // OR F/F
+		LOGUNIT_ASSERT_EQUAL(Filter::NEUTRAL, filter->decide(event));   // matches none
 	}
 
 };
 
-
 LOGUNIT_TEST_SUITE_REGISTRATION(MapFilterTest);
-
-


### PR DESCRIPTION
# Summary
Previously we either ACCEPTed or DENYed any log when this filter was present. This configuration prevented proper filter chaining.

# Changes
* Update mapfilter to return NEUTRAL when additional filters should be considered.
* Update tests to check for these values.

# Testing
Run the unit test.

To manually test: using any logging configuration where IP addreses are available in MDC (implementation dependent):
```
   <filter class="MapFilter">
      <param name="ip" value="192.169.0.2" />
      <param name="AcceptOnMatch" value="false" />
    </filter>
    <filter class="MapFilter">
      <param name="ip" value="192.169.0.3" />
      <param name="AcceptOnMatch" value="false" />
    </filter>
```
* In the first filter set the IP address to a machine/VM you want to ignore; entries from this machine won't be logged.
* In the second, change ip address to another machine to ignore.
* Now verify that the first and second are ignored and a third machine is accepted.