### PR TITLE
LOGCXX-527: mock the clock for tests

### DIFF
--- a/src/examples/cpp/delayedloop.cpp
+++ b/src/examples/cpp/delayedloop.cpp
@@ -20,6 +20,7 @@
 #include <log4cxx/propertyconfigurator.h>
 #include <apr_general.h>
 #include <apr_time.h>
+#include <apr.h>
 #include <iostream>
 #include <log4cxx/stream.h>
 #include <exception>

--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -26,6 +26,7 @@
 #include <apr_thread_mutex.h>
 #include <apr_thread_proc.h>
 #include <log4cxx/helpers/filewatchdog.h>
+#include <log4cxx/helpers/date.h>
 
 using namespace log4cxx::helpers;
 using namespace log4cxx;
@@ -46,7 +47,7 @@ APRInitializer::APRInitializer() : p(0), startTime(0), tlsKey(0)
 	apr_initialize();
 	apr_pool_create(&p, NULL);
 	apr_atomic_init(p);
-	startTime = apr_time_now();
+	startTime = Date::currentTime();
 #if APR_HAS_THREADS
 	apr_status_t stat = apr_threadkey_private_create(&tlsKey, tlsDestruct, p);
 	assert(stat == APR_SUCCESS);

--- a/src/main/cpp/date.cpp
+++ b/src/main/cpp/date.cpp
@@ -17,7 +17,7 @@
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/date.h>
 
-#include <apr_time.h>
+#define LOG4CXX_USEC_PER_SEC 1000000LL
 #ifndef INT64_C
 	#define INT64_C(x) x ## LL
 #endif
@@ -27,7 +27,10 @@ using namespace log4cxx::helpers;
 
 IMPLEMENT_LOG4CXX_OBJECT(Date)
 
-Date::Date() : time(apr_time_now())
+
+Date::GetCurrentTimeFn Date::getCurrentTimeFn = Date::getCurrentTimeStd;
+
+Date::Date() : time(getCurrentTimeFn())
 {
 }
 
