### PR TITLE
[LOGCXX-546] Prevent unnecessary locking when determining the logging level

### DIFF
--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -67,7 +67,7 @@ Hierarchy::~Hierarchy()
 	std::unique_lock<std::mutex> lock(mutex);
 	for (auto& item : *this->loggers)
 	{
-		if (auto pLogger = item.second.lock())
+		if (auto pLogger = item.second)
 			pLogger->setHierarchy(0);
 	}
 	root->setHierarchy(0);
@@ -125,7 +125,7 @@ LoggerPtr Hierarchy::exists(const LogString& name)
 
 	if (it != loggers->end())
 	{
-		logger = it->second.lock();
+		logger = it->second;
 	}
 
 
@@ -224,7 +224,7 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 	LoggerPtr result;
 	if (it != loggers->end())
 	{
-		result = it->second.lock();
+		result = it->second;
 	}
 	if (!result)
 	{
@@ -257,7 +257,7 @@ LoggerList Hierarchy::getCurrentLoggers() const
 	LoggerList v;
 	for (auto& item : *this->loggers)
 	{
-		if (auto pLogger = item.second.lock())
+		if (auto pLogger = item.second)
 			v.push_back(pLogger);
 	}
 	return v;
@@ -295,7 +295,7 @@ void Hierarchy::resetConfiguration()
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		if (auto pLogger = it->second.lock())
+		if (auto pLogger = it->second)
 		{
 			pLogger->setLevel(0);
 			pLogger->setAdditivity(true);
@@ -324,7 +324,7 @@ void Hierarchy::shutdownInternal()
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		if (auto pLogger = it->second.lock())
+		if (auto pLogger = it->second)
 			pLogger->closeNestedAppenders();
 	}
 
@@ -333,7 +333,7 @@ void Hierarchy::shutdownInternal()
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		if (auto pLogger = it->second.lock())
+		if (auto pLogger = it->second)
 			pLogger->removeAllAppenders();
 	}
 }
