### PR TITLE
Update log4cxx.h.in

### DIFF
--- a/src/main/cpp/class.cpp
+++ b/src/main/cpp/class.cpp
@@ -82,6 +82,11 @@ using namespace log4cxx::filter;
 using namespace log4cxx::xml;
 using namespace log4cxx::rolling;
 
+log4cxx_uint32_t libraryVersion(){
+	// This function defined in log4cxx.h
+	return LOG4CXX_VERSION;
+}
+
 Class::Class()
 {
 }

--- a/src/main/include/log4cxx/log4cxx.h.in
+++ b/src/main/include/log4cxx/log4cxx.h.in
@@ -79,4 +79,17 @@ typedef unsigned int log4cxx_uint32_t;
 #define LOG4CXX_EXPORT
 #endif /* WIN32 */
 
+namespace log4cxx {
+
+/**
+ * Query the compiled version of the library.  Ideally, this should
+ * be the same as the LOG4CXX_VERSION macro defined above.
+ *
+ * The LOG4CXX_VERSION_GET_ series of macros let you extract the
+ * specific bytes of the version if required.
+ */
+LOG4CXX_EXPORT log4cxx_uint32_t libraryVersion();
+
+}
+
 #endif

--- a/src/main/include/log4cxx/log4cxx.h.in
+++ b/src/main/include/log4cxx/log4cxx.h.in
@@ -29,10 +29,14 @@
 #define LOG4CXX_VERSION_MINOR @log4cxx_VERSION_MINOR@
 #define LOG4CXX_VERSION_PATCH @log4cxx_VERSION_PATCH@
 #define LOG4CXX_VERSION_TWEAK @log4cxx_VERSION_TWEAK@
-#define LOG4CXX_MAKE_VERSION(major, minor, patch, tweak) ((major << 24) |\
-	(minor << 16) |\
-	(patch << 8) |\
+#define LOG4CXX_MAKE_VERSION(major, minor, patch, tweak) (((major) << 24) |\
+	((minor) << 16) |\
+	((patch) << 8) |\
 	(tweak) )
+#define LOG4CXX_VERSION_GET_MAJOR(version) (((version) >> 24) & 0xFF)
+#define LOG4CXX_VERSION_GET_MINOR(version) (((version) >> 16) & 0xFF)
+#define LOG4CXX_VERSION_GET_PATCH(version) (((version) >> 8) & 0xFF)
+#define LOG4CXX_VERSION_GET_TWEAK(version) ((version) & 0xFF)
 #define LOG4CXX_VERSION \
   LOG4CXX_MAKE_VERSION(LOG4CXX_VERSION_MAJOR, LOG4CXX_VERSION_MINOR, LOG4CXX_VERSION_PATCH, LOG4CXX_VERSION_TWEAK)
 


### PR DESCRIPTION
Parenthesize arguments to LOG4CXX_MAKE_VERSION.  Provide companion LOG4CXX_VERSION_GET_{MAJOR, MINOR, PATCH, TWEAK} macros to facilitate reporting, and other usage, of LOG4CXX_VERSION at compile time and run time.  This is modeled, roughly, on the _IOC_* macros that one finds in the "/usr/src/kernels/*/includeuapi/asm-generic/ioctl.h" header file.  ("ioctl.h" takes it a step further and defines a mask and shift value for each field.  I wouldn't object to those being defined here as well, but I don't feel strongly about the need for their inclusion.)