### PR TITLE
LOGCXX-546] Prevent serialization of a multi-threaded application

### DIFF
--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -98,9 +98,9 @@ Hierarchy::~Hierarchy()
 	for (auto& item : *m_priv->loggers)
 	{
 		if (auto& pLogger = item.second)
-			pLogger->setHierarchy(0);
+			pLogger->removeHierarchy();
 	}
-	m_priv->root->setHierarchy(0);
+	m_priv->root->removeHierarchy();
 #ifndef APR_HAS_THREADS
 	delete loggers;
 	delete provisionNodes;
@@ -258,7 +258,7 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 	else
 	{
 		LoggerPtr logger(factory->makeNewLoggerInstance(m_priv->pool, name));
-		logger->setHierarchy(this);
+		logger->setHierarchy(shared_from_this());
 		m_priv->loggers->insert(LoggerMap::value_type(name, logger));
 
 		ProvisionNodeMap::iterator it2 = m_priv->provisionNodes->find(name);
@@ -450,6 +450,6 @@ bool Hierarchy::isConfigured()
 HierarchyPtr Hierarchy::create()
 {
 	HierarchyPtr ret( new Hierarchy() );
-	ret->m_priv->root->setHierarchy(ret.get());
+	ret->m_priv->root->setHierarchy(ret);
 	return ret;
 }

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -110,7 +110,7 @@ Logger::~Logger()
 void Logger::addAppender(const AppenderPtr newAppender)
 {
 	m_priv->aai->addAppender(newAppender);
-	if (auto rep = m_priv->repository)
+	if (auto rep = getLoggerRepository())
 	{
 		rep->fireAddAppenderEvent(this, newAppender.get());
 	}
@@ -130,7 +130,7 @@ void Logger::reconfigure( const std::vector<AppenderPtr>& appenders, bool additi
 	{
 		m_priv->aai->addAppender( *it );
 
-		if (auto rep = m_priv->repository)
+		if (auto rep = getLoggerRepository())
 		{
 			rep->fireAddAppenderEvent(this, it->get());
 		}
@@ -153,7 +153,7 @@ void Logger::callAppenders(const spi::LoggingEventPtr& event, Pool& p) const
 		}
 	}
 
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (writes == 0 && rep)
 	{
@@ -295,7 +295,7 @@ bool Logger::isAttached(const AppenderPtr appender) const
 
 bool Logger::isTraceEnabled() const
 {
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (!rep || rep->isDisabled(Level::TRACE_INT))
 	{
@@ -307,7 +307,7 @@ bool Logger::isTraceEnabled() const
 
 bool Logger::isDebugEnabled() const
 {
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (!rep || rep->isDisabled(Level::DEBUG_INT))
 	{
@@ -319,7 +319,7 @@ bool Logger::isDebugEnabled() const
 
 bool Logger::isEnabledFor(const LevelPtr& level1) const
 {
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (!rep || rep->isDisabled(level1->toInt()))
 	{
@@ -332,7 +332,7 @@ bool Logger::isEnabledFor(const LevelPtr& level1) const
 
 bool Logger::isInfoEnabled() const
 {
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (!rep || rep->isDisabled(Level::INFO_INT))
 	{
@@ -344,7 +344,7 @@ bool Logger::isInfoEnabled() const
 
 bool Logger::isErrorEnabled() const
 {
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (!rep || rep->isDisabled(Level::ERROR_INT))
 	{
@@ -356,7 +356,7 @@ bool Logger::isErrorEnabled() const
 
 bool Logger::isWarnEnabled() const
 {
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (!rep || rep->isDisabled(Level::WARN_INT))
 	{
@@ -368,7 +368,7 @@ bool Logger::isWarnEnabled() const
 
 bool Logger::isFatalEnabled() const
 {
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (!rep || rep->isDisabled(Level::FATAL_INT))
 	{
@@ -381,7 +381,9 @@ bool Logger::isFatalEnabled() const
 /*void Logger::l7dlog(const LevelPtr& level, const String& key,
                         const char* file, int line)
 {
-        if (repository == 0 || repository->isDisabled(level->level))
+	auto rep = getLoggerRepository();
+
+        if (!rep || rep->isDisabled(level->level))
         {
                 return;
         }
@@ -406,7 +408,7 @@ bool Logger::isFatalEnabled() const
 void Logger::l7dlog(const LevelPtr& level1, const LogString& key,
 	const LocationInfo& location, const std::vector<LogString>& params) const
 {
-	auto rep = m_priv->repository;
+	auto rep = getLoggerRepository();
 
 	if (!rep || rep->isDisabled(level1->toInt()))
 	{

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -80,7 +80,7 @@ struct Logger::LoggerPrivate
 
 
 	// Loggers need to know what Hierarchy they are in
-	log4cxx::spi::LoggerRepositoryWeakPtr repository;
+	log4cxx::spi::LoggerRepository* repository;
 
 	helpers::AppenderAttachableImplPtr aai;
 
@@ -109,12 +109,8 @@ Logger::~Logger()
 
 void Logger::addAppender(const AppenderPtr newAppender)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep;
-
 	m_priv->aai->addAppender(newAppender);
-	rep = m_priv->repository.lock();
-
-	if (rep)
+	if (auto rep = m_priv->repository)
 	{
 		rep->fireAddAppenderEvent(this, newAppender.get());
 	}
@@ -134,7 +130,7 @@ void Logger::reconfigure( const std::vector<AppenderPtr>& appenders, bool additi
 	{
 		m_priv->aai->addAppender( *it );
 
-		if (log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock())
+		if (auto rep = m_priv->repository)
 		{
 			rep->fireAddAppenderEvent(this, it->get());
 		}
@@ -157,7 +153,7 @@ void Logger::callAppenders(const spi::LoggingEventPtr& event, Pool& p) const
 		}
 	}
 
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (writes == 0 && rep)
 	{
@@ -219,7 +215,7 @@ AppenderPtr Logger::getAppender(const LogString& name1) const
 	return m_priv->aai->getAppender(name1);
 }
 
-const LevelPtr Logger::getEffectiveLevel() const
+const LevelPtr& Logger::getEffectiveLevel() const
 {
 	for (const Logger* l = this; l != 0; l = l->m_priv->parent.get())
 	{
@@ -235,7 +231,7 @@ const LevelPtr Logger::getEffectiveLevel() const
 #endif
 }
 
-LoggerRepositoryWeakPtr Logger::getLoggerRepository() const
+LoggerRepository* Logger::getLoggerRepository() const
 {
 	return m_priv->repository;
 }
@@ -287,7 +283,7 @@ LoggerPtr Logger::getParent() const
 	return m_priv->parent;
 }
 
-LevelPtr Logger::getLevel() const
+const LevelPtr& Logger::getLevel() const
 {
 	return m_priv->level;
 }
@@ -299,7 +295,7 @@ bool Logger::isAttached(const AppenderPtr appender) const
 
 bool Logger::isTraceEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (!rep || rep->isDisabled(Level::TRACE_INT))
 	{
@@ -311,7 +307,7 @@ bool Logger::isTraceEnabled() const
 
 bool Logger::isDebugEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (!rep || rep->isDisabled(Level::DEBUG_INT))
 	{
@@ -323,7 +319,7 @@ bool Logger::isDebugEnabled() const
 
 bool Logger::isEnabledFor(const LevelPtr& level1) const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (!rep || rep->isDisabled(level1->toInt()))
 	{
@@ -336,7 +332,7 @@ bool Logger::isEnabledFor(const LevelPtr& level1) const
 
 bool Logger::isInfoEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (!rep || rep->isDisabled(Level::INFO_INT))
 	{
@@ -348,7 +344,7 @@ bool Logger::isInfoEnabled() const
 
 bool Logger::isErrorEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (!rep || rep->isDisabled(Level::ERROR_INT))
 	{
@@ -360,7 +356,7 @@ bool Logger::isErrorEnabled() const
 
 bool Logger::isWarnEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (!rep || rep->isDisabled(Level::WARN_INT))
 	{
@@ -372,7 +368,7 @@ bool Logger::isWarnEnabled() const
 
 bool Logger::isFatalEnabled() const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (!rep || rep->isDisabled(Level::FATAL_INT))
 	{
@@ -410,7 +406,7 @@ bool Logger::isFatalEnabled() const
 void Logger::l7dlog(const LevelPtr& level1, const LogString& key,
 	const LocationInfo& location, const std::vector<LogString>& params) const
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = m_priv->repository.lock();
+	auto rep = m_priv->repository;
 
 	if (!rep || rep->isDisabled(level1->toInt()))
 	{
@@ -507,7 +503,7 @@ void Logger::setAdditivity(bool additive1)
 	m_priv->additive = additive1;
 }
 
-void Logger::setHierarchy(spi::LoggerRepositoryWeakPtr repository1)
+void Logger::setHierarchy(spi::LoggerRepository* repository1)
 {
 	m_priv->repository = repository1;
 }

--- a/src/main/cpp/rootlogger.cpp
+++ b/src/main/cpp/rootlogger.cpp
@@ -30,7 +30,7 @@ RootLogger::RootLogger(Pool& pool, const LevelPtr level1) :
 	setLevel(level1);
 }
 
-const LevelPtr RootLogger::getEffectiveLevel() const
+const LevelPtr& RootLogger::getEffectiveLevel() const
 {
 	return getLevel();
 }

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -577,13 +577,13 @@ class LOG4CXX_EXPORT Logger :
 
 		@throws RuntimeException if all levels are null in the hierarchy
 		*/
-		virtual const LevelPtr getEffectiveLevel() const;
+		virtual const LevelPtr& getEffectiveLevel() const;
 
 		/**
 		Return the the LoggerRepository where this
 		<code>Logger</code> is attached.
 		*/
-		log4cxx::spi::LoggerRepositoryWeakPtr getLoggerRepository() const;
+		log4cxx::spi::LoggerRepository* getLoggerRepository() const;
 
 
 		/**
@@ -633,7 +633,7 @@ class LOG4CXX_EXPORT Logger :
 
 		@return Level - the assigned Level, can be null.
 		*/
-		LevelPtr getLevel() const;
+		const LevelPtr& getLevel() const;
 
 		/**
 		* Retrieve a logger by name in current encoding.
@@ -1422,7 +1422,7 @@ class LOG4CXX_EXPORT Logger :
 		friend class Hierarchy;
 		/**
 		Only the Hierarchy class can set the hierarchy of a logger.*/
-		void setHierarchy(spi::LoggerRepositoryWeakPtr repository);
+		void setHierarchy(spi::LoggerRepository* repository);
 		void setParent(LoggerPtr parentLogger);
 
 	public:

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -583,7 +583,7 @@ class LOG4CXX_EXPORT Logger :
 		Return the the LoggerRepository where this
 		<code>Logger</code> is attached.
 		*/
-		log4cxx::spi::LoggerRepository* getLoggerRepository() const;
+		log4cxx::spi::LoggerRepositoryPtr getLoggerRepository() const;
 
 
 		/**
@@ -1422,8 +1422,10 @@ class LOG4CXX_EXPORT Logger :
 		friend class Hierarchy;
 		/**
 		Only the Hierarchy class can set the hierarchy of a logger.*/
-		void setHierarchy(spi::LoggerRepository* repository);
+		void removeHierarchy();
+		void setHierarchy(const spi::LoggerRepositoryPtr& repository);
 		void setParent(LoggerPtr parentLogger);
+		spi::LoggerRepository* getHierarchy() const;
 
 	public:
 		/**

--- a/src/main/include/log4cxx/spi/rootlogger.h
+++ b/src/main/include/log4cxx/spi/rootlogger.h
@@ -48,7 +48,7 @@ class LOG4CXX_EXPORT RootLogger : public Logger
 		Return the assigned level value without walking the logger
 		hierarchy.
 		*/
-		virtual const LevelPtr getEffectiveLevel() const;
+		virtual const LevelPtr& getEffectiveLevel() const;
 
 		/**
 		            Setting a null value to the level of the root logger may have catastrophic

--- a/src/test/cpp/customlogger/xlogger.cpp
+++ b/src/test/cpp/customlogger/xlogger.cpp
@@ -32,7 +32,7 @@ XFactoryPtr XLogger::factory = XFactoryPtr(new XFactory());
 
 void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = getLoggerRepository().lock();
+	auto rep = getLoggerRepository();
 
 	if (rep->isDisabled(XLevel::LETHAL_INT))
 	{
@@ -47,7 +47,7 @@ void XLogger::lethal(const LogString& message, const LocationInfo& locationInfo)
 
 void XLogger::lethal(const LogString& message)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = getLoggerRepository().lock();
+	auto rep = getLoggerRepository();
 
 	if (rep->isDisabled(XLevel::LETHAL_INT))
 	{
@@ -72,7 +72,7 @@ LoggerPtr XLogger::getLogger(const helpers::Class& clazz)
 
 void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = getLoggerRepository().lock();
+	auto rep = getLoggerRepository();
 
 	if (rep->isDisabled(XLevel::TRACE_INT))
 	{
@@ -87,7 +87,7 @@ void XLogger::trace(const LogString& message, const LocationInfo& locationInfo)
 
 void XLogger::trace(const LogString& message)
 {
-	log4cxx::spi::LoggerRepositoryPtr rep = getLoggerRepository().lock();
+	auto rep = getLoggerRepository();
 
 	if (rep->isDisabled(XLevel::TRACE_INT))
 	{

--- a/src/test/cpp/customlogger/xloggertestcase.cpp
+++ b/src/test/cpp/customlogger/xloggertestcase.cpp
@@ -52,7 +52,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		auto rep = logger->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/encodingtest.cpp
+++ b/src/test/cpp/encodingtest.cpp
@@ -58,7 +58,7 @@ public:
 	 */
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = Logger::getRootLogger()->getLoggerRepository().lock();
+		auto rep = Logger::getRootLogger()->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/hierarchythresholdtestcase.cpp
+++ b/src/test/cpp/hierarchythresholdtestcase.cpp
@@ -49,7 +49,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		auto rep = logger->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/l7dtestcase.cpp
+++ b/src/test/cpp/l7dtestcase.cpp
@@ -67,7 +67,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		auto rep = root->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/mdctestcase.cpp
+++ b/src/test/cpp/mdctestcase.cpp
@@ -42,7 +42,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = Logger::getRootLogger()->getLoggerRepository().lock();
+		auto rep = Logger::getRootLogger()->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/minimumtestcase.cpp
+++ b/src/test/cpp/minimumtestcase.cpp
@@ -53,7 +53,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		auto rep = root->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/ndctestcase.cpp
+++ b/src/test/cpp/ndctestcase.cpp
@@ -47,7 +47,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		auto rep = logger->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/patternlayouttest.cpp
+++ b/src/test/cpp/patternlayouttest.cpp
@@ -94,7 +94,7 @@ public:
 	void tearDown()
 	{
 		MDC::clear();
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		auto rep = root->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/varia/errorhandlertestcase.cpp
+++ b/src/test/cpp/varia/errorhandlertestcase.cpp
@@ -50,7 +50,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		auto rep = logger->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/varia/levelmatchfiltertestcase.cpp
+++ b/src/test/cpp/varia/levelmatchfiltertestcase.cpp
@@ -56,7 +56,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		auto rep = root->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/varia/levelrangefiltertestcase.cpp
+++ b/src/test/cpp/varia/levelrangefiltertestcase.cpp
@@ -56,7 +56,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		auto rep = root->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/xml/domtestcase.cpp
+++ b/src/test/cpp/xml/domtestcase.cpp
@@ -76,7 +76,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = root->getLoggerRepository().lock();
+		auto rep = root->getLoggerRepository();
 
 		if (rep)
 		{

--- a/src/test/cpp/xml/xmllayouttestcase.cpp
+++ b/src/test/cpp/xml/xmllayouttestcase.cpp
@@ -82,7 +82,7 @@ public:
 
 	void tearDown()
 	{
-		log4cxx::spi::LoggerRepositoryPtr rep = logger->getLoggerRepository().lock();
+		auto rep = logger->getLoggerRepository();
 
 		if (rep)
 		{


### PR DESCRIPTION
when using disabled logging statements.

throughputtests output after applying these changes:
```Benchmarking library only(no writing out):
**************************************************************
Benchmarking Single threaded: 1000000 messages
**************************************************************
Log4cxx NoFormat pattern: %m%n Elapsed: 4.866 secs 205,516/sec
Log4cxx DateOnly pattern: [%d] %m%n Elapsed: 4.875 secs 205,130/sec
Log4cxx DateClassLevel pattern: [%d] [%c] [%p] %m%n Elapsed: 4.898 secs 204,167/sec
Log4cxx Logging with FMT Elapsed: 2.437 secs 410,320/sec
Log4cxx Logging static string Elapsed: 3.409 secs 293,331/sec
Log4cxx Logging static string with FMT Elapsed: 2.759 secs 362,386/sec
Log4cxx Logging disabled debug Elapsed: 0.1323 secs 7,558,764/sec
Log4cxx Logging disabled trace Elapsed: 0.1336 secs 7,486,832/sec
Log4cxx Logging enabled debug Elapsed: 3.463 secs 288,802/sec
Log4cxx Logging enabled trace Elapsed: 3.463 secs 288,729/sec
**************************************************************
Benchmarking multithreaded threaded: 1000000 messages/thread, 4 threads
**************************************************************
Log4cxx Logging with FMT MT Elapsed: 4.469 secs 223,767/sec
Log4cxx Logging with FMT MT Elapsed: 4.512 secs 221,653/sec
Log4cxx Logging with FMT MT Elapsed: 4.578 secs 218,420/sec
Log4cxx Logging with FMT MT Elapsed: 4.583 secs 218,199/sec
**************************************************************
Benchmarking multithreaded disabled: 1000000 messages/thread, 4 threads
**************************************************************
Log4cxx Logging disabled MT Elapsed: 0.1453 secs 6,883,621/sec
Log4cxx Logging disabled MT Elapsed: 0.1457 secs 6,862,385/sec
Log4cxx Logging disabled MT Elapsed: 0.1458 secs 6,860,196/sec
Log4cxx Logging disabled MT Elapsed: 0.1459 secs 6,855,386/sec
```