@@ -356,7 +356,7 @@ void Hierarchy::updateParents(LoggerPtr logger)
 
 		if (it != loggers->end())
 		{
-			if (auto pLogger = it->second.lock())
+			if (auto pLogger = it->second)
 			{
 				parentFound = true;
 				logger->parent = pLogger;

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -52,8 +52,8 @@ Hierarchy::Hierarchy() :
 	loggers(new LoggerMap()),
 	provisionNodes(new ProvisionNodeMap())
 {
-	std::unique_lock<std::mutex> lock(mutex);
 	root = LoggerPtr(new RootLogger(pool, Level::getDebug()));
+	root->setHierarchy(this);
 	defaultFactory = LoggerFactoryPtr(new DefaultLoggerFactory());
 	emittedNoAppenderWarning = false;
 	configured = false;
@@ -64,8 +64,13 @@ Hierarchy::Hierarchy() :
 
 Hierarchy::~Hierarchy()
 {
-	// TODO LOGCXX-430
-	// https://issues.apache.org/jira/browse/LOGCXX-430?focusedCommentId=15175254&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15175254
+	std::unique_lock<std::mutex> lock(mutex);
+	for (auto& item : *this->loggers)
+	{
+		if (auto pLogger = item.second.lock())
+			pLogger->setHierarchy(0);
+	}
+	root->setHierarchy(0);
 #ifndef APR_HAS_THREADS
 	delete loggers;
 	delete provisionNodes;
@@ -120,7 +125,7 @@ LoggerPtr Hierarchy::exists(const LogString& name)
 
 	if (it != loggers->end())
 	{
-		logger = it->second;
+		logger = it->second.lock();
 	}
 
 
@@ -216,15 +221,19 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 
 	LoggerMap::iterator it = loggers->find(name);
 
+	LoggerPtr result;
 	if (it != loggers->end())
 	{
-		return it->second;
+		result = it->second.lock();
 	}
-	else
+	if (!result)
 	{
 		LoggerPtr logger(factory->makeNewLoggerInstance(pool, name));
-		logger->setHierarchy(shared_from_this());
-		loggers->insert(LoggerMap::value_type(name, logger));
+		logger->setHierarchy(this);
+		if (it != loggers->end())
+			it->second = logger;
+		else
+			loggers->insert(LoggerMap::value_type(name, logger));
 
 		ProvisionNodeMap::iterator it2 = provisionNodes->find(name);
 
@@ -235,8 +244,9 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 		}
 
 		updateParents(logger);
-		return logger;
+		result = logger;
 	}
+	return result;
 
 }
 
@@ -245,31 +255,22 @@ LoggerList Hierarchy::getCurrentLoggers() const
 	std::unique_lock<std::mutex> lock(mutex);
 
 	LoggerList v;
-	LoggerMap::const_iterator it, itEnd = loggers->end();
-
-	for (it = loggers->begin(); it != itEnd; it++)
+	for (auto& item : *this->loggers)
 	{
-		v.push_back(it->second);
+		if (auto pLogger = item.second.lock())
+			v.push_back(pLogger);
 	}
-
-
 	return v;
 }
 
 LoggerPtr Hierarchy::getRootLogger() const
 {
-	return root;
+	return this->root;
 }
 
 bool Hierarchy::isDisabled(int level) const
 {
-	bool currentlyConfigured;
-	{
-		std::unique_lock<std::mutex> lock(mutex);
-		currentlyConfigured = configured;
-	}
-
-	if (!currentlyConfigured)
+	if (!configured)
 	{
 		std::shared_ptr<Hierarchy> nonconstThis = std::const_pointer_cast<Hierarchy>(shared_from_this());
 		DefaultConfigurator::configure(
@@ -284,7 +285,7 @@ void Hierarchy::resetConfiguration()
 {
 	std::unique_lock<std::mutex> lock(mutex);
 
-	getRootLogger()->setLevel(Level::getDebug());
+	root->setLevel(Level::getDebug());
 	root->setResourceBundle(0);
 	setThresholdInternal(Level::getAll());
 
@@ -294,9 +295,12 @@ void Hierarchy::resetConfiguration()
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		it->second->setLevel(0);
-		it->second->setAdditivity(true);
-		it->second->setResourceBundle(0);
+		if (auto pLogger = it->second.lock())
+		{
+			pLogger->setLevel(0);
+			pLogger->setAdditivity(true);
+			pLogger->setResourceBundle(0);
+		}
 	}
 
 	//rendererMap.clear();
@@ -313,26 +317,24 @@ void Hierarchy::shutdownInternal()
 {
 	configured = false;
 
-	LoggerPtr root1 = getRootLogger();
-
 	// begin by closing nested appenders
-	root1->closeNestedAppenders();
+	root->closeNestedAppenders();
 
 	LoggerMap::iterator it, itEnd = loggers->end();
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		LoggerPtr logger = it->second;
-		logger->closeNestedAppenders();
+		if (auto pLogger = it->second.lock())
+			pLogger->closeNestedAppenders();
 	}
 
 	// then, remove all appenders
-	root1->removeAllAppenders();
+	root->removeAllAppenders();
 
 	for (it = loggers->begin(); it != itEnd; it++)
 	{
-		LoggerPtr logger = it->second;
-		logger->removeAllAppenders();
+		if (auto pLogger = it->second.lock())
+			pLogger->removeAllAppenders();
 	}
 }
 
@@ -354,9 +356,12 @@ void Hierarchy::updateParents(LoggerPtr logger)
 
 		if (it != loggers->end())
 		{
-			parentFound = true;
-			logger->parent = it->second;
-			break; // no need to update the ancestors of the closest ancestor
+			if (auto pLogger = it->second.lock())
+			{
+				parentFound = true;
+				logger->parent = pLogger;
+				break; // no need to update the ancestors of the closest ancestor
+			}
 		}
 		else
 		{
@@ -378,7 +383,7 @@ void Hierarchy::updateParents(LoggerPtr logger)
 	// If we could not find any existing parents, then link with root.
 	if (!parentFound)
 	{
-		logger->parent = root;
+		logger->parent = getRootLogger();
 	}
 }
 
@@ -414,15 +419,5 @@ bool Hierarchy::isConfigured()
 
 HierarchyPtr Hierarchy::create(){
 	HierarchyPtr ret( new Hierarchy() );
-	ret->configureRoot();
 	return ret;
-}
-
-void Hierarchy::configureRoot(){
-	// This should really be done in the constructor, but in order to fix
-	// LOGCXX-322 we need to turn the repositroy into a weak_ptr, and we
-	// can't use weak_from_this() in the constructor.
-	if( !root->getLoggerRepository().lock() ){
-		root->setHierarchy(shared_from_this());
-	}
 }

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -161,7 +161,7 @@ AppenderPtr Logger::getAppender(const LogString& name1) const
 	return aai->getAppender(name1);
 }
 
-const LevelPtr Logger::getEffectiveLevel() const
+const LevelPtr& Logger::getEffectiveLevel() const
 {
 	for (const Logger* l = this; l != 0; l = l->parent.get())
 	{

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -43,7 +43,7 @@ IMPLEMENT_LOG4CXX_OBJECT(Logger)
 
 Logger::Logger(Pool& p, const LogString& name1)
 	: pool(&p), name(), level(), parent(), resourceBundle(),
-	  repository(), aai(new AppenderAttachableImpl(*pool))
+	  repository(0), aai(new AppenderAttachableImpl(*pool))
 {
 	name = name1;
 	additive = true;
@@ -58,11 +58,9 @@ void Logger::addAppender(const AppenderPtr newAppender)
 	log4cxx::spi::LoggerRepositoryPtr rep;
 
 	aai->addAppender(newAppender);
-	rep = repository.lock();
-
-	if (rep)
+	if (repository)
 	{
-		rep->fireAddAppenderEvent(this, newAppender.get());
+		repository->fireAddAppenderEvent(this, newAppender.get());
 	}
 }
 
@@ -80,9 +78,9 @@ void Logger::reconfigure( const std::vector<AppenderPtr>& appenders, bool additi
 	{
 		aai->addAppender( *it );
 
-		if (log4cxx::spi::LoggerRepositoryPtr rep = repository.lock())
+		if (repository)
 		{
-			rep->fireAddAppenderEvent(this, it->get());
+			repository->fireAddAppenderEvent(this, it->get());
 		}
 	}
 }
@@ -103,10 +101,9 @@ void Logger::callAppenders(const spi::LoggingEventPtr& event, Pool& p) const
 		}
 	}
 
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (writes == 0 && rep)
+	if (writes == 0 && repository)
 	{
-		rep->emitNoAppenderWarning(const_cast<Logger*>(this));
+		repository->emitNoAppenderWarning(const_cast<Logger*>(this));
 	}
 }
 
@@ -180,7 +177,7 @@ const LevelPtr Logger::getEffectiveLevel() const
 #endif
 }
 
