### PR TITLE
Imported and slightly cleaned up throughput tests

### DIFF
--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -60,6 +60,7 @@ add_subdirectory(rolling)
 add_subdirectory(spi)
 add_subdirectory(varia)
 add_subdirectory(xml)
+add_subdirectory(throughput)
 
 # Note: we need to include the APR DLLs on our path so that the tests will run.
 # The way that CMake sets the environment is that it actually generates a secondary file,

--- a/src/test/cpp/throughput/CMakeLists.txt
+++ b/src/test/cpp/throughput/CMakeLists.txt
@@ -1,0 +1,40 @@
+option(BUILD_THROUGHPUT_TESTS "Build throughput tests"  OFF)
+
+if( NOT BUILD_THROUGHPUT_TESTS )
+	return()
+endif()
+
+find_package(fmt REQUIRED)
+
+add_executable(throughputtests
+	throughput-main.cpp
+	log4cxxbenchmarker.cpp)
+
+# Note: we need to include the APR DLLs on our path so that the tests will run.
+# The way that CMake sets the environment is that it actually generates a secondary file,
+# CTestTestfile.cmake, which sets the final properties of the test.
+# However, this results in a secondary quirk to the running of the tests: CMake uses
+# a semicolon to deliminate entries in a list!  Since the Windows PATH is semicolon-delimited
+# as well, CMake uses only the first entry in the list when setting the path.
+# So, we need to do a triple escape on the PATH that we want to set in order for CMake to
+# properly interpret the PATH
+if( WIN32 )
+  get_filename_component(APR_DLL_DIR "${APR_DLL}" DIRECTORY)
+  get_filename_component(APR_UTIL_DLL_DIR "${APR_UTIL_DLL}" DIRECTORY)
+  get_filename_component(EXPAT_LIB_DIR "${EXPAT_LIBRARY}" DIRECTORY)
+
+
+  set(EXPAT_DLL_DIR "${EXPAT_LIB_DIR}/../bin")
+  set(LOG4CXX_DLL_DIR "$<SHELL_PATH:$<TARGET_FILE_DIR:log4cxx>>;")
+  set(PATH_FOR_TESTS ${CMAKE_PROGRAM_PATH};${APR_DLL_DIR};${APR_UTIL_DLL_DIR};${LOG4CXX_DLL_DIR};${EXPAT_DLL_DIR}\;)
+  list(REMOVE_DUPLICATES PATH_FOR_TESTS)
+  set(NORMAL_PATH $ENV{PATH})
+  set(ESCAPED_PATH "")
+  foreach( ENTRY ${PATH_FOR_TESTS}${NORMAL_PATH} )
+	  set(ESCAPED_PATH "${ESCAPED_PATH}${ENTRY}\\\;")
+  endforeach()
+endif( WIN32 )
+
+target_compile_definitions(throughputtests PRIVATE ${LOG4CXX_COMPILE_DEFINITIONS} ${APR_COMPILE_DEFINITIONS} ${APR_UTIL_COMPILE_DEFINITIONS} )
+target_include_directories(throughputtests PRIVATE ${CMAKE_CURRENT_LIST_DIR} $<TARGET_PROPERTY:log4cxx,INCLUDE_DIRECTORIES>)
+target_link_libraries(throughputtests PRIVATE log4cxx ${APR_LIBRARIES} ${APR_SYSTEM_LIBS} Threads::Threads fmt::fmt)

