### PR TITLE
CMAKE in VS 2019 16.11.1 warns about missing file extensions…

### DIFF
--- a/src/test/cpp/xml/CMakeLists.txt
+++ b/src/test/cpp/xml/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(xmltests
-    domtestcase
-    xmllayouttest
-    xmllayouttestcase
+    domtestcase.cpp
+    xmllayouttest.cpp
+    xmllayouttestcase.cpp
 )
 
 target_link_libraries(xmltests PRIVATE ${APR_UTIL_LIBRARIES} EXPAT::EXPAT)


### PR DESCRIPTION
for XML-related tests:

> CMake Warning (dev) at src/test/cpp/xml/CMakeLists.txt:1 (add_executable):
>   Policy CMP0115 is not set: Source file extensions must be explicit.  Run
>   "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
>   command to set the policy and suppress this warning.

![Bild_2021-08-24_111156](https://user-images.githubusercontent.com/6223655/130590327-8c2ed88e-792b-438f-9a7c-4a9db9895d20.png)

Does the change make sense? It at least removes the warning, [can't test it currently](https://developercommunity.visualstudio.com/t/CMake-cache-generation-hangs-after-upg/1505033), though.