### PR TITLE
Prevent thoughputtests warning

### DIFF
--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -52,8 +52,8 @@ Hierarchy::Hierarchy() :
 	loggers(new LoggerMap()),
 	provisionNodes(new ProvisionNodeMap())
 {
-	std::unique_lock<std::mutex> lock(mutex);
 	root = LoggerPtr(new RootLogger(pool, Level::getDebug()));
+	root->setHierarchy(this);
 	defaultFactory = LoggerFactoryPtr(new DefaultLoggerFactory());
 	emittedNoAppenderWarning = false;
 	configured = false;
@@ -64,8 +64,13 @@ Hierarchy::Hierarchy() :
 
 Hierarchy::~Hierarchy()
 {
-	// TODO LOGCXX-430
-	// https://issues.apache.org/jira/browse/LOGCXX-430?focusedCommentId=15175254&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15175254
+	std::unique_lock<std::mutex> lock(mutex);
+	for (auto& item : *this->loggers)
+	{
+		if (auto pLogger = item.second.lock())
+			pLogger->setHierarchy(0);
+	}
+	root->setHierarchy(0);
 #ifndef APR_HAS_THREADS
 	delete loggers;
 	delete provisionNodes;
@@ -120,7 +125,7 @@ LoggerPtr Hierarchy::exists(const LogString& name)
 
 	if (it != loggers->end())
 	{
-		logger = it->second;
+		logger = it->second.lock();
 	}
 
 
@@ -216,15 +221,19 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 
 	LoggerMap::iterator it = loggers->find(name);
 
+	LoggerPtr result;
 	if (it != loggers->end())
 	{
-		return it->second;
+		result = it->second.lock();
 	}
-	else
+	if (!result)
 	{
 		LoggerPtr logger(factory->makeNewLoggerInstance(pool, name));
-		logger->setHierarchy(shared_from_this());
-		loggers->insert(LoggerMap::value_type(name, logger));
+		logger->setHierarchy(this);
+		if (it != loggers->end())
+			it->second = logger;
+		else
+			loggers->insert(LoggerMap::value_type(name, logger));
 
 		ProvisionNodeMap::iterator it2 = provisionNodes->find(name);
 
@@ -235,8 +244,9 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 		}
 
 		updateParents(logger);
-		return logger;
+		result = logger;
 	}
+	return result;
 
 }
 
@@ -245,31 +255,22 @@ LoggerList Hierarchy::getCurrentLoggers() const
 	std::unique_lock<std::mutex> lock(mutex);
 
 	LoggerList v;
-	LoggerMap::const_iterator it, itEnd = loggers->end();
-
-	for (it = loggers->begin(); it != itEnd; it++)
+	for (auto& item : *this->loggers)
 	{
-		v.push_back(it->second);
+		if (auto pLogger = item.second.lock())
+			v.push_back(pLogger);
 	}
