### PR TITLE
LOGCXX-523 Call error handler if rollover fails

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -61,7 +61,6 @@ AsyncAppender::~AsyncAppender()
 
 void AsyncAppender::addAppender(const AppenderPtr newAppender)
 {
-	std::unique_lock<std::mutex> lock(appenders->getMutex());
 	appenders->addAppender(newAppender);
 }
 
@@ -221,19 +220,16 @@ void AsyncAppender::close()
 
 AppenderList AsyncAppender::getAllAppenders() const
 {
-	std::unique_lock<std::mutex> lock(appenders->getMutex());
 	return appenders->getAllAppenders();
 }
 
 AppenderPtr AsyncAppender::getAppender(const LogString& n) const
 {
-	std::unique_lock<std::mutex> lock(appenders->getMutex());
 	return appenders->getAppender(n);
 }
 
 bool AsyncAppender::isAttached(const AppenderPtr appender) const
 {
-	std::unique_lock<std::mutex> lock(appenders->getMutex());
 	return appenders->isAttached(appender);
 }
 
@@ -244,19 +240,16 @@ bool AsyncAppender::requiresLayout() const
 
 void AsyncAppender::removeAllAppenders()
 {
-	std::unique_lock<std::mutex> lock(appenders->getMutex());
 	appenders->removeAllAppenders();
 }
 
 void AsyncAppender::removeAppender(const AppenderPtr appender)
 {
-	std::unique_lock<std::mutex> lock(appenders->getMutex());
 	appenders->removeAppender(appender);
 }
 
 void AsyncAppender::removeAppender(const LogString& n)
 {
-	std::unique_lock<std::mutex> lock(appenders->getMutex());
 	appenders->removeAppender(n);
 }
 
@@ -403,7 +396,6 @@ void AsyncAppender::dispatch()
 				iter != events.end();
 				iter++)
 			{
-				std::unique_lock<std::mutex> lock(appenders->getMutex());
 				appenders->appendLoopOnAppenders(*iter, p);
 			}
 		}

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -308,7 +308,9 @@ bool RollingFileAppenderSkeleton::rolloverInternal(Pool& p)
 								catch (std::exception& ex)
 								{
 									LogLog::warn(LOG4CXX_STR("Exception on rollover"));
-									errorHandler->error(ex.what(), ex, 0);
+									LogString exmsg;
+									log4cxx::helpers::Transcoder::decode(ex.what(), exmsg);
+									errorHandler->error(exmsg, ex, 0);
 								}
 							}
 
@@ -367,7 +369,9 @@ bool RollingFileAppenderSkeleton::rolloverInternal(Pool& p)
 								catch (std::exception& ex)
 								{
 									LogLog::warn(LOG4CXX_STR("Exception during rollover"));
-									errorHandler->error(ex.what(), ex, 0);
+									LogString exmsg;
+									log4cxx::helpers::Transcoder::decode(ex.what(), exmsg);
+									errorHandler->error(exmsg, ex, 0);
 								}
 							}
 
@@ -405,7 +409,9 @@ bool RollingFileAppenderSkeleton::rolloverInternal(Pool& p)
 				catch (std::exception& ex)
 				{
 					LogLog::warn(LOG4CXX_STR("Exception during rollover"));
-					errorHandler->error(ex.what(), ex, 0);
+					LogString exmsg;
+					log4cxx::helpers::Transcoder::decode(ex.what(), exmsg);
+					errorHandler->error(exmsg, ex, 0);
 				}
 
 #ifdef LOG4CXX_MULTI_PROCESS
@@ -464,7 +470,9 @@ void RollingFileAppenderSkeleton::subAppend(const LoggingEventPtr& event, Pool& 
 		catch (std::exception& ex)
 		{
 			LogLog::warn(LOG4CXX_STR("Exception during rollover attempt."));
-			errorHandler->error(ex.what());
+			LogString exmsg;
+			log4cxx::helpers::Transcoder::decode(ex.what(), exmsg);
+			errorHandler->error(exmsg);
 		}
 	}
 

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -39,6 +39,7 @@
 #include <log4cxx/helpers/bytebuffer.h>
 #include <log4cxx/rolling/fixedwindowrollingpolicy.h>
 #include <log4cxx/rolling/manualtriggeringpolicy.h>
+#include <log4cxx/helpers/transcoder.h>
 
 using namespace log4cxx;
 using namespace log4cxx::rolling;

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -305,9 +305,10 @@ bool RollingFileAppenderSkeleton::rolloverInternal(Pool& p)
 								{
 									success = rollover1->getSynchronous()->execute(p);
 								}
-								catch (std::exception&)
+								catch (std::exception& ex)
 								{
 									LogLog::warn(LOG4CXX_STR("Exception on rollover"));
+									errorHandler->error(ex.what(), ex, 0);
 								}
 							}
 
@@ -363,9 +364,10 @@ bool RollingFileAppenderSkeleton::rolloverInternal(Pool& p)
 								{
 									success = rollover1->getSynchronous()->execute(p);
 								}
-								catch (std::exception&)
+								catch (std::exception& ex)
 								{
 									LogLog::warn(LOG4CXX_STR("Exception during rollover"));
+									errorHandler->error(ex.what(), ex, 0);
 								}
 							}
 
@@ -400,9 +402,10 @@ bool RollingFileAppenderSkeleton::rolloverInternal(Pool& p)
 						return true;
 					}
 				}
-				catch (std::exception&)
+				catch (std::exception& ex)
 				{
 					LogLog::warn(LOG4CXX_STR("Exception during rollover"));
+					errorHandler->error(ex.what(), ex, 0);
 				}
 
 #ifdef LOG4CXX_MULTI_PROCESS
@@ -458,9 +461,10 @@ void RollingFileAppenderSkeleton::subAppend(const LoggingEventPtr& event, Pool& 
 			_event = &(const_cast<LoggingEventPtr&>(event));
 			rolloverInternal(p);
 		}
-		catch (std::exception&)
+		catch (std::exception& ex)
 		{
 			LogLog::warn(LOG4CXX_STR("Exception during rollover attempt."));
+			errorHandler->error(ex.what());
 		}
 	}
 


### PR DESCRIPTION
If the rollover fails, call the specified error handler for
the given appender.  This means that you can now replace appenders
with a new appender.

The entire API at this point is not very robust at the moment.  A
better error handling mechanism needs to be made to properly
handle the errors so that the error handler can have enough
data to do its job.
