### PR TITLE
boost-fallback: only check for boost if really needed

### DIFF
--- a/src/cmake/boost-fallback/boost-fallback.cmake
+++ b/src/cmake/boost-fallback/boost-fallback.cmake
@@ -55,6 +55,8 @@ try_compile(STD_SHARED_PTR_FOUND "${CMAKE_BINARY_DIR}/boost-fallback-compile-tes
 try_compile(STD_ATOMIC_FOUND "${CMAKE_BINARY_DIR}/boost-fallback-compile-tests"
     "${CMAKE_CURRENT_LIST_DIR}/test-stdatomic.cpp")
 
+# search for boost only in case needed for legacy c++ standard < c++17
+if(NOT ${STD_THREAD_FOUND} OR NOT ${STD_MUTEX_FOUND} OR NOT ${STD_SHARED_MUTEX_FOUND} OR NOT ${STD_SHARED_PTR_FOUND} OR NOT ${STD_ATOMIC_FOUND})
 find_package(Boost COMPONENTS thread)
 if( ${Boost_FOUND} )
     try_compile(Boost_SHARED_PTR_FOUND "${CMAKE_BINARY_DIR}/boost-fallback-compile-tests"
@@ -67,6 +69,7 @@ if( ${Boost_FOUND} )
     try_compile(Boost_ATOMIC_FOUND "${CMAKE_BINARY_DIR}/boost-fallback-compile-tests"
         "${CMAKE_CURRENT_LIST_DIR}/test-boostatomic.cpp")
 endif( ${Boost_FOUND} )
+endif()
 
 # Link the target with the appropriate boost libraries(if required)
 function(boostfallback_link target)


### PR DESCRIPTION
- only check for boost if really needed (in case of legacy c++ standard < c++17)

Signed-off-by: Peter Seiderer <ps.report@gmx.net>
---
Notes:

  - fixes the following buildroot configure/compile failure in case
    a only partly available boost is detected (but not needed as a
    c++17 capable compiler is available):

      -- Found Boost: .../host/x86_64-buildroot-linux-uclibc/sysroot/usr/include (found version "1.78.0") found components: thread chrono missing components: date_time atomic
      CMake Error at .../build/log4cxx-0.12.0/boost-fallback-compile-tests/CMakeFiles/CMakeTmp/CMakeLists.txt:19 (add_executable):
        Target "cmTC_aac37" links to target "Boost::date_time" but the target was
        not found.  Perhaps a find_package() call is missing for an IMPORTED
        target, or an ALIAS target is missing?

      CMake Error at .../build/log4cxx-0.12.0/boost-fallback-compile-tests/CMakeFiles/CMakeTmp/CMakeLists.txt:19 (add_executable):
        Target "cmTC_aac37" links to target "Boost::atomic" but the target was not
        found.  Perhaps a find_package() call is missing for an IMPORTED target, or
        an ALIAS target is missing?

    See http://lists.busybox.net/pipermail/buildroot/2022-January/635042.html