--- a/src/test/cpp/throughput/log4cxxbenchmarker.cpp
+++ b/src/test/cpp/throughput/log4cxxbenchmarker.cpp
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "log4cxxbenchmarker.h"
+
+#include <log4cxx/logger.h>
+#include <log4cxx/patternlayout.h>
+#include <log4cxx/appenderskeleton.h>
+
+#include <fmt/format.h>
+
+namespace log4cxx
+{
+
+class NullWriterAppender : public log4cxx::AppenderSkeleton
+{
+	public:
+		DECLARE_LOG4CXX_OBJECT(NullWriterAppender)
+		BEGIN_LOG4CXX_CAST_MAP()
+		LOG4CXX_CAST_ENTRY(NullWriterAppender)
+		LOG4CXX_CAST_ENTRY_CHAIN(AppenderSkeleton)
+		END_LOG4CXX_CAST_MAP()
+
+		NullWriterAppender() {}
+
+		virtual void close() {}
+
+		virtual bool requiresLayout() const
+		{
+			return true;
+		}
+
+		virtual void append(const spi::LoggingEventPtr& event, log4cxx::helpers::Pool& p)
+		{
+			// This gets called whenever there is a valid event for our appender.
+		}
+
+		virtual void activateOptions(log4cxx::helpers::Pool& /* pool */)
+		{
+			// Given all of our options, do something useful(e.g. open a file)
+		}
+
+		virtual void setOption(const LogString& option, const LogString& value)
+		{
+		}
+};
+
+IMPLEMENT_LOG4CXX_OBJECT(NullWriterAppender)
+
+LOG4CXX_PTR_DEF(NullWriterAppender);
+
+}
+
+log4cxxbenchmarker::log4cxxbenchmarker()
+{
+
+}
+
+log4cxx::LoggerPtr log4cxxbenchmarker::resetLogger()
+{
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+
+	logger->removeAllAppenders();
+	logger->setAdditivity( false );
+	logger->setLevel( log4cxx::Level::getInfo() );
+
+	log4cxx::PatternLayoutPtr pattern = std::make_shared<log4cxx::PatternLayout>();
+	pattern->setConversionPattern( "%m%n" );
+
+	log4cxx::NullWriterAppenderPtr nullWriter = std::make_shared<log4cxx::NullWriterAppender>();
+	nullWriter->setLayout( pattern );
+
+	logger->addAppender( nullWriter );
+
+	return logger;
+}
+
+void log4cxxbenchmarker::logWithConversionPattern( std::string conversionPattern, int howmany )
+{
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+
+	logger->removeAllAppenders();
+	logger->setAdditivity( false );
+	logger->setLevel( log4cxx::Level::getInfo() );
+
+	log4cxx::PatternLayoutPtr pattern = std::make_shared<log4cxx::PatternLayout>();
+	pattern->setConversionPattern( conversionPattern );
+
+	log4cxx::NullWriterAppenderPtr nullWriter = std::make_shared<log4cxx::NullWriterAppender>();
+	nullWriter->setLayout( pattern );
+
+	logger->addAppender( nullWriter );
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_INFO( logger, "Hello logger: msg number " << x);
+	}
+}
+
+void log4cxxbenchmarker::logWithFMT(int howmany)
+{
+	log4cxx::LoggerPtr logger = resetLogger();
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_INFO_FMT( logger, "Hello logger: msg number {}", x);
+	}
+}
+
+void log4cxxbenchmarker::logSetupMultithreaded()
+{
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+
+	logger->removeAllAppenders();
+	logger->setAdditivity( false );
+	logger->setLevel( log4cxx::Level::getInfo() );
+
+	log4cxx::PatternLayoutPtr pattern = std::make_shared<log4cxx::PatternLayout>();
+	pattern->setConversionPattern( "%m%n" );
+
+	log4cxx::NullWriterAppenderPtr nullWriter = std::make_shared<log4cxx::NullWriterAppender>();
+	nullWriter->setLayout( pattern );
+
+	logger->addAppender( nullWriter );
+}
+
+void log4cxxbenchmarker::logWithFMTMultithreaded(int howmany)
+{
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_INFO_FMT( logger, "Hello logger: msg number {}", x);
+	}
+}
+
+void log4cxxbenchmarker::logDisabledMultithreaded( int howmany )
+{
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_TRACE( logger, "Hello logger!  What is happening");
+	}
+}
+
+void log4cxxbenchmarker::logStaticString( int howmany )
+{
+	log4cxx::LoggerPtr logger = resetLogger();
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_INFO( logger, "This is a static string to see what happens");
+	}
+}
+
+void log4cxxbenchmarker::logStaticStringFMT( int howmany )
+{
+	log4cxx::LoggerPtr logger = resetLogger();
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_INFO_FMT( logger, "This is a static string to see what happens");
+	}
+}
+
+void log4cxxbenchmarker::logDisabledDebug( int howmany )
+{
+	log4cxx::LoggerPtr logger = resetLogger();
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_DEBUG( logger, "This is a static string to see what happens");
+	}
+}
+
+void log4cxxbenchmarker::logDisabledTrace( int howmany )
+{
+	log4cxx::LoggerPtr logger = resetLogger();
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_TRACE( logger, "This is a static string to see what happens");
+	}
+}
+
+void log4cxxbenchmarker::logEnabledDebug( int howmany )
+{
+	log4cxx::LoggerPtr logger = resetLogger();
+	logger->setLevel( log4cxx::Level::getDebug() );
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_DEBUG( logger, "This is a static string to see what happens");
+	}
+}
+
+void log4cxxbenchmarker::logEnabledTrace( int howmany )
+{
+	log4cxx::LoggerPtr logger = resetLogger();
+	logger->setLevel( log4cxx::Level::getTrace() );
+
+	for ( int x = 0; x < howmany; x++ )
+	{
+		LOG4CXX_DEBUG( logger, "This is a static string to see what happens");
+	}
+}

