### PR TITLE
Check for ABI changes

### DIFF
--- a/.github/workflows/abi-compatibility.yml
+++ b/.github/workflows/abi-compatibility.yml
@@ -48,7 +48,7 @@ jobs:
         cd main
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DLOG4CXX_ABI_CHECK=ON ..
+        cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DLOG4CXX_ABI_CHECK=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Og" ..
         cmake --build .
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/abi-compatibility.yml
+++ b/.github/workflows/abi-compatibility.yml
@@ -39,7 +39,7 @@ jobs:
     - name: 'Configure Dependencies - Ubuntu'
       run: |
         sudo apt-get update
-        sudo apt-get install -y libapr1-dev libaprutil1-dev
+        sudo apt-get install -y libapr1-dev libaprutil1-dev elfutils
         # note: sqlext.h exists on github VM, purge for now as we don't link correctly...
         sudo apt-get purge unixodbc-dev
 

--- a/.github/workflows/abi-compatibility.yml
+++ b/.github/workflows/abi-compatibility.yml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: abi-compatibility
+
+on: [push, pull_request]
+#on:
+#  push:
+#    branches:
+#      - master
+#  pull_request:
+#    branches:
+#      - master
+
+jobs:
+  job:
+    name: abi-check
+    runs-on: ubuntu-20.04
+    timeout-minutes: 38
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: main
+
+    - name: 'Configure Dependencies - Ubuntu'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libapr1-dev libaprutil1-dev
+        # note: sqlext.h exists on github VM, purge for now as we don't link correctly...
+        sudo apt-get purge unixodbc-dev
+
+    - name: 'run CMake'
+      run: |
+        cd main
+        mkdir build
+        cd build
+        cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DLOG4CXX_ABI_CHECK=ON ..
+        cmake --build .
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: abi-compatibility-report
+        path: main/build/src/main/cpp/compat_reports/log4cxx/11_to_11/compat_report.html

--- a/.github/workflows/abi-compatibility.yml
+++ b/.github/workflows/abi-compatibility.yml
@@ -39,7 +39,7 @@ jobs:
     - name: 'Configure Dependencies - Ubuntu'
       run: |
         sudo apt-get update
-        sudo apt-get install -y libapr1-dev libaprutil1-dev elfutils
+        sudo apt-get install -y libapr1-dev libaprutil1-dev elfutils vtable-dumper universal-ctags
         # note: sqlext.h exists on github VM, purge for now as we don't link correctly...
         sudo apt-get purge unixodbc-dev
 

--- a/.github/workflows/abi-compatibility.yml
+++ b/.github/workflows/abi-compatibility.yml
@@ -48,7 +48,7 @@ jobs:
         cd main
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DLOG4CXX_ABI_CHECK=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Og" ..
+        cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DLOG4CXX_ABI_CHECK=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Og" -DBUILD_TESTING=off ..
         cmake --build .
 
     - uses: actions/upload-artifact@v2

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -197,7 +197,7 @@ if(LOG4CXX_ABI_CHECK)
 	COMMENT "Dumping ABI symbols")
 
     add_custom_target(compare-abi ALL
-	COMMAND perl ${abi-compliance-script} -l log4cxx -old ${CMAKE_SOURCE_DIR}/src/main/abi-symbols/abi.dump -new new-abi.dump || true
+	COMMAND perl ${abi-compliance-script} -l log4cxx -old ${CMAKE_SOURCE_DIR}/src/main/abi-symbols/abi.dump -new new-abi.dump
 	DEPENDS dump-abi
 	COMMENT "Comparing ABI symbols")
 endif(LOG4CXX_ABI_CHECK)

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 # Options
 option(LOG4CXX_BLOCKING_ASYNC_APPENDER "Async appender behaviour" ON)
+option(LOG4CXX_ABI_CHECK "Check for ABI changes" OFF)
 
 # Build the log4cxx library
 add_library(log4cxx)
@@ -164,3 +165,39 @@ set_target_properties(log4cxx PROPERTIES
   SOVERSION ${LIBLOG4CXX_LIB_SOVERSION}
 )
 boostfallback_link(log4cxx)
+
+if(LOG4CXX_ABI_CHECK)
+    message("Getting dependencies for ABI compatability check...")
+    # Get the latest version of abi-dumper and abi-compliance-checker
+    include(FetchContent)
+    FetchContent_Declare(abi-dumper
+      GIT_REPOSITORY https://github.com/lvc/abi-dumper.git
+      GIT_TAG 1.2
+    )
+    FetchContent_GetProperties(abi-dumper)
+    if(NOT abi-dumper_POPULATED)
+      FetchContent_Populate(abi-dumper)
+    endif()
+
+    FetchContent_Declare(abi-compliance-checker
+      GIT_REPOSITORY https://github.com/lvc/abi-compliance-checker.git
+      GIT_TAG f60ce442c33f1d5cda1cec7cfddee24af1777572
+    )
+    FetchContent_GetProperties(abi-compliance-checker)
+    if(NOT abi-compliance-checker_POPULATED)
+      FetchContent_Populate(abi-compliance-checker)
+    endif()
+
+    set(abi-dumper-script ${abi-dumper_SOURCE_DIR}/abi-dumper.pl)
+    set(abi-compliance-script ${abi-compliance-checker_SOURCE_DIR}/abi-compliance-checker.pl)
+
+    add_custom_target(dump-abi ALL
+	COMMAND perl ${abi-dumper-script} -o new-abi.dump -skip-cxx -vnum ${PROJECT_VERSION_MINOR} $<TARGET_FILE:log4cxx>
+	DEPENDS log4cxx
+	COMMENT "Dumping ABI symbols")
+
+    add_custom_target(compare-abi ALL
+	COMMAND perl ${abi-compliance-script} -l log4cxx -old ${CMAKE_SOURCE_DIR}/src/main/abi-symbols/abi.dump -new new-abi.dump || true
+	DEPENDS dump-abi
+	COMMENT "Comparing ABI symbols")
+endif(LOG4CXX_ABI_CHECK)


### PR DESCRIPTION
Add some new options to check for ABI changes between an old, known version of the ABI and the newest build version of the ABI.