### PR TITLE
Allow throughputtests to be built when LOGCHAR_IS_WCHAR is on

### DIFF
--- a/src/test/cpp/throughput/log4cxxbenchmarker.cpp
+++ b/src/test/cpp/throughput/log4cxxbenchmarker.cpp
@@ -71,14 +71,14 @@ log4cxxbenchmarker::log4cxxbenchmarker()
 
 log4cxx::LoggerPtr log4cxxbenchmarker::resetLogger()
 {
-	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( LOG4CXX_STR("bench_logger") );
 
 	logger->removeAllAppenders();
 	logger->setAdditivity( false );
 	logger->setLevel( log4cxx::Level::getInfo() );
 
 	log4cxx::PatternLayoutPtr pattern = std::make_shared<log4cxx::PatternLayout>();
-	pattern->setConversionPattern( "%m%n" );
+	pattern->setConversionPattern( LOG4CXX_STR("%m%n") );
 
 	log4cxx::NullWriterAppenderPtr nullWriter = std::make_shared<log4cxx::NullWriterAppender>();
 	nullWriter->setLayout( pattern );
@@ -88,9 +88,9 @@ log4cxx::LoggerPtr log4cxxbenchmarker::resetLogger()
 	return logger;
 }
 
-void log4cxxbenchmarker::logWithConversionPattern( std::string conversionPattern, int howmany )
+void log4cxxbenchmarker::logWithConversionPattern( const log4cxx::LogString& conversionPattern, int howmany )
 {
-	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( LOG4CXX_STR("bench_logger") );
 
 	logger->removeAllAppenders();
 	logger->setAdditivity( false );
@@ -106,7 +106,7 @@ void log4cxxbenchmarker::logWithConversionPattern( std::string conversionPattern
 
 	for ( int x = 0; x < howmany; x++ )
 	{
-		LOG4CXX_INFO( logger, "Hello logger: msg number " << x);
+		LOG4CXX_INFO( logger, LOG4CXX_STR("Hello logger: msg number ") << x);
 	}
 }
 
@@ -120,26 +120,27 @@ void log4cxxbenchmarker::logWithFMT(int howmany)
 	}
 }
 
-void log4cxxbenchmarker::logSetupMultithreaded()
+log4cxx::LoggerPtr log4cxxbenchmarker::logSetupMultithreaded()
 {
-	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( LOG4CXX_STR("bench_logger") );
 
 	logger->removeAllAppenders();
 	logger->setAdditivity( false );
 	logger->setLevel( log4cxx::Level::getInfo() );
 
 	log4cxx::PatternLayoutPtr pattern = std::make_shared<log4cxx::PatternLayout>();
-	pattern->setConversionPattern( "%m%n" );
+	pattern->setConversionPattern( LOG4CXX_STR("%m%n") );
 
 	log4cxx::NullWriterAppenderPtr nullWriter = std::make_shared<log4cxx::NullWriterAppender>();
 	nullWriter->setLayout( pattern );
 
 	logger->addAppender( nullWriter );
+	return logger;
 }
 
 void log4cxxbenchmarker::logWithFMTMultithreaded(int howmany)
 {
-	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( LOG4CXX_STR("bench_logger") );
 
 	for ( int x = 0; x < howmany; x++ )
 	{
@@ -149,11 +150,11 @@ void log4cxxbenchmarker::logWithFMTMultithreaded(int howmany)
 
 void log4cxxbenchmarker::logDisabledMultithreaded( int howmany )
 {
-	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( "bench_logger" );
+	log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger( LOG4CXX_STR("bench_logger") );
 
 	for ( int x = 0; x < howmany; x++ )
 	{
-		LOG4CXX_TRACE( logger, "Hello logger!  What is happening");
+		LOG4CXX_TRACE( logger, LOG4CXX_STR("Hello logger!  What is happening"));
 	}
 }
 
@@ -163,7 +164,7 @@ void log4cxxbenchmarker::logStaticString( int howmany )
 
 	for ( int x = 0; x < howmany; x++ )
 	{
-		LOG4CXX_INFO( logger, "This is a static string to see what happens");
+		LOG4CXX_INFO( logger, LOG4CXX_STR("This is a static string to see what happens"));
 	}
 }
 
@@ -183,7 +184,7 @@ void log4cxxbenchmarker::logDisabledDebug( int howmany )
 
 	for ( int x = 0; x < howmany; x++ )
 	{
-		LOG4CXX_DEBUG( logger, "This is a static string to see what happens");
+		LOG4CXX_DEBUG( logger, LOG4CXX_STR("This is a static string to see what happens"));
 	}
 }
 
