### PR TITLE
Turn the threadname into a thread_local variable

### DIFF
--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -222,28 +222,35 @@ LoggingEvent::KeySet LoggingEvent::getPropertyKeySet() const
 const LogString LoggingEvent::getCurrentThreadName()
 {
 #if APR_HAS_THREADS
+#if LOG4CXX_THREAD_LOCAL
+	thread_local LogString thread_name;
+	if( thread_name.size() ){
+		return thread_name;
+	}
+#endif /* LOG4CXX_THREAD_LOCAL */
+
 #if defined(_WIN32)
 	char result[20];
 	DWORD threadId = GetCurrentThreadId();
 	apr_snprintf(result, sizeof(result), LOG4CXX_WIN32_THREAD_FMTSPEC, threadId);
 #else
-	thread_local LogString thread_name;
-	if( thread_name.size() ){
-		return thread_name;
-	}
-
 	// apr_os_thread_t encoded in HEX takes needs as many characters
 	// as two times the size of the type, plus an additional null byte.
 	char result[sizeof(apr_os_thread_t) * 3 + 10];
 	apr_os_thread_t threadId = apr_os_thread_current();
 	apr_snprintf(result, sizeof(result), LOG4CXX_APR_THREAD_FMTSPEC, (void*) &threadId);
-#endif
+#endif /* _WIN32 */
+
 	LOG4CXX_DECODE_CHAR(str, (const char*) result);
+
+#if LOG4CXX_THREAD_LOCAL
 	thread_name = str;
+#endif /* LOG4CXX_THREAD_LOCAL */
+
 	return str;
 #else
 	return LOG4CXX_STR("0x00000000");
-#endif
+#endif /* APR_HAS_THREADS */
 }
 
 

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -222,12 +222,10 @@ LoggingEvent::KeySet LoggingEvent::getPropertyKeySet() const
 const LogString LoggingEvent::getCurrentThreadName()
 {
 #if APR_HAS_THREADS
-#if LOG4CXX_THREAD_LOCAL
-	thread_local LogString thread_name;
+	LOG4CXX_THREAD_LOCAL LogString thread_name;
 	if( thread_name.size() ){
 		return thread_name;
 	}
-#endif /* LOG4CXX_THREAD_LOCAL */
 
 #if defined(_WIN32)
 	char result[20];
@@ -241,13 +239,9 @@ const LogString LoggingEvent::getCurrentThreadName()
 	apr_snprintf(result, sizeof(result), LOG4CXX_APR_THREAD_FMTSPEC, (void*) &threadId);
 #endif /* _WIN32 */
 
-	LOG4CXX_DECODE_CHAR(str, (const char*) result);
+	log4cxx::helpers::Transcoder::decode(reinterpret_cast<const char*>(result), thread_name);
 
-#if LOG4CXX_THREAD_LOCAL
-	thread_name = str;
-#endif /* LOG4CXX_THREAD_LOCAL */
-
-	return str;
+	return thread_name;
 #else
 	return LOG4CXX_STR("0x00000000");
 #endif /* APR_HAS_THREADS */

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -227,6 +227,11 @@ const LogString LoggingEvent::getCurrentThreadName()
 	DWORD threadId = GetCurrentThreadId();
 	apr_snprintf(result, sizeof(result), LOG4CXX_WIN32_THREAD_FMTSPEC, threadId);
 #else
+	thread_local LogString thread_name;
+	if( thread_name.size() ){
+		return thread_name;
+	}
+
 	// apr_os_thread_t encoded in HEX takes needs as many characters
 	// as two times the size of the type, plus an additional null byte.
 	char result[sizeof(apr_os_thread_t) * 3 + 10];
@@ -234,6 +239,7 @@ const LogString LoggingEvent::getCurrentThreadName()
 	apr_snprintf(result, sizeof(result), LOG4CXX_APR_THREAD_FMTSPEC, (void*) &threadId);
 #endif
 	LOG4CXX_DECODE_CHAR(str, (const char*) result);
+	thread_name = str;
 	return str;
 #else
 	return LOG4CXX_STR("0x00000000");

--- a/src/main/include/log4cxx/private/log4cxx_private.h.in
+++ b/src/main/include/log4cxx/private/log4cxx_private.h.in
@@ -53,6 +53,16 @@
 #define LOG4CXX_WIN32_THREAD_FMTSPEC "0x%.8x"
 #define LOG4CXX_APR_THREAD_FMTSPEC "0x%pt"
 
+#ifdef __BORLANDC__
+/*
+ * embarcadero/RAD Studio compilers don't support thread_local:
+ * http://docwiki.embarcadero.com/RADStudio/Sydney/en/Modern_C%2B%2B_Language_Features_Compliance_Status
+ */
+#define LOG4CXX_THREAD_LOCAL 0
+#else
+#define LOG4CXX_THREAD_LOCAL 1
+#endif
+
 #if defined(_MSC_VER)
 #define LOG4CXX_MEMSET_IOS_BASE 1
 #endif

--- a/src/main/include/log4cxx/private/log4cxx_private.h.in
+++ b/src/main/include/log4cxx/private/log4cxx_private.h.in
@@ -58,9 +58,9 @@
  * embarcadero/RAD Studio compilers don't support thread_local:
  * http://docwiki.embarcadero.com/RADStudio/Sydney/en/Modern_C%2B%2B_Language_Features_Compliance_Status
  */
-#define LOG4CXX_THREAD_LOCAL 0
+#define LOG4CXX_THREAD_LOCAL
 #else
-#define LOG4CXX_THREAD_LOCAL 1
+#define LOG4CXX_THREAD_LOCAL thread_local
 #endif
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
Every time a LoggingEvent is created, part of the information that is stored in the LoggingEvent is the name of the thread that the log is from.  By turning this into a `thread_local` variable and only setting it once, I was able to to get a speedup of 25-40% depending on the configuration that I'm using.

Note that since thread_local is C++11, the only check we do to see if it's supported or not is to determine if the compiler is Borland or not - everybody else seems to be just fine with it(https://en.cppreference.com/w/cpp/compiler_support).  We could add a more thorough check if needed. 