### PR TITLE
Register FallbackErrorHandler class

### DIFF
--- a/src/main/cpp/class.cpp
+++ b/src/main/cpp/class.cpp
@@ -71,6 +71,7 @@
 
 #include <log4cxx/xml/domconfigurator.h>
 #include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/varia/fallbackerrorhandler.h>
 #include <apr.h>
 
 
@@ -203,5 +204,6 @@ void Class::registerClasses()
 	log4cxx::rolling::FilterBasedTriggeringPolicy::registerClass();
 	log4cxx::xml::DOMConfigurator::registerClass();
 	log4cxx::PropertyConfigurator::registerClass();
+	log4cxx::varia::FallbackErrorHandler::registerClass();
 }
 


### PR DESCRIPTION
There are two error handlers in log4cxx(OnlyOnceErrorHandler and FallbackErrorHandler) but only ‘OnlyOnceErrorHandler’ gets registered.
The reason is that ‘FallbackErrorHandler’ is not referenced anywhere, so IMPLEMENT_LOG4CXX_OBJECT() for ‘FallbackErrorHandler’ won’t get called.
On the other hand, ‘OnlyOnceErrorHandler’ is referenced from appenderskeleton.cpp so class registration for that class will be done without any problem.
For the classes that are not internally referenced, Log4cxx is designed to register the classes in ‘Class::registerClasses()’, but ‘FallbackErrorHandler’ seems to be missing.

Since 'FallbackErrorHandler' is a built-in handler, I think the library should register that class by default.