### PR TITLE
Prevent static initialization order faults by using local statics

### DIFF
--- a/src/main/cpp/level.cpp
+++ b/src/main/cpp/level.cpp
@@ -30,89 +30,52 @@ using namespace log4cxx::helpers;
 
 IMPLEMENT_LOG4CXX_OBJECT_WITH_CUSTOM_CLASS(Level, LevelClass)
 
-volatile bool Level::initialized = false;
-std::mutex Level::initMutex;
-LevelPtr Level::allLevel;
-LevelPtr Level::fatalLevel;
-LevelPtr Level::errorLevel;
-LevelPtr Level::warnLevel;
-LevelPtr Level::infoLevel;
-LevelPtr Level::debugLevel;
-LevelPtr Level::traceLevel;
-LevelPtr Level::offLevel;
-
-void Level::initializeLevels()
+const LevelPtr& Level::getOff()
 {
-	if ( initialized )
-	{
-		return;
-	}
-
-	std::unique_lock<std::mutex> lock(initMutex);
-
-	if ( initialized )
-	{
-		return;
-	}
-
-	allLevel   = LevelPtr(new Level(Level::ALL_INT, LOG4CXX_STR("ALL"), 7));
-	fatalLevel = LevelPtr(new Level(Level::FATAL_INT, LOG4CXX_STR("FATAL"), 0));
-	errorLevel = LevelPtr(new Level(Level::ERROR_INT, LOG4CXX_STR("ERROR"), 3));
-	warnLevel  = LevelPtr(new Level(Level::WARN_INT, LOG4CXX_STR("WARN"), 4));
-	infoLevel  = LevelPtr(new Level(Level::INFO_INT, LOG4CXX_STR("INFO"), 6));
-	debugLevel = LevelPtr(new Level(Level::DEBUG_INT, LOG4CXX_STR("DEBUG"), 7));
-	traceLevel = LevelPtr(new Level(Level::TRACE_INT, LOG4CXX_STR("TRACE"), 7));
-	offLevel   = LevelPtr(new Level(Level::OFF_INT, LOG4CXX_STR("OFF"), 0));
-
-	initialized = true;
-}
-
-LevelPtr Level::getOff()
-{
-	initializeLevels();
+	static LevelPtr offLevel(new Level(Level::OFF_INT, LOG4CXX_STR("OFF"), 0));
 	return offLevel;
 }
 
-LevelPtr Level::getFatal()
+const LevelPtr& Level::getFatal()
 {
-	initializeLevels();
+	static LevelPtr fatalLevel(new Level(Level::FATAL_INT, LOG4CXX_STR("FATAL"), 0));
 	return fatalLevel;
 }
 
-LevelPtr Level::getError()
+const LevelPtr& Level::getError()
 {
-	initializeLevels();
+	static LevelPtr errorLevel(new Level(Level::ERROR_INT, LOG4CXX_STR("ERROR"), 3));
 	return errorLevel;
 }
 
-LevelPtr Level::getWarn()
+const LevelPtr& Level::getWarn()
 {
-	initializeLevels();
+	static LevelPtr warnLevel(new Level(Level::WARN_INT, LOG4CXX_STR("WARN"), 4));
 	return warnLevel;
 }
 
-LevelPtr Level::getInfo()
+const LevelPtr& Level::getInfo()
 {
-	initializeLevels();
+	static LevelPtr infoLevel(new Level(Level::INFO_INT, LOG4CXX_STR("INFO"), 6));
 	return infoLevel;
 }
 
-LevelPtr Level::getDebug()
+const LevelPtr& Level::getDebug()
 {
-	initializeLevels();
+	static LevelPtr debugLevel(new Level(Level::DEBUG_INT, LOG4CXX_STR("DEBUG"), 7));
 	return debugLevel;
 }
 
-LevelPtr Level::getTrace()
+const LevelPtr& Level::getTrace()
 {
-	initializeLevels();
+	static LevelPtr traceLevel(new Level(Level::TRACE_INT, LOG4CXX_STR("TRACE"), 7));
 	return traceLevel;
 }
 
 
-LevelPtr Level::getAll()
+const LevelPtr& Level::getAll()
 {
-	initializeLevels();
+	static LevelPtr allLevel(new Level(Level::ALL_INT, LOG4CXX_STR("ALL"), 7));
 	return allLevel;
 }
 
@@ -126,7 +89,7 @@ Level::Level(int level1,
 }
 
 