-LoggerRepositoryWeakPtr Logger::getLoggerRepository() const
+LoggerRepository* Logger::getLoggerRepository() const
 {
 	return repository;
 }
@@ -245,8 +242,7 @@ bool Logger::isAttached(const AppenderPtr appender) const
 
 bool Logger::isTraceEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::TRACE_INT))
+	if (!repository || repository->isDisabled(Level::TRACE_INT))
 	{
 		return false;
 	}
@@ -256,8 +252,7 @@ bool Logger::isTraceEnabled() const
 
 bool Logger::isDebugEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::DEBUG_INT))
+	if (!repository || repository->isDisabled(Level::DEBUG_INT))
 	{
 		return false;
 	}
@@ -267,8 +262,7 @@ bool Logger::isDebugEnabled() const
 
 bool Logger::isEnabledFor(const LevelPtr& level1) const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(level1->toInt()))
+	if (!repository || repository->isDisabled(level1->toInt()))
 	{
 		return false;
 	}
@@ -279,8 +273,7 @@ bool Logger::isEnabledFor(const LevelPtr& level1) const
 
 bool Logger::isInfoEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::INFO_INT))
+	if (!repository || repository->isDisabled(Level::INFO_INT))
 	{
 		return false;
 	}
@@ -290,8 +283,7 @@ bool Logger::isInfoEnabled() const
 
 bool Logger::isErrorEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::ERROR_INT))
+	if (!repository || repository->isDisabled(Level::ERROR_INT))
 	{
 		return false;
 	}
@@ -301,8 +293,7 @@ bool Logger::isErrorEnabled() const
 
 bool Logger::isWarnEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::WARN_INT))
+	if (!repository || repository->isDisabled(Level::WARN_INT))
 	{
 		return false;
 	}
@@ -312,8 +303,7 @@ bool Logger::isWarnEnabled() const
 
 bool Logger::isFatalEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(Level::FATAL_INT))
+	if (!repository || repository->isDisabled(Level::FATAL_INT))
 	{
 		return false;
 	}