@@ -193,7 +194,7 @@ void log4cxxbenchmarker::logDisabledTrace( int howmany )
 
 	for ( int x = 0; x < howmany; x++ )
 	{
-		LOG4CXX_TRACE( logger, "This is a static string to see what happens");
+		LOG4CXX_TRACE( logger, LOG4CXX_STR("This is a static string to see what happens"));
 	}
 }
 
@@ -204,7 +205,7 @@ void log4cxxbenchmarker::logEnabledDebug( int howmany )
 
 	for ( int x = 0; x < howmany; x++ )
 	{
-		LOG4CXX_DEBUG( logger, "This is a static string to see what happens");
+		LOG4CXX_DEBUG( logger, LOG4CXX_STR("This is a static string to see what happens"));
 	}
 }
 
@@ -215,6 +216,6 @@ void log4cxxbenchmarker::logEnabledTrace( int howmany )
 
 	for ( int x = 0; x < howmany; x++ )
 	{
-		LOG4CXX_DEBUG( logger, "This is a static string to see what happens");
+		LOG4CXX_DEBUG( logger, LOG4CXX_STR("This is a static string to see what happens"));
 	}
 }

--- a/src/test/cpp/throughput/log4cxxbenchmarker.h
+++ b/src/test/cpp/throughput/log4cxxbenchmarker.h
@@ -36,7 +36,7 @@ class log4cxxbenchmarker
 		 *
 		 * @param conversionPattern The conversion pattern used, as passed to the PatternLayout
 		 */
-		static void logWithConversionPattern( std::string conversionPattern, int howmany );
+		static void logWithConversionPattern( const log4cxx::LogString& conversionPattern, int howmany );
 
 		/**
 		 * Log with the LOG4CXX_INFO_FMT macro to see how long it takes.
@@ -49,7 +49,7 @@ class log4cxxbenchmarker
 		/**
 		 * Reset logger for multithreaded setup.
 		 */