-
-
 	return v;
 }
 
 LoggerPtr Hierarchy::getRootLogger() const
 {
-	return root;
+	return this->root;
 }
 
 bool Hierarchy::isDisabled(int level) const
 {
-	bool currentlyConfigured;
-	{
-		std::unique_lock<std::mutex> lock(mutex);
-		currentlyConfigured = configured;
-	}
-
-	if (!currentlyConfigured)
+	if (!configured)
 	{
 		std::shared_ptr<Hierarchy> nonconstThis = std::const_pointer_cast<Hierarchy>(shared_from_this());
 		DefaultConfigurator::configure(
@@ -284,7 +285,7 @@ void Hierarchy::resetConfiguration()
 {
 	std::unique_lock<std::mutex> lock(mutex);
 
-	getRootLogger()->setLevel(Level::getDebug());
+	root->setLevel(Level::getDebug());
 	root->setResourceBundle(0);
 	setThresholdInternal(Level::getAll());
 
@@ -294,9 +295,12 @@ void Hierarchy::resetConfiguration()
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		it->second->setLevel(0);
-		it->second->setAdditivity(true);
-		it->second->setResourceBundle(0);
+		if (auto pLogger = it->second.lock())
+		{
+			pLogger->setLevel(0);
+			pLogger->setAdditivity(true);
+			pLogger->setResourceBundle(0);
+		}
 	}
 
 	//rendererMap.clear();
@@ -313,26 +317,24 @@ void Hierarchy::shutdownInternal()
 {
 	configured = false;
 
-	LoggerPtr root1 = getRootLogger();
-
 	// begin by closing nested appenders
-	root1->closeNestedAppenders();
+	root->closeNestedAppenders();
 
 	LoggerMap::iterator it, itEnd = loggers->end();
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		LoggerPtr logger = it->second;
-		logger->closeNestedAppenders();
+		if (auto pLogger = it->second.lock())
+			pLogger->closeNestedAppenders();
 	}
 
 	// then, remove all appenders
-	root1->removeAllAppenders();
+	root->removeAllAppenders();
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		LoggerPtr logger = it->second;
-		logger->removeAllAppenders();
+		if (auto pLogger = it->second.lock())
+			pLogger->removeAllAppenders();
 	}
 }
 
@@ -354,9 +356,12 @@ void Hierarchy::updateParents(LoggerPtr logger)
 
 		if (it != loggers->end())
 		{
-			parentFound = true;
-			logger->parent = it->second;
-			break; // no need to update the ancestors of the closest ancestor
+			if (auto pLogger = it->second.lock())
+			{
+				parentFound = true;
+				logger->parent = pLogger;
+				break; // no need to update the ancestors of the closest ancestor
+			}
 		}
 		else
 		{
@@ -378,7 +383,7 @@ void Hierarchy::updateParents(LoggerPtr logger)
 	// If we could not find any existing parents, then link with root.
 	if (!parentFound)
 	{
-		logger->parent = root;
+		logger->parent = getRootLogger();
 	}
 }
 
@@ -414,15 +419,5 @@ bool Hierarchy::isConfigured()
 
 HierarchyPtr Hierarchy::create(){
 	HierarchyPtr ret( new Hierarchy() );
-	ret->configureRoot();
 	return ret;
-}
-
-void Hierarchy::configureRoot(){
-	// This should really be done in the constructor, but in order to fix
-	// LOGCXX-322 we need to turn the repositroy into a weak_ptr, and we
-	// can't use weak_from_this() in the constructor.
-	if( !root->getLoggerRepository().lock() ){
-		root->setHierarchy(shared_from_this());
-	}
 }

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -43,7 +43,7 @@ IMPLEMENT_LOG4CXX_OBJECT(Logger)
 
 Logger::Logger(Pool& p, const LogString& name1)
 	: pool(&p), name(), level(), parent(), resourceBundle(),
-	  repository(), aai(new AppenderAttachableImpl(*pool))
+	  repository(0), aai(new AppenderAttachableImpl(*pool))
 {
 	name = name1;
 	additive = true;
@@ -58,11 +58,9 @@ void Logger::addAppender(const AppenderPtr newAppender)
 	log4cxx::spi::LoggerRepositoryPtr rep;
 
 	aai->addAppender(newAppender);
-	rep = repository.lock();
-
-	if (rep)
+	if (repository)
 	{
-		rep->fireAddAppenderEvent(this, newAppender.get());
+		repository->fireAddAppenderEvent(this, newAppender.get());
 	}
 }
 
@@ -80,9 +78,9 @@ void Logger::reconfigure( const std::vector<AppenderPtr>& appenders, bool additi
 	{
 		aai->addAppender( *it );
 
-		if (log4cxx::spi::LoggerRepositoryPtr rep = repository.lock())
+		if (repository)
 		{
-			rep->fireAddAppenderEvent(this, it->get());
+			repository->fireAddAppenderEvent(this, it->get());
 		}
 	}
 }
@@ -103,10 +101,9 @@ void Logger::callAppenders(const spi::LoggingEventPtr& event, Pool& p) const
 		}
 	}
 
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (writes == 0 && rep)
+	if (writes == 0 && repository)
 	{
-		rep->emitNoAppenderWarning(const_cast<Logger*>(this));
+		repository->emitNoAppenderWarning(const_cast<Logger*>(this));
 	}
 }
 