@@ -324,7 +314,7 @@ bool Logger::isFatalEnabled() const
 /*void Logger::l7dlog(const LevelPtr& level, const String& key,
                         const char* file, int line)
 {
-        if (repository == 0 || repository->isDisabled(level->level))
+        if (!repository || repository->isDisabled(level->level))
         {
                 return;
         }
@@ -349,8 +339,7 @@ bool Logger::isFatalEnabled() const
 void Logger::l7dlog(const LevelPtr& level1, const LogString& key,
 	const LocationInfo& location, const std::vector<LogString>& params) const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (!rep || rep->isDisabled(level1->toInt()))
+	if (!repository || repository->isDisabled(level1->toInt()))
 	{
 		return;
 	}
@@ -445,7 +434,7 @@ void Logger::setAdditivity(bool additive1)
 	this->additive = additive1;
 }
 
-void Logger::setHierarchy(spi::LoggerRepositoryWeakPtr repository1)
+void Logger::setHierarchy(spi::LoggerRepository* repository1)
 {
 	this->repository = repository1;
 }

--- a/src/main/cpp/rootlogger.cpp
+++ b/src/main/cpp/rootlogger.cpp
@@ -30,7 +30,7 @@ RootLogger::RootLogger(Pool& pool, const LevelPtr level1) :
 	setLevel(level1);
 }
 
-const LevelPtr RootLogger::getEffectiveLevel() const
+const LevelPtr& RootLogger::getEffectiveLevel() const
 {
 	return level;
 }

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -69,7 +69,8 @@ class LOG4CXX_EXPORT Hierarchy :
 		spi::LoggerFactoryPtr defaultFactory;
 		spi::HierarchyEventListenerList listeners;
 
-		typedef std::map<LogString, LoggerPtr> LoggerMap;
+		typedef std::weak_ptr<Logger> WeakLoggerPtr;
+		typedef std::map<LogString, WeakLoggerPtr> LoggerMap;
 		std::unique_ptr<LoggerMap> loggers;
 
 		typedef std::map<LogString, ProvisionNode> ProvisionNodeMap;
@@ -288,7 +289,6 @@ class LOG4CXX_EXPORT Hierarchy :
 
 		void updateChildren(ProvisionNode& pn, LoggerPtr logger);
 
-		void configureRoot();
 };
 
 }  //namespace log4cxx

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -69,8 +69,7 @@ class LOG4CXX_EXPORT Hierarchy :
 		spi::LoggerFactoryPtr defaultFactory;
 		spi::HierarchyEventListenerList listeners;
 
-		typedef std::weak_ptr<Logger> WeakLoggerPtr;
-		typedef std::map<LogString, WeakLoggerPtr> LoggerMap;
+		typedef std::map<LogString, LoggerPtr> LoggerMap;
 		std::unique_ptr<LoggerMap> loggers;
 
 		typedef std::map<LogString, ProvisionNode> ProvisionNodeMap;

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -617,7 +617,7 @@ class LOG4CXX_EXPORT Logger :
 
 		@throws RuntimeException if all levels are null in the hierarchy
 		*/
-		virtual const LevelPtr getEffectiveLevel() const;
+		virtual const LevelPtr& getEffectiveLevel() const;
 
 		/**
 		Return the the LoggerRepository where this

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -102,7 +102,7 @@ class LOG4CXX_EXPORT Logger :
 
 
 		// Loggers need to know what Hierarchy they are in
-		log4cxx::spi::LoggerRepositoryWeakPtr repository;
+		log4cxx::spi::LoggerRepository* repository;
 
 		helpers::AppenderAttachableImplPtr aai;
 
@@ -623,7 +623,7 @@ class LOG4CXX_EXPORT Logger :
 		Return the the LoggerRepository where this
 		<code>Logger</code> is attached.
 		*/
-		log4cxx::spi::LoggerRepositoryWeakPtr getLoggerRepository() const;
+		log4cxx::spi::LoggerRepository* getLoggerRepository() const;
 
 
 		/**
@@ -1464,7 +1464,7 @@ class LOG4CXX_EXPORT Logger :
 		friend class Hierarchy;
 		/**
 		Only the Hierarchy class can set the hierarchy of a logger.*/
-		void setHierarchy(spi::LoggerRepositoryWeakPtr repository);
+		void setHierarchy(spi::LoggerRepository* repository);
 
 	public:
 		/**

--- a/src/main/include/log4cxx/spi/rootlogger.h
+++ b/src/main/include/log4cxx/spi/rootlogger.h
@@ -48,7 +48,7 @@ class LOG4CXX_EXPORT RootLogger : public Logger
 		Return the assigned level value without walking the logger
 		hierarchy.
 		*/