--- a/src/test/cpp/throughput/log4cxxbenchmarker.h
+++ b/src/test/cpp/throughput/log4cxxbenchmarker.h
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LOG4CXXBENCHMARKER_H
+#define LOG4CXXBENCHMARKER_H
+
+#include <string>
+
+#include <log4cxx/logger.h>
+
+class log4cxxbenchmarker
+{
+	private:
+		log4cxxbenchmarker();
+
+		static log4cxx::LoggerPtr resetLogger();
+
+	public:
+		/**
+		 * Given a conversion pattern, send a number of log messages to the logger.  INFO level.
+		 *
+		 * Log message format: "Hello logger: msg number " << x
+		 *
+		 * @param conversionPattern The conversion pattern used, as passed to the PatternLayout
+		 */
+		static void logWithConversionPattern( std::string conversionPattern, int howmany );
+
+		/**
+		 * Log with the LOG4CXX_INFO_FMT macro to see how long it takes.
+		 * This does a single parameter replacement with libfmt(the same message as logWithConversionPattern)
+		 *
+		 * @param howmany
+		 */
+		static void logWithFMT( int howmany );
+
+		/**
+		 * Reset logger for multithreaded setup.
+		 */
+		static void logSetupMultithreaded();
+
+		/**
+		 * Log with the LOG4CXX_INFO_FMT macro to see how long it takes(multithreaded).
+		 * @param howmany
+		 */
+		static void logWithFMTMultithreaded( int howmany );
+
+		/**
+		 * Log messages in a multithreaded manner, but at a TRACE level
+		 * so they will be disabled.
+		 *
+		 * @param howmany
+		 */
+		static void logDisabledMultithreaded( int howmany );
+
+		/**
+		 * Log a string that doesn't use operator<< any place.
+		 * Logs at INFO level
+		 *
+		 * String to log: "This is a static string to see what happens"
+		 * @param howmany
+		 */
+		static void logStaticString( int howmany );
+
+		/**
+		* Log a string that doesn't use operator<< any place, but uses libfmt.
+		* Logs at INFO level
+		*
+		* String to log: "This is a static string to see what happens"
+		* @param howmany
+		*/
+		static void logStaticStringFMT( int howmany );
+
+		/**
+		 * Log a message at the DEBUG level, with debug disabled.
+		 */
+		static void logDisabledDebug( int howmany );
+
+		/**
+		 * Log a message at the TRACE level, with trace disabled.
+		 */
+		static void logDisabledTrace( int howmany );
+
+		/**
+		 * Log a message at the DEBUG level, with debug enabled.
+		 */
+		static void logEnabledDebug( int howmany );
+
+		/**
+		 * Log a message at the TRACE level, with trace enabled.
+		 */
+		static void logEnabledTrace( int howmany );
+};
+
+#endif // LOG4CXXBENCHMARKER_H

