### PR TITLE
Adds multiple process support to the BufferedWriter class

### DIFF
--- a/src/main/include/log4cxx/helpers/bufferedwriter.h
+++ b/src/main/include/log4cxx/helpers/bufferedwriter.h
@@ -57,6 +57,13 @@ class LOG4CXX_EXPORT BufferedWriter : public Writer
 		virtual void flush(Pool& p);
 		virtual void write(const LogString& str, Pool& p);
 
+#ifdef LOG4CXX_MULTI_PROCESS
+		OutputStreamPtr getOutPutStreamPtr()
+		{
+			return out->getOutPutStreamPtr();
+		}
+#endif
+
 	private:
 		BufferedWriter(const BufferedWriter&);
 		BufferedWriter& operator=(const BufferedWriter&);


### PR DESCRIPTION
This pull request adds multiple process support to the BufferedWriter class.

Without this patch, enabling I/O buffering for a file appender generates an error at application startup when log4cxx has been compiled with the multi-process flag set (-DCMAKE_CXX_FLAGS="-DLOG4CXX_MULTI_PROCESS") :

> terminate called after throwing an instance of 'std::logic_error'
>   what():  getOutPutStreamPtr must be implemented in the derived class that you are using
> Aborted (core dumped)

Example of configuration:
```
log4j.appender.State=RollingFileAppender
log4j.appender.State.layout=PatternLayout
log4j.appender.State.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS Z} %t [%p] %m%n
log4j.appender.State.file=${logdir}/state.log
log4j.appender.State.bufferedIO=true
log4j.appender.State.bufferSize=8192
...
```