### PR TITLE
LOGCXX-510: Additional errors @ TSCHOENING

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,11 @@
+cmake_policy(SET CMP0079 NEW)
+
 add_subdirectory(main)
 target_compile_definitions(log4cxx PRIVATE ${LOG4CXX_COMPILE_DEFINITIONS} ${APR_COMPILE_DEFINITIONS} ${APR_UTIL_COMPILE_DEFINITIONS} )
 target_include_directories(log4cxx INTERFACE $<INSTALL_INTERFACE:include> PRIVATE ${APR_INCLUDE_DIR} ${APR_UTIL_INCLUDE_DIR})
 target_link_libraries(log4cxx PRIVATE ${APR_UTIL_LIBRARIES} EXPAT::EXPAT ${APR_LIBRARIES} ${APR_SYSTEM_LIBS})
 if(WIN32)
 # The ODBC appender is always enabled in the Windows configuration
-cmake_policy(SET CMP0079 NEW)
 target_link_libraries(log4cxx PRIVATE odbc32.lib)
 option(LOG4CXX_INSTALL_PDB "Install .pdb files (if generated)"  ON)
 endif()

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@
 option(LOG4CXX_BLOCKING_ASYNC_APPENDER "Async appender behaviour" ON)
 
 # Build the log4cxx library
-add_library(log4cxx action.cpp)
+add_library(log4cxx)
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(log4cxx PRIVATE LOG4CXX)
 else()
@@ -12,6 +12,7 @@ endif()
 add_dependencies(log4cxx configure_log4cxx)
 target_sources(log4cxx
   PRIVATE
+  action.cpp
   andfilter.cpp
   appenderattachableimpl.cpp
   appenderskeleton.cpp

--- a/src/main/resources/CMakeLists.txt
+++ b/src/main/resources/CMakeLists.txt
@@ -2,6 +2,6 @@
 if(WIN32)
 target_sources(log4cxx
   PRIVATE
-  log4cxx.rc
+  ../resources/log4cxx.rc
 )
 endif()


### PR DESCRIPTION
Building the current MASTER, I came across additional errors for [LOGCXX-510](https://issues.apache.org/jira/browse/LOGCXX-510?filter=-2). Would be great if someone could have a look at and tell me if those changes make any sense, if they break something, if my setup is broken etc. The only thing I did compared to a few months ago I remember is updating VS 19 community regularly.