### PR TITLE
[LOGCXX-322] Fix crashing on exit from multithreaded application

### DIFF
--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -53,7 +53,7 @@ Hierarchy::Hierarchy() :
 {
 	std::unique_lock<std::mutex> lock(mutex);
 	root = LoggerPtr(new RootLogger(pool, Level::getDebug()));
-	root->setHierarchy(this);
+	root->setHierarchy(weak_from_this());
 	defaultFactory = LoggerFactoryPtr(new DefaultLoggerFactory());
 	emittedNoAppenderWarning = false;
 	configured = false;
@@ -223,7 +223,7 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 	else
 	{
 		LoggerPtr logger(factory->makeNewLoggerInstance(pool, name));
-		logger->setHierarchy(this);
+		logger->setHierarchy(weak_from_this());
 		loggers->insert(LoggerMap::value_type(name, logger));
 
 		ProvisionNodeMap::iterator it2 = provisionNodes->find(name);

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -213,13 +213,6 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 {
 	std::unique_lock<std::mutex> lock(mutex);
 
-	// This should really be done in the constructor, but in order to fix
-	// LOGCXX-322 we need to turn the repositroy into a weak_ptr, and we
-	// can't use weak_from_this() in the constructor.
-	if( !root->getLoggerRepository().lock() ){
-		root->setHierarchy(weak_from_this());
-	}
-
 	LoggerMap::iterator it = loggers->find(name);
 
 	if (it != loggers->end())
@@ -416,4 +409,19 @@ void Hierarchy::setConfigured(bool newValue)
 bool Hierarchy::isConfigured()
 {
 	return configured;
+}
+
+HierarchyPtr Hierarchy::create(){
+	HierarchyPtr ret( new Hierarchy() );
+	ret->configureRoot();
+	return ret;
+}
+
+void Hierarchy::configureRoot(){
+	// This should really be done in the constructor, but in order to fix
+	// LOGCXX-322 we need to turn the repositroy into a weak_ptr, and we
+	// can't use weak_from_this() in the constructor.
+	if( !root->getLoggerRepository().lock() ){
+		root->setHierarchy(weak_from_this());
+	}
 }

--- a/src/main/cpp/logmanager.cpp
+++ b/src/main/cpp/logmanager.cpp
@@ -59,7 +59,7 @@ RepositorySelectorPtr LogManager::getRepositorySelector()
 
 	if (!repositorySelector)
 	{
-		LoggerRepositoryPtr hierarchy(new Hierarchy());
+		LoggerRepositoryPtr hierarchy = Hierarchy::create();
 		RepositorySelectorPtr selector(new DefaultRepositorySelector(hierarchy));
 		repositorySelector = selector;
 	}

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -34,6 +34,10 @@
 
 namespace log4cxx
 {
+
+class Hierarchy;
+LOG4CXX_PTR_DEF(Hierarchy);
+
 /**
 This class is specialized in retrieving loggers by name and also
 maintaining the logger hierarchy.
@@ -85,10 +89,14 @@ class LOG4CXX_EXPORT Hierarchy :
 		LOG4CXX_CAST_ENTRY(spi::LoggerRepository)
 		END_LOG4CXX_CAST_MAP()
 
+	private:
 		/**
 		Create a new logger hierarchy.
 		*/
 		Hierarchy();
+
+	public:
+		static HierarchyPtr create();
 
 		~Hierarchy();
 
@@ -279,6 +287,8 @@ class LOG4CXX_EXPORT Hierarchy :
 		Hierarchy& operator=(const Hierarchy&);
 
 		void updateChildren(ProvisionNode& pn, LoggerPtr logger);
+
+		void configureRoot();
 };
 
 }  //namespace log4cxx

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -102,7 +102,7 @@ class LOG4CXX_EXPORT Logger :
 
 
 		// Loggers need to know what Hierarchy they are in
-		log4cxx::spi::LoggerRepository* repository;
+		log4cxx::spi::LoggerRepositoryWeakPtr repository;
 
 		helpers::AppenderAttachableImplPtr aai;
 
@@ -623,7 +623,7 @@ class LOG4CXX_EXPORT Logger :
 		Return the the LoggerRepository where this
 		<code>Logger</code> is attached.
 		*/
-		log4cxx::spi::LoggerRepository* getLoggerRepository() const;
+		log4cxx::spi::LoggerRepositoryWeakPtr getLoggerRepository() const;
 
 
 		/**
@@ -1464,7 +1464,7 @@ class LOG4CXX_EXPORT Logger :
 		friend class Hierarchy;
 		/**
 		Only the Hierarchy class can set the hierarchy of a logger.*/
-		void setHierarchy(spi::LoggerRepository* repository);
+		void setHierarchy(spi::LoggerRepositoryWeakPtr repository);
 
 	public:
 		/**

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ set(ALL_LOG4CXX_TESTS
     propertyconfiguratortest
     rollingfileappendertestcase
     streamtestcase
+    multithreadtest
 )
 foreach(fileName IN LISTS ALL_LOG4CXX_TESTS)
     add_executable(${fileName} "${fileName}.cpp")

--- a/src/test/cpp/customlogger/xlogger.cpp
+++ b/src/test/cpp/customlogger/xlogger.cpp
@@ -33,7 +33,6 @@ XFactoryPtr XLogger::factory = XFactoryPtr(new XFactory());
 void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 {
 	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep) return;
 	if (rep->isDisabled(XLevel::LETHAL_INT))
 	{
 		return;
@@ -48,7 +47,6 @@ void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 void XLogger::lethal(const LogString& message)
 {
 	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep) return;
 	if (rep->isDisabled(XLevel::LETHAL_INT))
 	{
 		return;
@@ -73,7 +71,6 @@ LoggerPtr XLogger::getLogger(const helpers::Class& clazz)
 void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 {
 	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep) return;
 	if (rep->isDisabled(XLevel::TRACE_INT))
 	{
 		return;
@@ -88,7 +85,6 @@ void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 void XLogger::trace(const LogString& message)
 {
 	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep) return;
 	if (rep->isDisabled(XLevel::TRACE_INT))
 	{
 		return;

--- a/src/test/cpp/customlogger/xlogger.cpp
+++ b/src/test/cpp/customlogger/xlogger.cpp
@@ -32,7 +32,9 @@ XFactoryPtr XLogger::factory = XFactoryPtr(new XFactory());
 
 void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 {
-	if (repository->isDisabled(XLevel::LETHAL_INT))
+	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
+	if (!rep) return;
+	if (rep->isDisabled(XLevel::LETHAL_INT))
 	{
 		return;
 	}
@@ -45,7 +47,9 @@ void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 
 void XLogger::lethal(const LogString& message)
 {
-	if (repository->isDisabled(XLevel::LETHAL_INT))
+	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
+	if (!rep) return;
+	if (rep->isDisabled(XLevel::LETHAL_INT))
 	{
 		return;
 	}
@@ -68,7 +72,9 @@ LoggerPtr XLogger::getLogger(const helpers::Class& clazz)
 
 void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 {
-	if (repository->isDisabled(XLevel::TRACE_INT))
+	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
+	if (!rep) return;
+	if (rep->isDisabled(XLevel::TRACE_INT))
 	{
 		return;
 	}
@@ -81,7 +87,9 @@ void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 
 void XLogger::trace(const LogString& message)
 {
-	if (repository->isDisabled(XLevel::TRACE_INT))
+	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
+	if (!rep) return;
+	if (rep->isDisabled(XLevel::TRACE_INT))
 	{
 		return;
 	}

--- a/src/test/cpp/customlogger/xloggertestcase.cpp
+++ b/src/test/cpp/customlogger/xloggertestcase.cpp
@@ -52,7 +52,10 @@ public:
 
 	void tearDown()
 	{
-		logger->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	void test1()

--- a/src/test/cpp/encodingtest.cpp
+++ b/src/test/cpp/encodingtest.cpp
@@ -58,7 +58,10 @@ public:
 	 */
 	void tearDown()
 	{
-		Logger::getRootLogger()->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = Logger::getRootLogger()->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 

--- a/src/test/cpp/hierarchythresholdtestcase.cpp
+++ b/src/test/cpp/hierarchythresholdtestcase.cpp
@@ -49,7 +49,10 @@ public:
 
 	void tearDown()
 	{
-		logger->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	void test1()

--- a/src/test/cpp/l7dtestcase.cpp
+++ b/src/test/cpp/l7dtestcase.cpp
@@ -67,7 +67,10 @@ public:
 
 	void tearDown()
 	{
-		root->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	void test1()

--- a/src/test/cpp/loggertestcase.cpp
+++ b/src/test/cpp/loggertestcase.cpp
@@ -391,7 +391,7 @@ public:
 
 	void testHierarchy1()
 	{
-		LoggerRepositoryPtr h = LoggerRepositoryPtr(new Hierarchy());
+		LoggerRepositoryPtr h = Hierarchy::create();
 		LoggerPtr root(h->getRootLogger());
 		root->setLevel(Level::getError());
 		LoggerPtr a0 = h->getLogger(LOG4CXX_STR("a"));

--- a/src/test/cpp/mdctestcase.cpp
+++ b/src/test/cpp/mdctestcase.cpp
@@ -42,7 +42,10 @@ public:
 
 	void tearDown()
 	{
-		Logger::getRootLogger()->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = Logger::getRootLogger()->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	/**

--- a/src/test/cpp/minimumtestcase.cpp
+++ b/src/test/cpp/minimumtestcase.cpp
@@ -66,7 +66,10 @@ public:
 
 	void tearDown()
 	{
-		root->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	void simple()

--- a/src/test/cpp/multithreadtest.cpp
+++ b/src/test/cpp/multithreadtest.cpp
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "logunit.h"
+
+#include <log4cxx/logger.h>
+#include <log4cxx/logmanager.h>
+#include <log4cxx/simplelayout.h>
+#include <log4cxx/appenderskeleton.h>
+#include <thread>
+#include <vector>
+#include <random>
+
+using log4cxx::Logger;
+using log4cxx::LoggerPtr;
+using log4cxx::LogManager;
+
+class NullWriterAppender : public log4cxx::AppenderSkeleton{
+public:
+	NullWriterAppender(){}
+
+	virtual void close(){}
+
+	virtual bool requiresLayout() const {
+		return false;
+	}
+
+	virtual void append(const log4cxx::spi::LoggingEventPtr& event, log4cxx::helpers::Pool& p){
+		// Do nothing but discard the data
+	}
+};
+
+static void multithread_logger( int times ){
+	/*
+	 * An explanation on this test: according to LOGCXX-322, calling
+	 * exit(0) (or equivalent) from a secondary thread causes a segfault.
+	 *
+	 * In order to do this somewhat reliably, we generate a pseudo-random
+	 * number in each thread that will call the exit() function from that thread.
+	 * Sadly this is not a 100% reliable way of generating a hit on std::exit,
+	 * but given enough iterations and enough threads it seems to be working just
+	 * fine.
+	 */
+
+	LoggerPtr logger = LogManager::getLogger( "test.multithreaded" );
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::uniform_int_distribution<> distribution( 100, times );
+
+	for( int x = 0; x < times; x++ ){
+		LOG4CXX_INFO( logger, "This is a test message that has some data" );
+		if( distribution(gen) == x ){
+			std::exit(0);
+		}
+	}
+}
+
+LOGUNIT_CLASS(MultithreadTest){
+	LOGUNIT_TEST_SUITE(MultithreadTest);
+	LOGUNIT_TEST(testMultithreadedLoggers);
+	LOGUNIT_TEST_SUITE_END();
+
+public:
+	void setUp()
+	{
+		Logger::getRootLogger()->removeAllAppenders();
+		std::shared_ptr<NullWriterAppender> nullWriter( new NullWriterAppender() );
+		Logger::getRootLogger()->addAppender( nullWriter );
+	}
+
+	void tearDown()
+	{
+//		root->getLoggerRepository()->resetConfiguration();
+	}
+
+	void testMultithreadedLoggers(){
+		std::vector<std::thread> threads;
+
+		for( int x = 0; x < 6; x++ ){
+			std::thread thr( multithread_logger, 20000 );
+			threads.push_back( std::move(thr) );
+		}
+
+		for( std::thread& thr : threads ){
+			if( thr.joinable() ){
+				thr.join();
+			}
+		}
+	}
+};
+
+LOGUNIT_TEST_SUITE_REGISTRATION(MultithreadTest);

--- a/src/test/cpp/ndctestcase.cpp
+++ b/src/test/cpp/ndctestcase.cpp
@@ -47,7 +47,10 @@ public:
 
 	void tearDown()
 	{
-		logger->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	/**

--- a/src/test/cpp/net/socketservertestcase.cpp
+++ b/src/test/cpp/net/socketservertestcase.cpp
@@ -131,7 +131,10 @@ public:
 	void tearDown()
 	{
 		socketAppender = 0;
-		root->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 		logger = 0;
 		root = 0;
 	}

--- a/src/test/cpp/patternlayouttest.cpp
+++ b/src/test/cpp/patternlayouttest.cpp
@@ -93,7 +93,8 @@ public:
 	void tearDown()
 	{
 		MDC::clear();
-		root->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		if (rep) rep->resetConfiguration();
 	}
 
 	void test1()

--- a/src/test/cpp/varia/errorhandlertestcase.cpp
+++ b/src/test/cpp/varia/errorhandlertestcase.cpp
@@ -50,7 +50,10 @@ public:
 
 	void tearDown()
 	{
-		logger->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 

--- a/src/test/cpp/varia/levelmatchfiltertestcase.cpp
+++ b/src/test/cpp/varia/levelmatchfiltertestcase.cpp
@@ -56,7 +56,10 @@ public:
 
 	void tearDown()
 	{
-		root->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	void accept()

--- a/src/test/cpp/varia/levelrangefiltertestcase.cpp
+++ b/src/test/cpp/varia/levelrangefiltertestcase.cpp
@@ -56,7 +56,10 @@ public:
 
 	void tearDown()
 	{
-		root->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	void accept()

--- a/src/test/cpp/xml/domtestcase.cpp
+++ b/src/test/cpp/xml/domtestcase.cpp
@@ -76,7 +76,10 @@ public:
 
 	void tearDown()
 	{
-		root->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	void test1()

--- a/src/test/cpp/xml/xmllayouttestcase.cpp
+++ b/src/test/cpp/xml/xmllayouttestcase.cpp
@@ -82,7 +82,10 @@ public:
 
 	void tearDown()
 	{
-		logger->getLoggerRepository()->resetConfiguration();
+		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		if (rep) {
+			rep->resetConfiguration();
+		}
 	}
 
 	void basic()


### PR DESCRIPTION
By turning the `LogManager::repositorySelector` into a std::shared_ptr as part of the smart pointer conversion, it is now possible to know when the `LogManager::repositorySelector` is valid or not by configuring the loggers to use a weak reference to the `RepositorySelector` instead of a raw pointer.

This also adds a test that runs multiple threads, and a random thread will then call `std::exit` to force a (semi-abnormal) shutdown.

It is possible that log messages are lost because of this, but fixing that probably requires some more invasive changes.