@@ -41,16 +44,28 @@ Date::~Date()
 
 log4cxx_time_t Date::getMicrosecondsPerDay()
 {
-	return APR_INT64_C(86400000000);
+	return 86400000000ull;
 }
 
 log4cxx_time_t Date::getMicrosecondsPerSecond()
 {
-	return APR_USEC_PER_SEC;
+	return LOG4CXX_USEC_PER_SEC;
 }
 
 
 log4cxx_time_t Date::getNextSecond() const
 {
-	return ((time / APR_USEC_PER_SEC) + 1) * APR_USEC_PER_SEC;
+	return ((time / LOG4CXX_USEC_PER_SEC) + 1) * LOG4CXX_USEC_PER_SEC;
+}
+
+void Date::setGetCurrentTimeFunction(GetCurrentTimeFn fn){
+	getCurrentTimeFn = fn;
+}
+
+log4cxx_time_t Date::currentTime(){
+	return getCurrentTimeFn();
+}
+
+log4cxx_time_t Date::getCurrentTimeStd(){
+	return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -18,7 +18,6 @@
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/filewatchdog.h>
 #include <log4cxx/helpers/loglog.h>
-#include <apr_time.h>
 #include <apr_thread_proc.h>
 #include <apr_atomic.h>
 #include <log4cxx/helpers/transcoder.h>

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -38,6 +38,7 @@
 #include <log4cxx/defaultconfigurator.h>
 #include <log4cxx/spi/rootlogger.h>
 #include <mutex>
+#include <apr.h>
 #include "assert.h"
 
 

--- a/src/main/cpp/htmllayout.cpp
+++ b/src/main/cpp/htmllayout.cpp
@@ -24,8 +24,8 @@
 #include <log4cxx/helpers/iso8601dateformat.h>
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/transcoder.h>
+#include <log4cxx/helpers/date.h>
 
-#include <apr_time.h>
 #include <apr_strings.h>
 #include <string.h>
 
@@ -185,7 +185,7 @@ void HTMLLayout::appendHeader(LogString& output, Pool& p)
 	output.append(LOG4CXX_EOL);
 	output.append(LOG4CXX_STR("Log session start time "));
 
-	dateFormat.format(output, apr_time_now(), p);
+	dateFormat.format(output, Date::currentTime(), p);
 
 	output.append(LOG4CXX_STR("<br>"));
 	output.append(LOG4CXX_EOL);

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -29,7 +29,6 @@
 #include <log4cxx/helpers/threadspecificdata.h>
 #include <log4cxx/helpers/transcoder.h>
 
-#include <apr_time.h>
 #include <apr_portable.h>
 #include <apr_strings.h>
 #include <log4cxx/helpers/stringhelper.h>
@@ -37,6 +36,7 @@
 #include <log4cxx/helpers/bytebuffer.h>
 #include <log4cxx/logger.h>
 #include <log4cxx/private/log4cxx_private.h>
+#include <log4cxx/helpers/date.h>
 
 using namespace log4cxx;
 using namespace log4cxx::spi;
@@ -75,7 +75,7 @@ LoggingEvent::LoggingEvent(
 	ndcLookupRequired(true),
 	mdcCopyLookupRequired(true),
 	message(message1),
-	timeStamp(apr_time_now()),
+	timeStamp(Date::currentTime()),
 	locationInfo(locationInfo1),
 	threadName(getCurrentThreadName()),
 	threadUserName(getCurrentThreadUserName())

--- a/src/main/cpp/propertyconfigurator.cpp
+++ b/src/main/cpp/propertyconfigurator.cpp
@@ -40,6 +40,7 @@
 
 #define LOG4CXX 1
 #include <log4cxx/helpers/aprinitializer.h>
+#include <apr.h>
 
 
 using namespace log4cxx;

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -34,12 +34,6 @@
 #include <log4cxx/rolling/rollingfileappenderskeleton.h>
 #include<iostream>
 
-#ifndef INT64_C
-	#define INT64_C(x) x ## LL
-#endif
-
-#include <apr_time.h>
-
 using namespace log4cxx;
 using namespace log4cxx::rolling;
 using namespace log4cxx::helpers;
@@ -202,9 +196,8 @@ void TimeBasedRollingPolicy::activateOptions(log4cxx::helpers::Pool& pool)
 		throw IllegalStateException();
 	}
 
-	apr_time_t n = apr_time_now();
 	LogString buf;
-	ObjectPtr obj(new Date(n));
+	ObjectPtr obj(new Date());
 	formatFileName(obj, buf, pool);
 	lastFileName = buf;
 
@@ -268,8 +261,9 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::initialize(
 	const   bool        append,
 	Pool&       pool)
 {
-	apr_time_t n = apr_time_now();
-	nextCheck = ((n / APR_USEC_PER_SEC) + 1) * APR_USEC_PER_SEC;
+	Date now;
+	log4cxx_time_t n = now.getTime();
+	nextCheck = now.getNextSecond();
 
 	File currentFile(currentActiveFile);
 
@@ -299,8 +293,9 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::rollover(
 	const   bool        append,
 	Pool&       pool)
 {
-	apr_time_t n = apr_time_now();
-	nextCheck = ((n / APR_USEC_PER_SEC) + 1) * APR_USEC_PER_SEC;
+	Date now;
+	log4cxx_time_t n = now.getTime();
+	nextCheck = now.getNextSecond();
 
 	LogString buf;
 	ObjectPtr obj(new Date(n));
@@ -419,6 +414,6 @@ bool TimeBasedRollingPolicy::isTriggeringEvent(
 
 	return ((apr_time_now()) > nextCheck) || (!bAlreadyInitialized);
 #else
-	return apr_time_now() > nextCheck;
+	return Date::currentTime() > nextCheck;
 #endif
 }

--- a/src/main/include/log4cxx/helpers/aprinitializer.h
+++ b/src/main/include/log4cxx/helpers/aprinitializer.h
@@ -23,13 +23,14 @@
 #endif
 
 #include <list>
+#include <log4cxx/helpers/date.h>
 
 extern "C" {
 	typedef struct apr_thread_mutex_t apr_thread_mutex_t;
 	typedef struct apr_threadkey_t apr_threadkey_t;
+	struct apr_pool_t;
 }
 
-#include <apr_time.h>
 #include <mutex>
 
 namespace log4cxx
@@ -61,7 +62,7 @@ class APRInitializer
 		apr_pool_t* p;
 		std::mutex mutex;
 		std::list<FileWatchdog*> watchdogs;
-		apr_time_t startTime;
+		log4cxx_time_t startTime;
 		apr_threadkey_t* tlsKey;
 		static APRInitializer& getInstance();
 

--- a/src/main/include/log4cxx/helpers/date.h
+++ b/src/main/include/log4cxx/helpers/date.h
@@ -20,7 +20,7 @@
 
 #include <log4cxx/helpers/object.h>
 #include <log4cxx/log4cxx.h>
-
+#include <functional>
 
 namespace log4cxx
 {
@@ -35,6 +35,13 @@ namespace helpers
 class LOG4CXX_EXPORT Date : public Object
 {
 		const log4cxx_time_t time;
+
+		/**
+		 * A function that will return the current time(in microseconds) when called
+		 */
+		typedef std::function<log4cxx_time_t()> GetCurrentTimeFn;
+
+		static log4cxx_time_t getCurrentTimeStd();
 
 	public:
 		DECLARE_LOG4CXX_OBJECT(Date)
@@ -59,6 +66,19 @@ class LOG4CXX_EXPORT Date : public Object
 
 		static log4cxx_time_t getMicrosecondsPerDay();
 		static log4cxx_time_t getMicrosecondsPerSecond();
+
+		static log4cxx_time_t currentTime();
+
+		static GetCurrentTimeFn getCurrentTimeFn;
+
+		/**
+		 * Set the function that is used to get the current time.
+		 * This is used only for testing purposes and should never be called
+		 * under normal circumstances.
+		 *
+		 * @param fn
+		 */
+		static void setGetCurrentTimeFunction(GetCurrentTimeFn fn);
 
 };
 

--- a/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
+++ b/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
@@ -25,6 +25,7 @@
 #include <log4cxx/writerappender.h>
 #include <log4cxx/helpers/outputstream.h>
 #include <apr_mmap.h>
+#include <functional>
 
 #if defined(_MSC_VER)
 	#pragma warning ( push )


### PR DESCRIPTION
Mock the clock for unit tests to make them more reliable and configurable.
This also cleans up some APR calls to make us less dependent on APR and
more on standard C++ features