### PR TITLE
Fix underspecification for logger

### DIFF
--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -174,7 +174,7 @@ class LOG4CXX_EXPORT Logger :
 		registered appenders in this logger and also higher in the
 		hierarchy depending on the value of the additivity flag.
 
-		@param msg the message string to log.
+		@param msg the message string to log (WARNING, THIS STRING MAY RESULT IN CODE BEING EXECUTED AS SHELL).
 		@param location location of source of logging request.
 		*/
 		void debug(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;


### PR DESCRIPTION
(Please update this PR to fix all affected functions in all files. This is zero-day live Twitch stream, can't type more here.)

---

This function is specified as logging a string.

In light of recent disclosures, actually much more is happening here than interpreting only as "message the message string to log."