-LevelPtr Level::toLevelLS(const LogString& sArg)
+const LevelPtr& Level::toLevelLS(const LogString& sArg)
 {
 	return toLevelLS(sArg, Level::getDebug());
 }
@@ -137,12 +100,12 @@ LogString Level::toString() const
 }
 
 
-LevelPtr Level::toLevel(int val)
+const LevelPtr& Level::toLevel(int val)
 {
 	return toLevel(val, Level::getDebug());
 }
 
-LevelPtr Level::toLevel(int val, const LevelPtr& defaultLevel)
+const LevelPtr& Level::toLevel(int val, const LevelPtr& defaultLevel)
 {
 	switch (val)
 	{
@@ -175,12 +138,12 @@ LevelPtr Level::toLevel(int val, const LevelPtr& defaultLevel)
 	}
 }
 
-LevelPtr Level::toLevel(const std::string& sArg)
+const LevelPtr& Level::toLevel(const std::string& sArg)
 {
 	return toLevel(sArg, Level::getDebug());
 }
 
-LevelPtr Level::toLevel(const std::string& sArg, const LevelPtr& defaultLevel)
+const LevelPtr& Level::toLevel(const std::string& sArg, const LevelPtr& defaultLevel)
 {
 	LOG4CXX_DECODE_CHAR(s, sArg);
 	return toLevelLS(s, defaultLevel);
@@ -192,12 +155,12 @@ void Level::toString(std::string& dst) const
 }
 
 #if LOG4CXX_WCHAR_T_API
-LevelPtr Level::toLevel(const std::wstring& sArg)
+const LevelPtr& Level::toLevel(const std::wstring& sArg)
 {
 	return toLevel(sArg, Level::getDebug());
 }
 