@@ -180,7 +177,7 @@ const LevelPtr Logger::getEffectiveLevel() const
 #endif
 }
 
-LoggerRepositoryWeakPtr Logger::getLoggerRepository() const
+LoggerRepository* Logger::getLoggerRepository() const
 {
 	return repository;
 }
@@ -245,8 +242,7 @@ bool Logger::isAttached(const AppenderPtr appender) const
 
 bool Logger::isTraceEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::TRACE_INT))
+	if (!repository || repository->isDisabled(Level::TRACE_INT))
 	{
 		return false;
 	}
@@ -256,8 +252,7 @@ bool Logger::isTraceEnabled() const
 
 bool Logger::isDebugEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::DEBUG_INT))
+	if (!repository || repository->isDisabled(Level::DEBUG_INT))
 	{
 		return false;
 	}
@@ -267,8 +262,7 @@ bool Logger::isDebugEnabled() const
 
 bool Logger::isEnabledFor(const LevelPtr& level1) const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(level1->toInt()))
+	if (!repository || repository->isDisabled(level1->toInt()))
 	{
 		return false;
 	}
@@ -279,8 +273,7 @@ bool Logger::isEnabledFor(const LevelPtr& level1) const
 
 bool Logger::isInfoEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::INFO_INT))
+	if (!repository || repository->isDisabled(Level::INFO_INT))
 	{
 		return false;
 	}
@@ -290,8 +283,7 @@ bool Logger::isInfoEnabled() const
 
 bool Logger::isErrorEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::ERROR_INT))
+	if (!repository || repository->isDisabled(Level::ERROR_INT))
 	{
 		return false;
 	}
@@ -301,8 +293,7 @@ bool Logger::isErrorEnabled() const
 
 bool Logger::isWarnEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::WARN_INT))
+	if (!repository || repository->isDisabled(Level::WARN_INT))
 	{
 		return false;
 	}
@@ -312,8 +303,7 @@ bool Logger::isWarnEnabled() const
 
 bool Logger::isFatalEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::FATAL_INT))
+	if (!repository || repository->isDisabled(Level::FATAL_INT))
 	{
 		return false;
 	}
@@ -324,7 +314,7 @@ bool Logger::isFatalEnabled() const
 /*void Logger::l7dlog(const LevelPtr& level, const String& key,
                         const char* file, int line)
 {
-        if (repository == 0 || repository->isDisabled(level->level))
+        if (!repository || repository->isDisabled(level->level))
         {
                 return;
         }
@@ -349,8 +339,7 @@ bool Logger::isFatalEnabled() const
 void Logger::l7dlog(const LevelPtr& level1, const LogString& key,
 	const LocationInfo& location, const std::vector<LogString>& params) const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(level1->toInt()))
+	if (!repository || repository->isDisabled(level1->toInt()))
 	{
 		return;
 	}
@@ -445,7 +434,7 @@ void Logger::setAdditivity(bool additive1)
 	this->additive = additive1;
 }
 
-void Logger::setHierarchy(spi::LoggerRepositoryWeakPtr repository1)
+void Logger::setHierarchy(spi::LoggerRepository* repository1)
 {
 	this->repository = repository1;
 }

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -69,7 +69,8 @@ class LOG4CXX_EXPORT Hierarchy :
 		spi::LoggerFactoryPtr defaultFactory;
 		spi::HierarchyEventListenerList listeners;
 
-		typedef std::map<LogString, LoggerPtr> LoggerMap;
+		typedef std::weak_ptr<Logger> WeakLoggerPtr;
+		typedef std::map<LogString, WeakLoggerPtr> LoggerMap;
 		std::unique_ptr<LoggerMap> loggers;
 
 		typedef std::map<LogString, ProvisionNode> ProvisionNodeMap;
@@ -288,7 +289,6 @@ class LOG4CXX_EXPORT Hierarchy :
 
 		void updateChildren(ProvisionNode& pn, LoggerPtr logger);
 
-		void configureRoot();
 };
 
 }  //namespace log4cxx

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -102,7 +102,7 @@ class LOG4CXX_EXPORT Logger :
 
 
 		// Loggers need to know what Hierarchy they are in
-		log4cxx::spi::LoggerRepositoryWeakPtr repository;
+		log4cxx::spi::LoggerRepository* repository;
 
 		helpers::AppenderAttachableImplPtr aai;
 
@@ -623,7 +623,7 @@ class LOG4CXX_EXPORT Logger :
 		Return the the LoggerRepository where this
 		<code>Logger</code> is attached.
 		*/