--- a/src/test/cpp/throughput/throughput-main.cpp
+++ b/src/test/cpp/throughput/throughput-main.cpp
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <log4cxx/logger.h>
+#include <log4cxx/xml/domconfigurator.h>
+#include <log4cxx/patternlayout.h>
+#include <log4cxx/consoleappender.h>
+
+#include <string>
+#include <thread>
+
+#include <fmt/core.h>
+#include <fmt/chrono.h>
+#include <fmt/ostream.h>
+
+#include "log4cxxbenchmarker.h"
+
+static log4cxx::LoggerPtr console = log4cxx::Logger::getLogger( "console" );
+static std::vector<uint64_t> results;
+
+static void benchmark_function( std::string name, void (*fn)(int), int howmany )
+{
+	using std::chrono::duration;
+	using std::chrono::duration_cast;
+	using std::chrono::high_resolution_clock;
+
+	auto start = high_resolution_clock::now();
+	fn(howmany);
+	auto delta = high_resolution_clock::now() - start;
+	auto delta_d = duration_cast<duration<double>>(delta).count();
+
+	LOG4CXX_INFO_FMT( console, "Log4cxx {} Elapsed: {:.4} secs {:L}/sec",
+		name,
+		delta_d,
+		int(howmany / delta_d));
+
+	results.push_back( howmany / delta_d );
+}
+
+static void benchmark_conversion_pattern( std::string name,
+	std::string conversion_pattern,
+	void(*fn)(std::string, int),
+	int howmany)
+{
+	using std::chrono::duration;
+	using std::chrono::duration_cast;
+	using std::chrono::high_resolution_clock;
+
+	auto start = high_resolution_clock::now();
+	fn(conversion_pattern, howmany);
+	auto delta = high_resolution_clock::now() - start;
+	auto delta_d = duration_cast<duration<double>>(delta).count();
+
+	LOG4CXX_INFO_FMT( console, "Log4cxx {} pattern: {} Elapsed: {:.4} secs {:L}/sec",
+		name,
+		conversion_pattern,
+		delta_d,
+		int(howmany / delta_d) );
+
+	results.push_back( howmany / delta_d );
+}
+
+static void bench_log4cxx_single_threaded(int iters)
+{
+	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO_FMT(console, "Benchmarking Single threaded: {} messages", iters );
+	LOG4CXX_INFO(console, "**************************************************************");
+
+	benchmark_conversion_pattern( "NoFormat", "%m%n", &log4cxxbenchmarker::logWithConversionPattern, iters );
+	benchmark_conversion_pattern( "DateOnly", "[%d] %m%n", &log4cxxbenchmarker::logWithConversionPattern, iters );
+	benchmark_conversion_pattern( "DateClassLevel", "[%d] [%c] [%p] %m%n", &log4cxxbenchmarker::logWithConversionPattern, iters );
+
+	benchmark_function( "Logging with FMT", &log4cxxbenchmarker::logWithFMT, iters );
+	benchmark_function( "Logging static string", &log4cxxbenchmarker::logStaticString, iters );
+	benchmark_function( "Logging static string with FMT", &log4cxxbenchmarker::logStaticStringFMT, iters );
+	benchmark_function( "Logging disabled debug", &log4cxxbenchmarker::logDisabledDebug, iters );
+	benchmark_function( "Logging disabled trace", &log4cxxbenchmarker::logDisabledTrace, iters );
+	benchmark_function( "Logging enabled debug", &log4cxxbenchmarker::logEnabledDebug, iters );
+	benchmark_function( "Logging enabled trace", &log4cxxbenchmarker::logEnabledTrace, iters );
+}
+
+static void bench_log4cxx_multi_threaded(size_t threads, int iters)
+{
+	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO_FMT(console, "Benchmarking multithreaded threaded: {} messages/thread, {} threads", iters, threads );
+	LOG4CXX_INFO(console, "**************************************************************");
+
+	std::vector<std::thread> runningThreads;
+
+	log4cxxbenchmarker::logSetupMultithreaded();
+
+	for ( size_t x = 0; x < threads; x++ )
+	{
+		runningThreads.push_back( std::thread( [iters]()
+		{
+			benchmark_function( "Logging with FMT MT", &log4cxxbenchmarker::logWithFMTMultithreaded, iters );
+		}) );
+	}
+
+	for ( std::thread& th : runningThreads )
+	{
+		th.join();
+	}
+}
+
+static void bench_log4cxx_multi_threaded_disabled(size_t threads, int iters)
+{
+	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO_FMT(console, "Benchmarking multithreaded disabled: {} messages/thread, {} threads", iters, threads );
+	LOG4CXX_INFO(console, "**************************************************************");
+
+	std::vector<std::thread> runningThreads;
+
+	log4cxxbenchmarker::logSetupMultithreaded();
+
+	for ( size_t x = 0; x < threads; x++ )
+	{
+		runningThreads.push_back( std::thread( [iters]()
+		{
+			benchmark_function( "Logging disabled MT", &log4cxxbenchmarker::logDisabledMultithreaded, iters );
+		}) );
+	}
+
+	for ( std::thread& th : runningThreads )
+	{
+		th.join();
+	}
+}
+
+int main(int argc, char* argv[])
+{
+	int iters = 1000000;
+	size_t threads = 4;
+	size_t max_threads = 32;
+
+	std::setlocale( LC_ALL, "" ); /* Set locale for C functions */
+	std::locale::global(std::locale("")); /* set locale for C++ functions */
+
+	console->setAdditivity( false );
+	log4cxx::PatternLayoutPtr pattern( new log4cxx::PatternLayout() );
+	pattern->setConversionPattern( "%m%n" );
+
+	log4cxx::ConsoleAppenderPtr consoleWriter( new log4cxx::ConsoleAppender );
+	consoleWriter->setLayout( pattern );
+	consoleWriter->setTarget( "System.out" );
+	log4cxx::helpers::Pool p;
+	consoleWriter->activateOptions(p);
+
+	console->addAppender( consoleWriter );
+
+	if (argc > 1)
+	{
+		iters = std::stoi(argv[1]);
+	}
+
+	if (argc > 2)
+	{
+		threads = std::stoul(argv[2]);
+	}
+
+	if (threads > max_threads)
+	{
+		LOG4CXX_ERROR_FMT(console, "Too many threads specified(max: {})", max_threads);
+		return 1;
+	}
+
+	LOG4CXX_INFO_FMT(console, "Benchmarking library only(no writing out):");
+	bench_log4cxx_single_threaded(iters);
+	bench_log4cxx_multi_threaded(threads, iters);
+	bench_log4cxx_multi_threaded_disabled(threads, iters);
+
+	LOG4CXX_INFO_FMT(console, "Results for use in spreadsheet:");
+
+	for ( uint64_t result : results )
+	{
+		LOG4CXX_INFO_FMT(console, "{}", result );
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This PR adds in a utility used for benchmarking the log4cxx library.  It does not benchmark anything about actually writing data out; that is outside of the scope of what this benchmarks at the moment(as that can be highly variable depending on the OS).

This is made as a separate utility application, as it is not really a unit test and is more of a test of how well the library itself performs.

Sample output:
```
Benchmarking library only(no writing out):
**************************************************************
Benchmarking Single threaded: 1000000 messages
**************************************************************
Log4cxx NoFormat pattern: %m%n Elapsed: 0.9181 secs 1,089,168/sec
Log4cxx DateOnly pattern: [%d] %m%n Elapsed: 0.8941 secs 1,118,448/sec
Log4cxx DateClassLevel pattern: [%d] [%c] [%p] %m%n Elapsed: 0.8908 secs 1,122,597/sec
Log4cxx Logging with FMT Elapsed: 0.4779 secs 2,092,464/sec
Log4cxx Logging static string Elapsed: 0.4279 secs 2,337,184/sec
Log4cxx Logging static string with FMT Elapsed: 0.4834 secs 2,068,577/sec
Log4cxx Logging disabled debug Elapsed: 0.04615 secs 21,670,312/sec
Log4cxx Logging disabled trace Elapsed: 0.04780 secs 20,921,870/sec
Log4cxx Logging enabled debug Elapsed: 0.4301 secs 2,325,013/sec
Log4cxx Logging enabled trace Elapsed: 0.4288 secs 2,332,359/sec
**************************************************************
Benchmarking multithreaded threaded: 1000000 messages/thread, 4 threads
**************************************************************
Log4cxx Logging with FMT MT Elapsed: 2.869 secs 348,524/sec
Log4cxx Logging with FMT MT Elapsed: 2.937 secs 340,445/sec
Log4cxx Logging with FMT MT Elapsed: 2.956 secs 338,264/sec
Log4cxx Logging with FMT MT Elapsed: 2.968 secs 336,947/sec
**************************************************************
Benchmarking multithreaded disabled: 1000000 messages/thread, 4 threads
**************************************************************
Log4cxx Logging disabled MT Elapsed: 0.3615 secs 2,766,610/sec
Log4cxx Logging disabled MT Elapsed: 0.3884 secs 2,574,516/sec
Log4cxx Logging disabled MT Elapsed: 0.4346 secs 2,300,853/sec
Log4cxx Logging disabled MT Elapsed: 0.4362 secs 2,292,636/sec
Results for use in spreadsheet:
1089168
1118448
1122597
2092464
2337184
2068577
21670312
20921870
2325013
2332359
348524
340445
338264
336947
2766610
2574516
2300853
2292636
```