### PR TITLE
Log4cxx Qt support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,20 @@ if(UNIX)
 
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblog4cxx.pc" 
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+
+  if(LOG4CXX_QT_SUPPORT)
+      set(prefix "${CMAKE_INSTALL_PREFIX}")
+      set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
+      set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+      set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+      set(VERSION "${log4cxx_VERSION_MAJOR}.${log4cxx_VERSION_MINOR}.${log4cxx_VERSION_PATCH}")
+      configure_file("${CMAKE_CURRENT_SOURCE_DIR}/liblog4cxx-qt.pc.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/liblog4cxx-qt.pc"
+      )
+
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblog4cxx-qt.pc"
+	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+  endif(LOG4CXX_QT_SUPPORT)
 endif(UNIX)
 
 # Support for find_package(log4cxx) in consuming CMake projects using
@@ -148,6 +162,7 @@ message(STATUS "  logchar type .................... : ${LOG4CXX_CHAR}")
 message(STATUS "  Using libESMTP .................. : ${HAS_LIBESMTP}")
 message(STATUS "  ODBC library .................... : ${HAS_ODBC}")
 message(STATUS "  syslog .......................... : ${HAS_SYSLOG}")
+message(STATUS "  Qt support ...................... : ${LOG4CXX_QT_SUPPORT}")
 
 if(BUILD_TESTING)
 message(STATUS "Applications required for tests:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,19 @@ install(TARGETS log4cxx EXPORT log4cxxTargets
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+if(LOG4CXX_QT_SUPPORT)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/main/include/log4cxx-qt
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+      FILES_MATCHING PATTERN "*.h"
+    )
+    install(TARGETS log4cxx-qt EXPORT log4cxx-qtTargets
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+endif(LOG4CXX_QT_SUPPORT)
+
 IF(WIN32 AND BUILD_SHARED_LIBS AND LOG4CXX_INSTALL_PDB)
   INSTALL(FILES $<TARGET_PDB_FILE:log4cxx>
           DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -101,6 +114,22 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/log4cxxConfigVersi
 install(FILES   "${CMAKE_CURRENT_BINARY_DIR}/log4cxxConfigVersion.cmake"
   DESTINATION   share/cmake/log4cxx
 )
+
+if(LOG4CXX_QT_SUPPORT)
+    install(EXPORT log4cxx-qtTargets
+      FILE        log4cxx-qtConfig.cmake
+      DESTINATION share/cmake/log4cxx
+    )
+    # Support for find_package(log4cxx 0.11) in consuming CMake projects
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/log4cxx-qtConfigVersion.cmake"
+      VERSION       ${PROJECT_VERSION}
+      COMPATIBILITY SameMinorVersion
+    )
+    install(FILES   "${CMAKE_CURRENT_BINARY_DIR}/log4cxx-qtConfigVersion.cmake"
+      DESTINATION   share/cmake/log4cxx
+    )
+endif(LOG4CXX_QT_SUPPORT)
 
 #
 # Get the varaibles from the subdirectories

--- a/liblog4cxx-qt.pc.in
+++ b/liblog4cxx-qt.pc.in
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: log4cxx
+Description: log4cxx C++ logging framework(Qt support)
+Version: @VERSION@
+Libs: -L${libdir} -llog4cxx-qt
+Cflags: -I${includedir}
+Requires: liblog4cxx
+

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -9,6 +9,9 @@ target_include_directories(log4cxx PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_include_directories(log4cxx-qt PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-)
+
+if(LOG4CXX_QT_SUPPORT)
+    target_include_directories(log4cxx-qt PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    )
+endif(LOG4CXX_QT_SUPPORT)

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,10 +1,14 @@
 add_subdirectory(include)
 add_subdirectory(cpp)
+add_subdirectory(cpp-qt)
 add_subdirectory(resources)
 
 # setup include directories 
 include(GNUInstallDirs)
 target_include_directories(log4cxx PUBLIC 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+target_include_directories(log4cxx-qt PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )

--- a/src/main/cpp-qt/CMakeLists.txt
+++ b/src/main/cpp-qt/CMakeLists.txt
@@ -1,0 +1,24 @@
+option(LOG4CXX_QT_SUPPORT "Qt support/integration" OFF)
+
+# Log4cxx Qt support, if enabled
+if(LOG4CXX_QT_SUPPORT)
+    find_package(Qt5 COMPONENTS Core REQUIRED)
+
+    add_library(log4cxx-qt)
+    if(BUILD_SHARED_LIBS)
+	target_compile_definitions(log4cxx-qt PRIVATE LOG4CXX)
+    else()
+	target_compile_definitions(log4cxx-qt PUBLIC LOG4CXX_STATIC)
+    endif()
+    add_dependencies(log4cxx-qt configure_log4cxx)
+    target_compile_definitions(log4cxx-qt PRIVATE "QT_NO_KEYWORDS")
+    target_link_libraries(log4cxx-qt Qt5::Core)
+    target_sources(log4cxx-qt
+      PRIVATE
+      messagehandler.cpp
+    )
+    set_target_properties(log4cxx-qt PROPERTIES
+      VERSION ${LIBLOG4CXX_LIB_VERSION}
+      SOVERSION ${LIBLOG4CXX_LIB_SOVERSION}
+    )
+endif( LOG4CXX_QT_SUPPORT)

--- a/src/main/cpp-qt/messagehandler.cpp
+++ b/src/main/cpp-qt/messagehandler.cpp
@@ -18,7 +18,8 @@
 #include <log4cxx/logger.h>
 #include <log4cxx/spi/location/locationinfo.h>
 
-using namespace log4cxx::qt;
+namespace log4cxx {
+namespace qt {
 
 void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& message )
 {
@@ -50,3 +51,6 @@ void messageHandler(QtMsgType type, const QMessageLogContext& context, const QSt
 			std::abort();
 	}
 }
+
+} /* namespace qt */
+} /* namespace log4cxx */

--- a/src/main/cpp-qt/messagehandler.cpp
+++ b/src/main/cpp-qt/messagehandler.cpp
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <log4cxx-qt/messagehandler.h>
+#include <log4cxx/logger.h>
+#include <log4cxx/spi/location/locationinfo.h>
+
+using namespace log4cxx::qt;
+
+void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& message )
+{
+	log4cxx::LoggerPtr qtLogger = log4cxx::Logger::getLogger( context.category );
+	log4cxx::spi::LocationInfo location( context.file, context.function, context.line );
+
+	switch ( type )
+	{
+		case QtMsgType::QtDebugMsg:
+			qtLogger->debug( message.toStdString(), location );
+			break;
+
+		case QtMsgType::QtWarningMsg:
+			qtLogger->warn( message.toStdString(), location );
+			break;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
+
+		case QtMsgType::QtInfoMsg:
+			qtLogger->info( message.toStdString(), location );
+			break;
+#endif
+
+		case QtMsgType::QtCriticalMsg:
+			qtLogger->error( message.toStdString(), location );
+			break;
+
+		case QtMsgType::QtFatalMsg:
+			qtLogger->fatal( message.toStdString(), location );
+			std::abort();
+	}
+}

--- a/src/main/include/log4cxx-qt/messagehandler.h
+++ b/src/main/include/log4cxx-qt/messagehandler.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LOG4CXX_QT_MESSAGEHANDLER_H
+#define LOG4CXX_QT_MESSAGEHANDLER_H
+
+#include <QString>
+
+namespace log4cxx
+{
+namespace qt
+{
+
+/**
+ * The messageHandler function is a log4cxx replacement of the standard
+ * Qt message handler.
+ *
+ * Use this function as follows:
+ *   qInstallMessageHandler( log4cxx::qt::messageHandler );
+ *
+ * Note that similar to Qt, upon receipt of a fatal message this calls
+ * std::abort().
+ */
+void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& message);
+
+} /* namespace qt */
+} /* namespace log4cxx */
+
+#endif /* LOG4CXX_QT_MESSAGEHANDLER_H */