-		log4cxx::spi::LoggerRepositoryWeakPtr getLoggerRepository() const;
+		log4cxx::spi::LoggerRepository* getLoggerRepository() const;
 
 
 		/**
@@ -1464,7 +1464,7 @@ class LOG4CXX_EXPORT Logger :
 		friend class Hierarchy;
 		/**
 		Only the Hierarchy class can set the hierarchy of a logger.*/
-		void setHierarchy(spi::LoggerRepositoryWeakPtr repository);
+		void setHierarchy(spi::LoggerRepository* repository);
 
 	public:
 		/**

--- a/src/test/cpp/customlogger/xlogger.cpp
+++ b/src/test/cpp/customlogger/xlogger.cpp
@@ -32,8 +32,8 @@ XFactoryPtr XLogger::factory = XFactoryPtr(new XFactory());
 
 void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (rep->isDisabled(XLevel::LETHAL_INT))
+	auto rep = repository;
+	if (!rep || rep->isDisabled(XLevel::LETHAL_INT))
 	{
 		return;
 	}
@@ -46,8 +46,8 @@ void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 
 void XLogger::lethal(const LogString& message)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (rep->isDisabled(XLevel::LETHAL_INT))
+	auto rep = repository;
+	if (!rep || rep->isDisabled(XLevel::LETHAL_INT))
 	{
 		return;
 	}
@@ -70,8 +70,8 @@ LoggerPtr XLogger::getLogger(const helpers::Class& clazz)
 
 void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (rep->isDisabled(XLevel::TRACE_INT))
+	auto rep = repository;
+	if (!rep || rep->isDisabled(XLevel::TRACE_INT))
 	{
 		return;
 	}
@@ -84,8 +84,8 @@ void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 
 void XLogger::trace(const LogString& message)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (rep->isDisabled(XLevel::TRACE_INT))
+	auto rep = repository;
+	if (!rep || rep->isDisabled(XLevel::TRACE_INT))
 	{
 		return;
 	}

--- a/src/test/cpp/customlogger/xloggertestcase.cpp
+++ b/src/test/cpp/customlogger/xloggertestcase.cpp
@@ -52,8 +52,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/encodingtest.cpp
+++ b/src/test/cpp/encodingtest.cpp
@@ -58,8 +58,8 @@ public:
 	 */
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = Logger::getRootLogger()->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = Logger::getRootLogger()->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/hierarchythresholdtestcase.cpp
+++ b/src/test/cpp/hierarchythresholdtestcase.cpp
@@ -49,8 +49,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/l7dtestcase.cpp
+++ b/src/test/cpp/l7dtestcase.cpp
@@ -67,8 +67,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/mdctestcase.cpp
+++ b/src/test/cpp/mdctestcase.cpp
@@ -42,8 +42,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = Logger::getRootLogger()->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = Logger::getRootLogger()->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/minimumtestcase.cpp
+++ b/src/test/cpp/minimumtestcase.cpp
@@ -66,8 +66,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/multithreadtest.cpp
+++ b/src/test/cpp/multithreadtest.cpp
@@ -84,7 +84,6 @@ public:
 
 	void tearDown()
 	{
-//		root->getLoggerRepository()->resetConfiguration();
 	}
 
 	void testMultithreadedLoggers(){

--- a/src/test/cpp/ndctestcase.cpp
+++ b/src/test/cpp/ndctestcase.cpp
@@ -47,8 +47,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/net/socketservertestcase.cpp
+++ b/src/test/cpp/net/socketservertestcase.cpp
@@ -131,8 +131,8 @@ public:
 	void tearDown()
 	{
 		socketAppender = 0;
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 		logger = 0;

--- a/src/test/cpp/patternlayouttest.cpp
+++ b/src/test/cpp/patternlayouttest.cpp
@@ -94,8 +94,8 @@ public:
 	void tearDown()
 	{
 		MDC::clear();
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) rep->resetConfiguration();
+		if (auto rep = root->getLoggerRepository())
+			rep->resetConfiguration();
 	}
 
 	void test1()

--- a/src/test/cpp/throughput/log4cxxbenchmarker.cpp
+++ b/src/test/cpp/throughput/log4cxxbenchmarker.cpp
@@ -120,7 +120,7 @@ void log4cxxbenchmarker::logWithFMT(int howmany)
 	}
 }
 
