### PR TITLE
[LOG4CXX-548] Reproducible Doxygen doc generation

### DIFF
--- a/src/site/CMakeLists.txt
+++ b/src/site/CMakeLists.txt
@@ -1,15 +1,18 @@
 option(BUILD_SITE "Build log4cxx website" OFF)
 if(BUILD_SITE)
-    find_package( Doxygen REQUIRED dot )
-    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/doxy/Doxyfile.in
-	            ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile )
+	file(RELATIVE_PATH LOG4CXX_REL_BIN_TO_SRC_DIR "${LOG4CXX_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
 
-    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/markdown/download.md.in
-	            ${CMAKE_CURRENT_BINARY_DIR}/markdown/download.md )
+	find_package( Doxygen REQUIRED dot )
+	
+	configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/doxy/Doxyfile.in
+		${CMAKE_CURRENT_BINARY_DIR}/Doxyfile )
 
-    add_custom_target( doc_doxygen ALL
-	COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-	COMMENT "Generate site with Doxygen"
-	VERBATIM )
+	configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/markdown/download.md.in
+		${CMAKE_CURRENT_BINARY_DIR}/markdown/download.md )
+
+	add_custom_target( doc_doxygen ALL
+		COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+		WORKING_DIRECTORY ${LOG4CXX_SOURCE_DIR}
+		COMMENT "Generate site with Doxygen"
+		VERBATIM )
 endif()

--- a/src/site/doxy/Doxyfile.in
+++ b/src/site/doxy/Doxyfile.in
@@ -73,7 +73,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       =
+OUTPUT_DIRECTORY       = ${LOG4CXX_REL_BIN_TO_SRC_DIR}
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -718,7 +718,7 @@ FILE_VERSION_FILTER    =
 # DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
 # tag is left empty.
 
-LAYOUT_FILE            = ${LOG4CXX_SOURCE_DIR}/src/site/doxy/DoxygenLayout.xml
+LAYOUT_FILE            = src/site/doxy/DoxygenLayout.xml
 
 # The CITE_BIB_FILES tag can be used to specify one or more bib files containing
 # the reference definitions. This must be a list of .bib files. The .bib
@@ -805,9 +805,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ${LOG4CXX_SOURCE_DIR}/src/main/include \
-                         ${LOG4CXX_SOURCE_DIR}/src/site/markdown \
-                         ${CMAKE_BINARY_DIR}/src/site/markdown
+INPUT                  = src/main/include \
+                         src/site/markdown \
+                         ${LOG4CXX_REL_BIN_TO_SRC_DIR}/markdown
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -943,7 +943,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = ${LOG4CXX_SOURCE_DIR}/src/site/images
+IMAGE_PATH             = src/site/images
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program
@@ -999,7 +999,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ${LOG4CXX_SOURCE_DIR}/src/site/markdown/index.md
+USE_MDFILE_AS_MAINPAGE = src/site/markdown/index.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1184,7 +1184,7 @@ HTML_HEADER            =
 # that doxygen normally uses.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_FOOTER            = ${LOG4CXX_SOURCE_DIR}/src/site/doxy/footer.html
+HTML_FOOTER            = src/site/doxy/footer.html
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading style
 # sheet that is used by each HTML page. It can be used to fine-tune the look of
@@ -1209,7 +1209,7 @@ HTML_STYLESHEET        =
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  = ${LOG4CXX_SOURCE_DIR}/src/site/doxy/customdoxygen.css
+HTML_EXTRA_STYLESHEET  = src/site/doxy/customdoxygen.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note


### PR DESCRIPTION
The way the doxygen documenation is generated with CMake, it is unfortunatly
not reproducible (as in https://reproducible-builds.org/).

This is a regression as log4cxx has been previously reproducible (at least on
Debian –
https://tests.reproducible-builds.org/debian/rb-pkg/experimental/amd64/log4cxx.html)

The problem is that doxygen's configure has several absolute paths, which it
then bakes into the generated documentation, for example in this snippt, the
bold part dependent on the build path:

<div class="contents">
<div class="textblock"><p><a class="anchor" id="md__build_log4cxx_0_12_1_src_site_markdown_index"></a></p>