### PR TITLE
Fix constructions of sed filter in corner cases

### DIFF
--- a/src/test/cpp/util/transformer.cpp
+++ b/src/test/cpp/util/transformer.cpp
@@ -116,7 +116,7 @@ void Transformer::createSedCommandFile(const std::string& regexName,
 
 	std::string tmp;
 
-	auto sedsaniziter = [] (const std::string in, const std::string sedseperator = "Q") {
+	auto sedsaniziter = [] (const std::string &in, const std::string &sedseperator = "Q") {
 		std::string ret = in;
 		std::string replace_to = "\\" + sedseperator;
 		size_t pos = 0;

--- a/src/test/cpp/util/transformer.cpp
+++ b/src/test/cpp/util/transformer.cpp
@@ -116,14 +116,25 @@ void Transformer::createSedCommandFile(const std::string& regexName,
 
 	std::string tmp;
 
+	auto sedsaniziter = [] (const std::string in, const std::string sedseperator = "Q") {
+		std::string ret = in;
+		std::string replace_to = "\\" + sedseperator;
+		size_t pos = 0;
+		while((pos = ret.find(sedseperator, pos)) != std::string::npos) {
+			ret.replace(pos, sedseperator.length(), replace_to);
+			pos += replace_to.length();
+		}
+		return ret;
+	};
+
 	for (log4cxx::Filter::PatternList::const_iterator iter = patterns.begin();
 		iter != patterns.end();
 		iter++)
 	{
 		tmp = "sQ";
-		tmp.append(iter->first);
+		tmp.append(sedsaniziter(iter->first));
 		tmp.append(1, 'Q');
-		tmp.append(iter->second);
+		tmp.append(sedsaniziter(iter->second));
 		tmp.append("Qg\n");
 		apr_file_puts(tmp.c_str(), regexFile);
 	}

--- a/src/test/cpp/util/transformer.cpp
+++ b/src/test/cpp/util/transformer.cpp
@@ -116,15 +116,15 @@ void Transformer::createSedCommandFile(const std::string& regexName,
 
 	std::string tmp;
 
-	auto sedSanitizer = [] (const std::string& in, const std::string& sedSeperator = "Q")
+	auto sedSanitizer = [] (const std::string& in, const std::string& sedSeparator = "Q")
 	{
 		std::string ret = in;
-		std::string replaceTo = "\\" + sedSeperator;
+		std::string replaceTo = "\\" + sedSeparator;
 		size_t pos = 0;
 
-		while((pos = ret.find(sedSeperator, pos)) != std::string::npos)
+		while((pos = ret.find(sedSeparator, pos)) != std::string::npos)
 		{
-			ret.replace(pos, sedSeperator.length(), replaceTo);
+			ret.replace(pos, sedSeparator.length(), replaceTo);
 			pos += replaceTo.length();
 		}
 

--- a/src/test/cpp/util/transformer.cpp
+++ b/src/test/cpp/util/transformer.cpp
@@ -116,14 +116,18 @@ void Transformer::createSedCommandFile(const std::string& regexName,
 
 	std::string tmp;
 
-	auto sedsaniziter = [] (const std::string &in, const std::string &sedseperator = "Q") {
+	auto sedSanitizer = [] (const std::string& in, const std::string& sedSeperator = "Q")
+	{
 		std::string ret = in;
-		std::string replace_to = "\\" + sedseperator;
+		std::string replaceTo = "\\" + sedSeperator;
 		size_t pos = 0;
-		while((pos = ret.find(sedseperator, pos)) != std::string::npos) {
-			ret.replace(pos, sedseperator.length(), replace_to);
-			pos += replace_to.length();
+
+		while((pos = ret.find(sedSeperator, pos)) != std::string::npos)
+		{
+			ret.replace(pos, sedSeperator.length(), replaceTo);
+			pos += replaceTo.length();
 		}
+
 		return ret;
 	};
 
@@ -132,9 +136,9 @@ void Transformer::createSedCommandFile(const std::string& regexName,
 		iter++)
 	{
 		tmp = "sQ";
-		tmp.append(sedsaniziter(iter->first));
+		tmp.append(sedSanitizer(iter->first));
 		tmp.append(1, 'Q');
-		tmp.append(sedsaniziter(iter->second));
+		tmp.append(sedSanitizer(iter->second));
 		tmp.append("Qg\n");
 		apr_file_puts(tmp.c_str(), regexFile);
 	}


### PR DESCRIPTION
Some tests use sed to generate predictable outputs and employ sed files for
that.  In some circumstances, the generated sed file syntax is incorrect, if
the subsitions data contains the sed expresssion seperator. The patch escapes
the data if needed.  The bug manifested in (local) autopkgtest runs, when the
temporary directory contained the separator ("Q").

https://issues.apache.org/jira/browse/LOGCXX-543