-		virtual const LevelPtr getEffectiveLevel() const;
+		virtual const LevelPtr& getEffectiveLevel() const;
 
 		/**
 		            Setting a null value to the level of the root logger may have catastrophic

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ find_program(GZIP_APP gzip REQUIRED)
 
 # Tests defined in this directory
 set(ALL_LOG4CXX_TESTS
+    autoConfigureTestCase
     asyncappendertestcase
     consoleappendertestcase
     decodingtest
@@ -87,13 +88,14 @@ if( WIN32 )
   endforeach()
 endif( WIN32 )
 
+get_filename_component(UNIT_TEST_WORKING_DIR ../resources ABSOLUTE)
 foreach(testName IN LISTS ALL_LOG4CXX_TESTS)
     target_compile_definitions(${testName} PRIVATE ${LOG4CXX_COMPILE_DEFINITIONS} ${APR_COMPILE_DEFINITIONS} ${APR_UTIL_COMPILE_DEFINITIONS} )
     target_include_directories(${testName} PRIVATE ${CMAKE_CURRENT_LIST_DIR} $<TARGET_PROPERTY:log4cxx,INCLUDE_DIRECTORIES>)
     target_link_libraries(${testName} PRIVATE testingFramework testingUtilities log4cxx ${APR_LIBRARIES} ${APR_SYSTEM_LIBS} Threads::Threads)
     add_test(NAME ${testName}
         COMMAND ${testName} -v
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../resources
+        WORKING_DIRECTORY ${UNIT_TEST_WORKING_DIR}
     )
     set_tests_properties( ${testName} PROPERTIES TIMEOUT 120 )
 
@@ -101,6 +103,10 @@ foreach(testName IN LISTS ALL_LOG4CXX_TESTS)
         if(${testName} STREQUAL socketservertestcase)
             set_tests_properties(socketservertestcase PROPERTIES
                 ENVIRONMENT "SOCKET_SERVER_PARAMETER_FILE=${START_SOCKET_SERVER_PARAMETER_FILE};PATH=${ESCAPED_PATH}"
+            )
+        elseif(${testName} STREQUAL autoConfigureTestCase)
+            set_tests_properties(autoConfigureTestCase PROPERTIES
+                ENVIRONMENT "LOG4CXX_CONFIGURATION=${UNIT_TEST_WORKING_DIR}/input/autoConfigureTest.properties;PATH=${ESCAPED_PATH}"
             )
         else()
            set_tests_properties(${testName} PROPERTIES
@@ -111,6 +117,10 @@ foreach(testName IN LISTS ALL_LOG4CXX_TESTS)
         if(${testName} STREQUAL socketservertestcase)
             set_tests_properties(socketservertestcase PROPERTIES
                 ENVIRONMENT "SOCKET_SERVER_PARAMETER_FILE=${START_SOCKET_SERVER_PARAMETER_FILE}"
+            )
+        elseif(${testName} STREQUAL autoConfigureTestCase)
+            set_tests_properties(autoConfigureTestCase PROPERTIES
+                ENVIRONMENT "LOG4CXX_CONFIGURATION=${UNIT_TEST_WORKING_DIR}/input/autoConfigureTest.properties"
             )
         else()
            set_tests_properties(${testName} PROPERTIES

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -17,7 +17,7 @@ find_program(GZIP_APP gzip REQUIRED)
 
 # Tests defined in this directory
 set(ALL_LOG4CXX_TESTS
-    autoConfigureTestCase
+    autoconfiguretestcase
     asyncappendertestcase
     consoleappendertestcase
     decodingtest
@@ -104,8 +104,8 @@ foreach(testName IN LISTS ALL_LOG4CXX_TESTS)
             set_tests_properties(socketservertestcase PROPERTIES
                 ENVIRONMENT "SOCKET_SERVER_PARAMETER_FILE=${START_SOCKET_SERVER_PARAMETER_FILE};PATH=${ESCAPED_PATH}"
             )
-        elseif(${testName} STREQUAL autoConfigureTestCase)
-            set_tests_properties(autoConfigureTestCase PROPERTIES
+        elseif(${testName} STREQUAL autoconfiguretestcase)
+            set_tests_properties(autoconfiguretestcase PROPERTIES
                 ENVIRONMENT "LOG4CXX_CONFIGURATION=${UNIT_TEST_WORKING_DIR}/input/autoConfigureTest.properties;PATH=${ESCAPED_PATH}"
             )
         else()
@@ -118,8 +118,8 @@ foreach(testName IN LISTS ALL_LOG4CXX_TESTS)
             set_tests_properties(socketservertestcase PROPERTIES
                 ENVIRONMENT "SOCKET_SERVER_PARAMETER_FILE=${START_SOCKET_SERVER_PARAMETER_FILE}"
             )
-        elseif(${testName} STREQUAL autoConfigureTestCase)
-            set_tests_properties(autoConfigureTestCase PROPERTIES
+        elseif(${testName} STREQUAL autoconfiguretestcase)
+            set_tests_properties(autoconfiguretestcase PROPERTIES
                 ENVIRONMENT "LOG4CXX_CONFIGURATION=${UNIT_TEST_WORKING_DIR}/input/autoConfigureTest.properties"
             )
         else()

--- a/src/test/cpp/autoconfiguretestcase.cpp
+++ b/src/test/cpp/autoconfiguretestcase.cpp
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "logunit.h"
+#include <log4cxx/logger.h>
+#include <log4cxx/logmanager.h>
+#include <log4cxx/file.h>
+#include "util/compare.h"
+
+using namespace log4cxx;
+LOGUNIT_CLASS(AutoConfigureTestCase)
+{
+	LOGUNIT_TEST_SUITE(AutoConfigureTestCase);
+	LOGUNIT_TEST(test1);
+	LOGUNIT_TEST(test2);
+	LOGUNIT_TEST_SUITE_END();
+
+public:
+
+	void test1()
+	{
+		LoggerPtr debugLogger = Logger::getLogger(LOG4CXX_STR("AutoConfig.test1"));
+		LOGUNIT_ASSERT(!debugLogger->isDebugEnabled());
+		LOGUNIT_ASSERT(LogManager::getLoggerRepository()->isConfigured());
+    }
+
+	void test2()
+	{
+		LoggerPtr debugLogger = Logger::getLogger(LOG4CXX_STR("AutoConfig.test2"));
+		LOGUNIT_ASSERT(debugLogger->isDebugEnabled());
+		LOG4CXX_DEBUG(debugLogger, LOG4CXX_STR("This is some expected ouput"));
+		LOGUNIT_ASSERT_EQUAL(true, Compare::compare
+				( File("output/autoConfigureTest.log")
+				, File("witness/autoConfigureTest.log")
+				));
+	}
+};
+
+LOGUNIT_TEST_SUITE_REGISTRATION(AutoConfigureTestCase);

--- a/src/test/cpp/customlogger/xlogger.cpp
+++ b/src/test/cpp/customlogger/xlogger.cpp
@@ -32,8 +32,8 @@ XFactoryPtr XLogger::factory = XFactoryPtr(new XFactory());
 
 void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (rep->isDisabled(XLevel::LETHAL_INT))
+	auto rep = repository;
+	if (!rep || rep->isDisabled(XLevel::LETHAL_INT))
 	{
 		return;
 	}
@@ -46,8 +46,8 @@ void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 
 void XLogger::lethal(const LogString& message)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (rep->isDisabled(XLevel::LETHAL_INT))
+	auto rep = repository;
+	if (!rep || rep->isDisabled(XLevel::LETHAL_INT))
 	{
 		return;
 	}
@@ -70,8 +70,8 @@ LoggerPtr XLogger::getLogger(const helpers::Class& clazz)
 
 void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (rep->isDisabled(XLevel::TRACE_INT))
+	auto rep = repository;
+	if (!rep || rep->isDisabled(XLevel::TRACE_INT))
 	{
 		return;
 	}
@@ -84,8 +84,8 @@ void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 
 void XLogger::trace(const LogString& message)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = repository.lock();
-	if (rep->isDisabled(XLevel::TRACE_INT))
+	auto rep = repository;
+	if (!rep || rep->isDisabled(XLevel::TRACE_INT))
 	{
 		return;
 	}

--- a/src/test/cpp/customlogger/xloggertestcase.cpp
+++ b/src/test/cpp/customlogger/xloggertestcase.cpp
@@ -52,8 +52,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/encodingtest.cpp
+++ b/src/test/cpp/encodingtest.cpp
@@ -58,8 +58,8 @@ public:
 	 */
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = Logger::getRootLogger()->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = Logger::getRootLogger()->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/hierarchythresholdtestcase.cpp
+++ b/src/test/cpp/hierarchythresholdtestcase.cpp
@@ -49,8 +49,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/l7dtestcase.cpp
+++ b/src/test/cpp/l7dtestcase.cpp
@@ -67,8 +67,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/mdctestcase.cpp
+++ b/src/test/cpp/mdctestcase.cpp
@@ -42,8 +42,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = Logger::getRootLogger()->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = Logger::getRootLogger()->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/minimumtestcase.cpp
+++ b/src/test/cpp/minimumtestcase.cpp
@@ -66,8 +66,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/multithreadtest.cpp
+++ b/src/test/cpp/multithreadtest.cpp
@@ -84,7 +84,6 @@ public:
 
 	void tearDown()
 	{
-//		root->getLoggerRepository()->resetConfiguration();
 	}
 
 	void testMultithreadedLoggers(){

--- a/src/test/cpp/ndctestcase.cpp
+++ b/src/test/cpp/ndctestcase.cpp
@@ -47,8 +47,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/net/socketservertestcase.cpp
+++ b/src/test/cpp/net/socketservertestcase.cpp
@@ -131,8 +131,8 @@ public:
 	void tearDown()
 	{
 		socketAppender = 0;
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 		logger = 0;

--- a/src/test/cpp/patternlayouttest.cpp
+++ b/src/test/cpp/patternlayouttest.cpp
@@ -94,8 +94,8 @@ public:
 	void tearDown()
 	{
 		MDC::clear();
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) rep->resetConfiguration();
+		if (auto rep = root->getLoggerRepository())
+			rep->resetConfiguration();
 	}
 
 	void test1()

--- a/src/test/cpp/throughput/log4cxxbenchmarker.cpp
+++ b/src/test/cpp/throughput/log4cxxbenchmarker.cpp
@@ -120,7 +120,7 @@ void log4cxxbenchmarker::logWithFMT(int howmany)
 	}
 }
 