-LevelPtr Level::toLevel(const std::wstring& sArg, const LevelPtr& defaultLevel)
+const LevelPtr& Level::toLevel(const std::wstring& sArg, const LevelPtr& defaultLevel)
 {
 	LOG4CXX_DECODE_WCHAR(s, sArg);
 	return toLevelLS(s, defaultLevel);
@@ -211,12 +174,12 @@ void Level::toString(std::wstring& dst) const
 #endif
 
 #if LOG4CXX_UNICHAR_API
-LevelPtr Level::toLevel(const std::basic_string<UniChar>& sArg)
+const LevelPtr& Level::toLevel(const std::basic_string<UniChar>& sArg)
 {
 	return toLevel(sArg, Level::getDebug());
 }
 
-LevelPtr Level::toLevel(const std::basic_string<UniChar>& sArg, const LevelPtr& defaultLevel)
+const LevelPtr& Level::toLevel(const std::basic_string<UniChar>& sArg, const LevelPtr& defaultLevel)
 {
 	LOG4CXX_DECODE_UNICHAR(s, sArg);
 	return toLevelLS(s, defaultLevel);
@@ -230,12 +193,12 @@ void Level::toString(std::basic_string<UniChar>& dst) const
 #endif
 
 #if LOG4CXX_CFSTRING_API
-LevelPtr Level::toLevel(const CFStringRef& sArg)
+const LevelPtr& Level::toLevel(const CFStringRef& sArg)
 {
 	return toLevel(sArg, Level::getDebug());
 }
 
-LevelPtr Level::toLevel(const CFStringRef& sArg, const LevelPtr& defaultLevel)
+const LevelPtr& Level::toLevel(const CFStringRef& sArg, const LevelPtr& defaultLevel)
 {
 	LogString s;
 	Transcoder::decode(sArg, s);
@@ -249,7 +212,7 @@ void Level::toString(CFStringRef& dst) const
 #endif
 
 
-LevelPtr Level::toLevelLS(const LogString& sArg, const LevelPtr& defaultLevel)
+const LevelPtr& Level::toLevelLS(const LogString& sArg, const LevelPtr& defaultLevel)
 {
 	const LogString trimmed(StringHelper::trim(sArg));
 	const size_t len = trimmed.length();

--- a/src/main/cpp/level.cpp
+++ b/src/main/cpp/level.cpp
@@ -30,50 +30,50 @@ using namespace log4cxx::helpers;
 
 IMPLEMENT_LOG4CXX_OBJECT_WITH_CUSTOM_CLASS(Level, LevelClass)
 
-const LevelPtr& Level::getOff()
+LevelPtr Level::getOff()
 {
 	static LevelPtr offLevel(new Level(Level::OFF_INT, LOG4CXX_STR("OFF"), 0));
 	return offLevel;
 }
 
-const LevelPtr& Level::getFatal()
+LevelPtr Level::getFatal()
 {
 	static LevelPtr fatalLevel(new Level(Level::FATAL_INT, LOG4CXX_STR("FATAL"), 0));
 	return fatalLevel;
 }
 
-const LevelPtr& Level::getError()
+LevelPtr Level::getError()
 {
 	static LevelPtr errorLevel(new Level(Level::ERROR_INT, LOG4CXX_STR("ERROR"), 3));
 	return errorLevel;
 }
 
-const LevelPtr& Level::getWarn()
+LevelPtr Level::getWarn()
 {
 	static LevelPtr warnLevel(new Level(Level::WARN_INT, LOG4CXX_STR("WARN"), 4));
 	return warnLevel;
 }
 
-const LevelPtr& Level::getInfo()
+LevelPtr Level::getInfo()
 {
 	static LevelPtr infoLevel(new Level(Level::INFO_INT, LOG4CXX_STR("INFO"), 6));
 	return infoLevel;
 }
 
-const LevelPtr& Level::getDebug()
+LevelPtr Level::getDebug()
 {
 	static LevelPtr debugLevel(new Level(Level::DEBUG_INT, LOG4CXX_STR("DEBUG"), 7));
 	return debugLevel;
 }
 
-const LevelPtr& Level::getTrace()
+LevelPtr Level::getTrace()
 {
 	static LevelPtr traceLevel(new Level(Level::TRACE_INT, LOG4CXX_STR("TRACE"), 7));
 	return traceLevel;
 }
 
 
-const LevelPtr& Level::getAll()
+LevelPtr Level::getAll()
 {
 	static LevelPtr allLevel(new Level(Level::ALL_INT, LOG4CXX_STR("ALL"), 7));
 	return allLevel;
@@ -89,7 +89,7 @@ Level::Level(int level1,
 }
 
 
-const LevelPtr& Level::toLevelLS(const LogString& sArg)
+LevelPtr Level::toLevelLS(const LogString& sArg)
 {
 	return toLevelLS(sArg, Level::getDebug());
 }
@@ -100,12 +100,12 @@ LogString Level::toString() const
 }
 
 
-const LevelPtr& Level::toLevel(int val)
+LevelPtr Level::toLevel(int val)
 {
 	return toLevel(val, Level::getDebug());
 }
 
-const LevelPtr& Level::toLevel(int val, const LevelPtr& defaultLevel)
+LevelPtr Level::toLevel(int val, const LevelPtr& defaultLevel)
 {
 	switch (val)
 	{
@@ -138,12 +138,12 @@ const LevelPtr& Level::toLevel(int val, const LevelPtr& defaultLevel)
 	}
 }
 
-const LevelPtr& Level::toLevel(const std::string& sArg)
+LevelPtr Level::toLevel(const std::string& sArg)
 {
 	return toLevel(sArg, Level::getDebug());
 }
 
-const LevelPtr& Level::toLevel(const std::string& sArg, const LevelPtr& defaultLevel)
+LevelPtr Level::toLevel(const std::string& sArg, const LevelPtr& defaultLevel)
 {
 	LOG4CXX_DECODE_CHAR(s, sArg);
 	return toLevelLS(s, defaultLevel);
@@ -155,12 +155,12 @@ void Level::toString(std::string& dst) const
 }
 
 #if LOG4CXX_WCHAR_T_API
-const LevelPtr& Level::toLevel(const std::wstring& sArg)
+LevelPtr Level::toLevel(const std::wstring& sArg)
 {
 	return toLevel(sArg, Level::getDebug());
 }
 
-const LevelPtr& Level::toLevel(const std::wstring& sArg, const LevelPtr& defaultLevel)
+LevelPtr Level::toLevel(const std::wstring& sArg, const LevelPtr& defaultLevel)
 {
 	LOG4CXX_DECODE_WCHAR(s, sArg);
 	return toLevelLS(s, defaultLevel);
@@ -174,12 +174,12 @@ void Level::toString(std::wstring& dst) const
 #endif
 
 #if LOG4CXX_UNICHAR_API
-const LevelPtr& Level::toLevel(const std::basic_string<UniChar>& sArg)
+LevelPtr Level::toLevel(const std::basic_string<UniChar>& sArg)
 {
 	return toLevel(sArg, Level::getDebug());
 }
 
-const LevelPtr& Level::toLevel(const std::basic_string<UniChar>& sArg, const LevelPtr& defaultLevel)
+LevelPtr Level::toLevel(const std::basic_string<UniChar>& sArg, const LevelPtr& defaultLevel)
 {
 	LOG4CXX_DECODE_UNICHAR(s, sArg);
 	return toLevelLS(s, defaultLevel);
@@ -193,12 +193,12 @@ void Level::toString(std::basic_string<UniChar>& dst) const
 #endif
 
 #if LOG4CXX_CFSTRING_API
-const LevelPtr& Level::toLevel(const CFStringRef& sArg)
+LevelPtr Level::toLevel(const CFStringRef& sArg)
 {
 	return toLevel(sArg, Level::getDebug());
 }
 
-const LevelPtr& Level::toLevel(const CFStringRef& sArg, const LevelPtr& defaultLevel)
+LevelPtr Level::toLevel(const CFStringRef& sArg, const LevelPtr& defaultLevel)
 {
 	LogString s;
 	Transcoder::decode(sArg, s);
@@ -212,7 +212,7 @@ void Level::toString(CFStringRef& dst) const
 #endif
 
 
-const LevelPtr& Level::toLevelLS(const LogString& sArg, const LevelPtr& defaultLevel)
+LevelPtr Level::toLevelLS(const LogString& sArg, const LevelPtr& defaultLevel)
 {
 	const LogString trimmed(StringHelper::trim(sArg));
 	const size_t len = trimmed.length();
@@ -276,11 +276,11 @@ const LevelPtr& Level::toLevelLS(const LogString& sArg, const LevelPtr& defaultL
 
 bool Level::equals(const LevelPtr& level1) const
 {
-	return (this->level == level1->level);
+	return level1 && this->level == level1->level;
 }
 
 bool Level::isGreaterOrEqual(const LevelPtr& level1) const
 {
-	return this->level >= level1->level;
+	return level1 && this->level >= level1->level;
 }
 

--- a/src/main/include/log4cxx/level.h
+++ b/src/main/include/log4cxx/level.h
@@ -91,7 +91,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static LevelPtr toLevel(const std::string& sArg);
+		static const LevelPtr& toLevel(const std::string& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -100,7 +100,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static LevelPtr toLevel(const std::string& sArg,
+		static const LevelPtr& toLevel(const std::string& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		 *  Get the name of the level in the current encoding.
@@ -114,7 +114,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static LevelPtr toLevel(const std::wstring& sArg);
+		static const LevelPtr& toLevel(const std::wstring& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -123,7 +123,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static LevelPtr toLevel(const std::wstring& sArg,
+		static const LevelPtr& toLevel(const std::wstring& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		 *  Get the name of the level.
@@ -137,7 +137,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static LevelPtr toLevel(const std::basic_string<UniChar>& sArg);
+		static const LevelPtr& toLevel(const std::basic_string<UniChar>& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -146,7 +146,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static LevelPtr toLevel(const std::basic_string<UniChar>& sArg,
+		static const LevelPtr& toLevel(const std::basic_string<UniChar>& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		 *  Get the name of the level.
@@ -160,7 +160,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static LevelPtr toLevel(const CFStringRef& sArg);
+		static const LevelPtr& toLevel(const CFStringRef& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -169,7 +169,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static LevelPtr toLevel(const CFStringRef& sArg,
+		static const LevelPtr& toLevel(const CFStringRef& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		 *  Get the name of the level.
@@ -182,7 +182,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static LevelPtr toLevelLS(const LogString& sArg);
+		static const LevelPtr& toLevelLS(const LogString& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -191,7 +191,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static LevelPtr toLevelLS(const LogString& sArg,
+		static const LevelPtr& toLevelLS(const LogString& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		Returns the string representation of this level.
@@ -203,13 +203,13 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		Convert an integer passed as argument to a level. If the
 		conversion fails, then this method returns DEBUG.
 		*/
-		static LevelPtr toLevel(int val);
+		static const LevelPtr& toLevel(int val);
 
 		/**
 		Convert an integer passed as argument to a level. If the
 		conversion fails, then this method returns the specified default.
 		*/
-		static LevelPtr toLevel(int val, const LevelPtr& defaultLevel);
+		static const LevelPtr& toLevel(int val, const LevelPtr& defaultLevel);
 
 		enum
 		{
@@ -224,15 +224,14 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		};
 
 
-		static void initializeLevels();
-		static LevelPtr getAll();
-		static LevelPtr getFatal();
-		static LevelPtr getError();
-		static LevelPtr getWarn();
-		static LevelPtr getInfo();
-		static LevelPtr getDebug();
-		static LevelPtr getTrace();
-		static LevelPtr getOff();
+		static const LevelPtr& getAll();
+		static const LevelPtr& getFatal();
+		static const LevelPtr& getError();
+		static const LevelPtr& getWarn();
+		static const LevelPtr& getInfo();
+		static const LevelPtr& getDebug();
+		static const LevelPtr& getTrace();
+		static const LevelPtr& getOff();
 
 
 		/**
@@ -278,18 +277,6 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		{
 			return level;
 		}
-
-	private:
-		static volatile bool initialized;
-		static std::mutex initMutex;
-		static LevelPtr allLevel;
-		static LevelPtr fatalLevel;
-		static LevelPtr errorLevel;
-		static LevelPtr warnLevel;
-		static LevelPtr infoLevel;
-		static LevelPtr debugLevel;
-		static LevelPtr traceLevel;
-		static LevelPtr offLevel;
 
 		int level;
 		LogString name;

--- a/src/main/include/log4cxx/level.h
+++ b/src/main/include/log4cxx/level.h
@@ -91,7 +91,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static const LevelPtr& toLevel(const std::string& sArg);
+		static LevelPtr toLevel(const std::string& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -100,7 +100,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static const LevelPtr& toLevel(const std::string& sArg,
+		static LevelPtr toLevel(const std::string& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		 *  Get the name of the level in the current encoding.
@@ -114,7 +114,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static const LevelPtr& toLevel(const std::wstring& sArg);
+		static LevelPtr toLevel(const std::wstring& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -123,7 +123,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static const LevelPtr& toLevel(const std::wstring& sArg,
+		static LevelPtr toLevel(const std::wstring& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		 *  Get the name of the level.
@@ -137,7 +137,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static const LevelPtr& toLevel(const std::basic_string<UniChar>& sArg);
+		static LevelPtr toLevel(const std::basic_string<UniChar>& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -146,7 +146,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static const LevelPtr& toLevel(const std::basic_string<UniChar>& sArg,
+		static LevelPtr toLevel(const std::basic_string<UniChar>& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		 *  Get the name of the level.
@@ -160,7 +160,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static const LevelPtr& toLevel(const CFStringRef& sArg);
+		static LevelPtr toLevel(const CFStringRef& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -169,7 +169,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static const LevelPtr& toLevel(const CFStringRef& sArg,
+		static LevelPtr toLevel(const CFStringRef& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		 *  Get the name of the level.
@@ -182,7 +182,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		conversion fails, then this method returns DEBUG.
 		* @param sArg level name.
 		*/
-		static const LevelPtr& toLevelLS(const LogString& sArg);
+		static LevelPtr toLevelLS(const LogString& sArg);
 		/**
 		Convert the string passed as argument to a level. If the
 		conversion fails, then this method returns the value of
@@ -191,7 +191,7 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		* @param defaultLevel level to return if no match.
 		* @return
 		*/
-		static const LevelPtr& toLevelLS(const LogString& sArg,
+		static LevelPtr toLevelLS(const LogString& sArg,
 			const LevelPtr& defaultLevel);
 		/**
 		Returns the string representation of this level.
@@ -203,13 +203,13 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		Convert an integer passed as argument to a level. If the
 		conversion fails, then this method returns DEBUG.
 		*/
-		static const LevelPtr& toLevel(int val);
+		static LevelPtr toLevel(int val);
 
 		/**
 		Convert an integer passed as argument to a level. If the
 		conversion fails, then this method returns the specified default.
 		*/
-		static const LevelPtr& toLevel(int val, const LevelPtr& defaultLevel);
+		static LevelPtr toLevel(int val, const LevelPtr& defaultLevel);
 
 		enum
 		{
@@ -224,14 +224,14 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 		};
 
 
-		static const LevelPtr& getAll();
-		static const LevelPtr& getFatal();
-		static const LevelPtr& getError();
-		static const LevelPtr& getWarn();
-		static const LevelPtr& getInfo();
-		static const LevelPtr& getDebug();
-		static const LevelPtr& getTrace();
-		static const LevelPtr& getOff();
+		static LevelPtr getAll();
+		static LevelPtr getFatal();
+		static LevelPtr getError();
+		static LevelPtr getWarn();
+		static LevelPtr getInfo();
+		static LevelPtr getDebug();
+		static LevelPtr getTrace();
+		static LevelPtr getOff();
 
 
 		/**


### PR DESCRIPTION
This PR is further work towards fixing LOGCXX-532.

I believe localstatics are thread safe since C++11