-void log4cxxbenchmarker::logSetupMultithreaded()
+log4cxx::LoggerPtr log4cxxbenchmarker::logSetupMultithreaded()
 {
 	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
 
@@ -135,6 +135,7 @@ void log4cxxbenchmarker::logSetupMultithreaded()
 	nullWriter->setLayout( pattern );
 
 	logger->addAppender( nullWriter );
+	return logger;
 }
 
 void log4cxxbenchmarker::logWithFMTMultithreaded(int howmany)

--- a/src/test/cpp/throughput/log4cxxbenchmarker.h
+++ b/src/test/cpp/throughput/log4cxxbenchmarker.h
@@ -49,7 +49,7 @@ class log4cxxbenchmarker
 		/**
 		 * Reset logger for multithreaded setup.
 		 */
-		static void logSetupMultithreaded();
+		static log4cxx::LoggerPtr logSetupMultithreaded();
 
 		/**
 		 * Log with the LOG4CXX_INFO_FMT macro to see how long it takes(multithreaded).

--- a/src/test/cpp/throughput/throughput-main.cpp
+++ b/src/test/cpp/throughput/throughput-main.cpp
@@ -101,7 +101,7 @@ static void bench_log4cxx_multi_threaded(size_t threads, int iters)
 
 	std::vector<std::thread> runningThreads;
 
-	log4cxxbenchmarker::logSetupMultithreaded();
+	auto logger = log4cxxbenchmarker::logSetupMultithreaded();
 
 	for ( size_t x = 0; x < threads; x++ )
 	{
@@ -125,7 +125,7 @@ static void bench_log4cxx_multi_threaded_disabled(size_t threads, int iters)
 
 	std::vector<std::thread> runningThreads;
 
-	log4cxxbenchmarker::logSetupMultithreaded();
+	auto logger = log4cxxbenchmarker::logSetupMultithreaded();
 
 	for ( size_t x = 0; x < threads; x++ )
 	{

--- a/src/test/cpp/varia/errorhandlertestcase.cpp
+++ b/src/test/cpp/varia/errorhandlertestcase.cpp
@@ -50,8 +50,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/varia/levelmatchfiltertestcase.cpp
+++ b/src/test/cpp/varia/levelmatchfiltertestcase.cpp
@@ -56,8 +56,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/varia/levelrangefiltertestcase.cpp
+++ b/src/test/cpp/varia/levelrangefiltertestcase.cpp
@@ -56,8 +56,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/xml/domtestcase.cpp
+++ b/src/test/cpp/xml/domtestcase.cpp
@@ -76,8 +76,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/xml/xmllayouttestcase.cpp
+++ b/src/test/cpp/xml/xmllayouttestcase.cpp
@@ -82,8 +82,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}


### PR DESCRIPTION
This PR is required to prevent 'No appender could be found for logger (bench_logger)' warning in throughputtests after applying #88 