-		static void logSetupMultithreaded();
+		static log4cxx::LoggerPtr logSetupMultithreaded();
 
 		/**
 		 * Log with the LOG4CXX_INFO_FMT macro to see how long it takes(multithreaded).

--- a/src/test/cpp/throughput/throughput-main.cpp
+++ b/src/test/cpp/throughput/throughput-main.cpp
@@ -19,6 +19,7 @@
 #include <log4cxx/xml/domconfigurator.h>
 #include <log4cxx/patternlayout.h>
 #include <log4cxx/consoleappender.h>
+#include <log4cxx/helpers/transcoder.h>
 
 #include <string>
 #include <thread>
@@ -28,11 +29,13 @@
 #include <fmt/ostream.h>
 
 #include "log4cxxbenchmarker.h"
+using log4cxx::LogString;
 
 static log4cxx::LoggerPtr console = log4cxx::Logger::getLogger( "console" );
 static std::vector<uint64_t> results;
+static std::mutex results_mutex;
 
-static void benchmark_function( std::string name, void (*fn)(int), int howmany )
+static void benchmark_function( const std::string& name, void (*fn)(int), int howmany )
 {
 	using std::chrono::duration;
 	using std::chrono::duration_cast;
@@ -43,17 +46,17 @@ static void benchmark_function( std::string name, void (*fn)(int), int howmany )
 	auto delta = high_resolution_clock::now() - start;
 	auto delta_d = duration_cast<duration<double>>(delta).count();
 
+	std::unique_lock<std::mutex> lk(results_mutex);
+	results.push_back( uint64_t(howmany / delta_d) );
 	LOG4CXX_INFO_FMT( console, "Log4cxx {} Elapsed: {:.4} secs {:L}/sec",
 		name,
 		delta_d,
-		int(howmany / delta_d));
-
-	results.push_back( howmany / delta_d );
+		results.back());
 }
 
-static void benchmark_conversion_pattern( std::string name,
-	std::string conversion_pattern,
-	void(*fn)(std::string, int),
+static void benchmark_conversion_pattern( const std::string& name,
+	const std::string& conversion_pattern,
+	void(*fn)(const LogString&, int),
 	int howmany)
 {
 	using std::chrono::duration;
@@ -61,24 +64,25 @@ static void benchmark_conversion_pattern( std::string name,
 	using std::chrono::high_resolution_clock;
 
 	auto start = high_resolution_clock::now();
-	fn(conversion_pattern, howmany);
+	LOG4CXX_DECODE_CHAR(conversion_patternLS, conversion_pattern);
+	fn(conversion_patternLS, howmany);
 	auto delta = high_resolution_clock::now() - start;
 	auto delta_d = duration_cast<duration<double>>(delta).count();
 
+	std::unique_lock<std::mutex> lk(results_mutex);
+	results.push_back( uint64_t(howmany / delta_d) );
 	LOG4CXX_INFO_FMT( console, "Log4cxx {} pattern: {} Elapsed: {:.4} secs {:L}/sec",
 		name,
 		conversion_pattern,
 		delta_d,
-		int(howmany / delta_d) );
-
-	results.push_back( howmany / delta_d );
+		results.back());
 }
 
 static void bench_log4cxx_single_threaded(int iters)
 {
-	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO(console, LOG4CXX_STR("**************************************************************"));
 	LOG4CXX_INFO_FMT(console, "Benchmarking Single threaded: {} messages", iters );
-	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO(console, LOG4CXX_STR("**************************************************************"));
 
 	benchmark_conversion_pattern( "NoFormat", "%m%n", &log4cxxbenchmarker::logWithConversionPattern, iters );
 	benchmark_conversion_pattern( "DateOnly", "[%d] %m%n", &log4cxxbenchmarker::logWithConversionPattern, iters );
@@ -95,13 +99,13 @@ static void bench_log4cxx_single_threaded(int iters)
 
 static void bench_log4cxx_multi_threaded(size_t threads, int iters)
 {
-	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO(console, LOG4CXX_STR("**************************************************************"));
 	LOG4CXX_INFO_FMT(console, "Benchmarking multithreaded threaded: {} messages/thread, {} threads", iters, threads );
-	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO(console, LOG4CXX_STR("**************************************************************"));
 
 	std::vector<std::thread> runningThreads;
 
-	log4cxxbenchmarker::logSetupMultithreaded();
+	auto logger = log4cxxbenchmarker::logSetupMultithreaded();
 
 	for ( size_t x = 0; x < threads; x++ )
 	{
@@ -119,13 +123,13 @@ static void bench_log4cxx_multi_threaded(size_t threads, int iters)
 
 static void bench_log4cxx_multi_threaded_disabled(size_t threads, int iters)
 {
-	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO(console, LOG4CXX_STR("**************************************************************"));
 	LOG4CXX_INFO_FMT(console, "Benchmarking multithreaded disabled: {} messages/thread, {} threads", iters, threads );
-	LOG4CXX_INFO(console, "**************************************************************");
+	LOG4CXX_INFO(console, LOG4CXX_STR("**************************************************************"));
 
 	std::vector<std::thread> runningThreads;
 
-	log4cxxbenchmarker::logSetupMultithreaded();
+	auto logger = log4cxxbenchmarker::logSetupMultithreaded();
 
 	for ( size_t x = 0; x < threads; x++ )
 	{
@@ -152,11 +156,11 @@ int main(int argc, char* argv[])
 
 	console->setAdditivity( false );
 	log4cxx::PatternLayoutPtr pattern( new log4cxx::PatternLayout() );
-	pattern->setConversionPattern( "%m%n" );
+	pattern->setConversionPattern( LOG4CXX_STR("%m%n") );
 
 	log4cxx::ConsoleAppenderPtr consoleWriter( new log4cxx::ConsoleAppender );
 	consoleWriter->setLayout( pattern );
-	consoleWriter->setTarget( "System.out" );
+	consoleWriter->setTarget( LOG4CXX_STR("System.out") );
 	log4cxx::helpers::Pool p;
 	consoleWriter->activateOptions(p);
 


### PR DESCRIPTION
This change is as per master and also include serialization of additions to results.