--- a/src/site/markdown/qt-support.md
+++ b/src/site/markdown/qt-support.md
@@ -1,4 +1,4 @@
-Usage {#usage-overview}
+Qt Support {#qt-support}
 ===
 <!--
  Note: License header cannot be first, as doxygen does not generate
@@ -21,10 +21,25 @@ Usage {#usage-overview}
  limitations under the License.
 -->
 
-See the following pages for usage information:
+When using Qt, messages from the Qt framework itself or other libraries
+may use the `QDebug` classes.  By default, this will print to stderr,
+thus bypassing the logger entirely.  In order to have these messages
+routed to log4cxx, a message handler for Qt must be installed.
 
-* @subpage usage
-* @subpage extending-log4cxx
-* @subpage faq
-* @subpage configuration-samples
-* @subpage qt-support
+Log4cxx provides a separate library, log4cxx-qt, which contains useful
+utilities for working with Qt.
+
+To install a message handler that will route the Qt logging messages
+through log4cxx, include the messagehandler.h and call
+`qInstallMessageHandler` as follows:
+
+```cpp
+#include <log4cxx-qt/messagehandler.h>
+
+...
+
+qInstallMessageHandler( log4cxx::qt::messageHandler );
+```
+
+Note that by default, this message handler also calls `abort` upon a
+fatal message.


### PR DESCRIPTION
Add a message handler function that is used for Qt so that log messages from Qt can be routed through log4cxx.

Note that this is built as a separate library - this is intentional, as many people may not be using Qt, so building it into the main log4cxx library doesn't make much sense.  This is so that (for example) Debian could build a separate package, log4cxx-qt, that is installed along with the main log4cxx .so files.