-void log4cxxbenchmarker::logSetupMultithreaded()
+log4cxx::LoggerPtr log4cxxbenchmarker::logSetupMultithreaded()
 {
 	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
 
@@ -135,6 +135,7 @@ void log4cxxbenchmarker::logSetupMultithreaded()
 	nullWriter->setLayout( pattern );
 
 	logger->addAppender( nullWriter );
+	return logger;
 }
 
 void log4cxxbenchmarker::logWithFMTMultithreaded(int howmany)

--- a/src/test/cpp/throughput/log4cxxbenchmarker.h
+++ b/src/test/cpp/throughput/log4cxxbenchmarker.h
@@ -49,7 +49,7 @@ class log4cxxbenchmarker
 		/**
 		 * Reset logger for multithreaded setup.
 		 */
-		static void logSetupMultithreaded();
+		static log4cxx::LoggerPtr logSetupMultithreaded();
 
 		/**
 		 * Log with the LOG4CXX_INFO_FMT macro to see how long it takes(multithreaded).

--- a/src/test/cpp/throughput/throughput-main.cpp
+++ b/src/test/cpp/throughput/throughput-main.cpp
@@ -101,7 +101,7 @@ static void bench_log4cxx_multi_threaded(size_t threads, int iters)
 
 	std::vector<std::thread> runningThreads;
 
-	log4cxxbenchmarker::logSetupMultithreaded();
+	auto logger = log4cxxbenchmarker::logSetupMultithreaded();
 
 	for ( size_t x = 0; x < threads; x++ )
 	{
@@ -125,7 +125,7 @@ static void bench_log4cxx_multi_threaded_disabled(size_t threads, int iters)
 
 	std::vector<std::thread> runningThreads;
 
-	log4cxxbenchmarker::logSetupMultithreaded();
+	auto logger = log4cxxbenchmarker::logSetupMultithreaded();
 
 	for ( size_t x = 0; x < threads; x++ )
 	{

--- a/src/test/cpp/varia/errorhandlertestcase.cpp
+++ b/src/test/cpp/varia/errorhandlertestcase.cpp
@@ -50,8 +50,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/varia/levelmatchfiltertestcase.cpp
+++ b/src/test/cpp/varia/levelmatchfiltertestcase.cpp
@@ -56,8 +56,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/varia/levelrangefiltertestcase.cpp
+++ b/src/test/cpp/varia/levelrangefiltertestcase.cpp
@@ -56,8 +56,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/xml/domtestcase.cpp
+++ b/src/test/cpp/xml/domtestcase.cpp
@@ -76,8 +76,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = root->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/cpp/xml/xmllayouttestcase.cpp
+++ b/src/test/cpp/xml/xmllayouttestcase.cpp
@@ -82,8 +82,8 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
-		if (rep) {
+		if (auto rep = logger->getLoggerRepository())
+		{
 			rep->resetConfiguration();
 		}
 	}

--- a/src/test/resources/input/autoConfigureTest.properties
+++ b/src/test/resources/input/autoConfigureTest.properties
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+log4j.rootCategory=INFO, A1
+
+log4j.appender.A1=org.apache.log4j.FileAppender
+log4j.appender.A1.File=output/autoConfigureTest.log
+log4j.appender.A1.Append=false
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%m%n
+
+#log4j.logger.AutoConfig.test1=DEBUG
+log4j.logger.AutoConfig.test2=DEBUG

--- a/src/test/resources/witness/autoConfigureTest.log
+++ b/src/test/resources/witness/autoConfigureTest.log
@@ -1,0 +1,1 @@
+This is some expected ouput


### PR DESCRIPTION
**throughputtests after these changes:**
```
Benchmarking library only(no writing out):
**************************************************************
Benchmarking Single threaded: 1000000 messages
**************************************************************
Log4cxx NoFormat pattern: %m%n Elapsed: 2.658 secs 376,183/sec
Log4cxx DateOnly pattern: [%d] %m%n Elapsed: 2.665 secs 375,241/sec
Log4cxx DateClassLevel pattern: [%d] [%c] [%p] %m%n Elapsed: 2.688 secs 372,005/sec
Log4cxx Logging with FMT Elapsed: 2.137 secs 468,036/sec
Log4cxx Logging static string Elapsed: 2.143 secs 466,650/sec
Log4cxx Logging static string with FMT Elapsed: 2.245 secs 445,344/sec
Log4cxx Logging disabled debug Elapsed: 0.03112 secs 32,134,432/sec
Log4cxx Logging disabled trace Elapsed: 0.03091 secs 32,355,477/sec
Log4cxx Logging enabled debug Elapsed: 2.142 secs 466,769/sec
Log4cxx Logging enabled trace Elapsed: 2.161 secs 462,705/sec
**************************************************************
Benchmarking multithreaded threaded: 1000000 messages/thread, 4 threads
**************************************************************
Log4cxx Logging with FMT MT Elapsed: 4.19 secs 238,661/sec
Log4cxx Logging with FMT MT Elapsed: 4.233 secs 236,256/sec
Log4cxx Logging with FMT MT Elapsed: 4.315 secs 231,733/sec
Log4cxx Logging with FMT MT Elapsed: 4.324 secs 231,272/sec
**************************************************************
Benchmarking multithreaded disabled: 1000000 messages/thread, 4 threads
**************************************************************
Log4cxx Logging disabled MT Elapsed: 0.03375 secs 29,632,945/sec
Log4cxx Logging disabled MT Elapsed: 0.03366 secs 29,706,781/sec
Log4cxx Logging disabled MT Elapsed: 0.03372 secs 29,653,837/sec
Log4cxx Logging disabled MT Elapsed: 0.03375 secs 29,627,664/sec
```

**throughput output before these changes:**
```**************************************************************
Benchmarking Single threaded: 1000000 messages
**************************************************************
Log4cxx NoFormat pattern: %m%n Elapsed: 2.828 secs 353,625/sec
Log4cxx DateOnly pattern: [%d] %m%n Elapsed: 2.767 secs 361,350/sec
Log4cxx DateClassLevel pattern: [%d] [%c] [%p] %m%n Elapsed: 2.81 secs 355,882/sec
Log4cxx Logging with FMT Elapsed: 2.088 secs 478,949/sec
Log4cxx Logging static string Elapsed: 2.217 secs 451,045/sec
Log4cxx Logging static string with FMT Elapsed: 2.302 secs 434,344/sec
Log4cxx Logging disabled debug Elapsed: 0.1867 secs 5,357,277/sec
Log4cxx Logging disabled trace Elapsed: 0.186 secs 5,375,506/sec
Log4cxx Logging enabled debug Elapsed: 2.261 secs 442,245/sec
Log4cxx Logging enabled trace Elapsed: 2.263 secs 441,886/sec
**************************************************************
Benchmarking multithreaded threaded: 1000000 messages/thread, 4 threads
**************************************************************
Log4cxx Logging with FMT MT Elapsed: 4.097 secs 244,063/sec
Log4cxx Logging with FMT MT Elapsed: 4.105 secs 243,617/sec
Log4cxx Logging with FMT MT Elapsed: 4.132 secs 242,014/sec
Log4cxx Logging with FMT MT Elapsed: 4.132 secs 242,005/sec
**************************************************************
Benchmarking multithreaded disabled: 1000000 messages/thread, 4 threads
**************************************************************
Log4cxx Logging disabled MT Elapsed: 0.6538 secs 1,529,611/sec
Log4cxx Logging disabled MT Elapsed: 0.6681 secs 1,496,778/sec
Log4cxx Logging disabled MT Elapsed: 0.6699 secs 1,492,832/sec
Log4cxx Logging disabled MT Elapsed: 0.6702 secs 1,492,142/sec
```
