### PR TITLE
Stop all file watch dog instances in LogManager::shutdown().

### DIFF
--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -59,9 +59,10 @@ APRInitializer::~APRInitializer()
 {
 	stopWatchDogs();
 	isDestructed = true;
-#ifndef APR_HAS_THREADS
+#if APR_HAS_THREADS
 	std::unique_lock<std::mutex> lock(mutex);
 	apr_threadkey_private_delete(tlsKey);
+#else
 	apr_terminate();
 #endif
 }

--- a/src/main/cpp/defaultconfigurator.cpp
+++ b/src/main/cpp/defaultconfigurator.cpp
@@ -67,7 +67,8 @@ void DefaultConfigurator::configure(LoggerRepositoryPtr repository)
 		OptionConverter::selectAndConfigure(
 			configuration,
 			configuratorClassName,
-			repo);
+			repo,
+			getConfigurationWatchDelay());
 	}
 	else
 	{
@@ -110,6 +111,17 @@ const LogString DefaultConfigurator::getConfigurationFileName()
 		OptionConverter::getSystemProperty(LOG4CXX_DEFAULT_CONFIGURATION_KEY,
 			log4jConfigurationOptionStr));
 	return configurationOptionStr;
+}
+
+
+int DefaultConfigurator::getConfigurationWatchDelay()
+{
+	static const LogString LOG4CXX_DEFAULT_CONFIGURATION_WATCH_KEY(LOG4CXX_STR("LOG4CXX_CONFIGURATION_WATCH_SECONDS"));
+	LogString optionStr = OptionConverter::getSystemProperty(LOG4CXX_DEFAULT_CONFIGURATION_WATCH_KEY, LogString());
+	int milliseconds = 0;
+	if (!optionStr.empty())
+		milliseconds = stoi(optionStr) * 1000;
+	return milliseconds;
 }
 
 

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -24,6 +24,7 @@
 #include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/helpers/exception.h>
 #include <log4cxx/helpers/threadutility.h>
+#include <log4cxx/helpers/stringhelper.h>
 #include <functional>
 
 using namespace log4cxx;
@@ -103,6 +104,12 @@ void FileWatchdog::checkAndConfigure()
 
 void FileWatchdog::run()
 {
+	LogString msg(LOG4CXX_STR("Checking ["));
+	msg += m_priv->file.getPath();
+	msg += LOG4CXX_STR("] at ");
+	StringHelper::toString(m_priv->delay, m_priv->pool, msg);
+	msg += LOG4CXX_STR(" ms interval");
+	LogLog::debug(msg);
 
 	while (m_priv->interrupted != 0xFFFF)
 	{
@@ -113,6 +120,10 @@ void FileWatchdog::run()
 		checkAndConfigure();
 	}
 
+	LogString msg2(LOG4CXX_STR("Stop checking ["));
+	msg2 += m_priv->file.getPath();
+	msg2 += LOG4CXX_STR("]");
+	LogLog::debug(msg2);
 }
 
 void FileWatchdog::start()

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -107,7 +107,7 @@ void FileWatchdog::run()
 	LogString msg(LOG4CXX_STR("Checking ["));
 	msg += m_priv->file.getPath();
 	msg += LOG4CXX_STR("] at ");
-	StringHelper::toString(m_priv->delay, m_priv->pool, msg);
+	StringHelper::toString((int)m_priv->delay, m_priv->pool, msg);
 	msg += LOG4CXX_STR(" ms interval");
 	LogLog::debug(msg);
 

--- a/src/main/cpp/logmanager.cpp
+++ b/src/main/cpp/logmanager.cpp
@@ -200,6 +200,7 @@ LoggerList LogManager::getCurrentLoggers()
 
 void LogManager::shutdown()
 {
+	APRInitializer::unregisterAll();
 	LoggerRepositoryPtr repPtr = getLoggerRepository();
 	getLoggerRepository()->shutdown();
 }

--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -36,9 +36,12 @@
 #include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/file.h>
 #include <log4cxx/xml/domconfigurator.h>
-#include <log4cxx/helpers/aprinitializer.h>
 #include <log4cxx/logmanager.h>
 #include <apr_general.h>
+#if !defined(LOG4CXX)
+	#define LOG4CXX 1
+#endif
+#include <log4cxx/helpers/aprinitializer.h>
 
 #if APR_HAS_THREADS
 #include <log4cxx/helpers/filewatchdog.h>

--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -36,6 +36,38 @@
 #include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/file.h>
 #include <log4cxx/xml/domconfigurator.h>
+#include <log4cxx/helpers/aprinitializer.h>
+#include <log4cxx/logmanager.h>
+#include <apr_general.h>
+
+#if APR_HAS_THREADS
+#include <log4cxx/helpers/filewatchdog.h>
+namespace log4cxx
+{
+
+class ConfiguratorWatchdog  : public helpers::FileWatchdog
+{
+	spi::ConfiguratorPtr m_config;
+	public:
+    ConfiguratorWatchdog(const spi::ConfiguratorPtr& config, const File& filename)
+        : helpers::FileWatchdog(filename)
+        , m_config(config)
+    {
+    }
+
+    /**
+    Call PropertyConfigurator#doConfigure(const String& configFileName,
+    const spi::LoggerRepositoryPtr& hierarchy) with the
+    <code>filename</code> to reconfigure log4cxx.
+    */
+    void doOnChange()
+    {
+        m_config->doConfigure(file(), LogManager::getLoggerRepository());
+    }
+};
+
+}
+#endif
 
 using namespace log4cxx;
 using namespace log4cxx::helpers;
@@ -375,7 +407,7 @@ ObjectPtr OptionConverter::instantiateByClassName(const LogString& className,
 }
 
 void OptionConverter::selectAndConfigure(const File& configFileName,
-	const LogString& _clazz, spi::LoggerRepositoryPtr hierarchy)
+	const LogString& _clazz, spi::LoggerRepositoryPtr hierarchy, int delay)
 {
 	ConfiguratorPtr configurator;
 	LogString clazz = _clazz;
@@ -410,5 +442,15 @@ void OptionConverter::selectAndConfigure(const File& configFileName,
 		configurator = ConfiguratorPtr(new PropertyConfigurator());
 	}
 
-	configurator->doConfigure(configFileName, hierarchy);
+#if APR_HAS_THREADS
+	if (0 < delay)
+	{
+		auto dog = new ConfiguratorWatchdog(configurator, configFileName);
+		APRInitializer::registerCleanup(dog);
+		dog->setDelay(delay);
+		dog->start();
+	}
+	else
+#endif
+		configurator->doConfigure(configFileName, hierarchy);
 }

--- a/src/main/include/log4cxx/defaultconfigurator.h
+++ b/src/main/include/log4cxx/defaultconfigurator.h
@@ -47,7 +47,7 @@ class LOG4CXX_EXPORT DefaultConfigurator
 	private:
 		static const LogString getConfigurationFileName();
 		static const LogString getConfiguratorClass();
-		static int DefaultConfigurator::getConfigurationWatchDelay();
+		static int getConfigurationWatchDelay();
 
 
 

--- a/src/main/include/log4cxx/defaultconfigurator.h
+++ b/src/main/include/log4cxx/defaultconfigurator.h
@@ -47,6 +47,7 @@ class LOG4CXX_EXPORT DefaultConfigurator
 	private:
 		static const LogString getConfigurationFileName();
 		static const LogString getConfiguratorClass();
+		static int DefaultConfigurator::getConfigurationWatchDelay();
 
 
 

--- a/src/main/include/log4cxx/helpers/aprinitializer.h
+++ b/src/main/include/log4cxx/helpers/aprinitializer.h
@@ -55,6 +55,7 @@ class APRInitializer
 		 */
 		static void registerCleanup(FileWatchdog* watchdog);
 		static void unregisterCleanup(FileWatchdog* watchdog);
+		static void unregisterAll();
 		/**
 		 *  Store a single instance type ObjectPtr for deletion prior to termination
 		 */
@@ -78,6 +79,7 @@ class APRInitializer
 	private: // Modifiers
 		void addObject(size_t key, const ObjectPtr& pObject);
 		const ObjectPtr& findOrAddObject(size_t key, std::function<ObjectPtr()> creator);
+		void stopWatchDogs();
 	private: // Attributes
 		apr_pool_t* p;
 		std::mutex mutex;

--- a/src/main/include/log4cxx/helpers/optionconverter.h
+++ b/src/main/include/log4cxx/helpers/optionconverter.h
@@ -153,9 +153,12 @@ class LOG4CXX_EXPORT OptionConverter
 		filename pointed to by <code>configFileName</code> ends in '.xml',
 		in which case DOMConfigurator is used.
 		@param hierarchy The Hierarchy to act on.
+		@param delay If greater than zero, the milliseconds to sleep
+		between checking if <code>configFileName</code> has been modified
+		and needs to be reloaded.
 		*/
 		static void selectAndConfigure(const File& configFileName,
-			const LogString& clazz, spi::LoggerRepositoryPtr hierarchy);
+			const LogString& clazz, spi::LoggerRepositoryPtr hierarchy, int delay = 0);
 };
 }  // namespace helpers
 } // namespace log4cxx

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -124,7 +124,7 @@ foreach(testName IN LISTS ALL_LOG4CXX_TESTS)
             )
         elseif(${testName} STREQUAL autoconfiguretestcase)
             set_tests_properties(autoconfiguretestcase PROPERTIES
-                ENVIRONMENT "LOG4CXX_CONFIGURATION=${UNIT_TEST_WORKING_DIR}/input/autoConfigureTest.properties;PATH=${ESCAPED_PATH}"
+                ENVIRONMENT "LOG4CXX_CONFIGURATION=${UNIT_TEST_WORKING_DIR}/input/autoConfigureTest.properties;LOG4CXX_CONFIGURATION_WATCH_SECONDS=1;PATH=${ESCAPED_PATH}"
             )
         else()
            set_tests_properties(${testName} PROPERTIES

--- a/src/test/cpp/autoconfiguretestcase.cpp
+++ b/src/test/cpp/autoconfiguretestcase.cpp
@@ -47,6 +47,7 @@ LOGUNIT_CLASS(AutoConfigureTestCase)
 	LOGUNIT_TEST_SUITE(AutoConfigureTestCase);
 	LOGUNIT_TEST_THREADS(test1, 4);
 	LOGUNIT_TEST(test2);
+	LOGUNIT_TEST(stop);
 	LOGUNIT_TEST_SUITE_END();
 #ifdef _DEBUG
 	struct Fixture
@@ -72,6 +73,11 @@ public:
 		auto debugLogger = Logger::getLogger(LOG4CXX_STR("AutoConfig.test2"));
 		LOGUNIT_ASSERT(debugLogger);
 		LOGUNIT_ASSERT(debugLogger->isDebugEnabled());
+	}
+
+	void stop()
+	{
+		LogManager::shutdown();
 	}
 };
 


### PR DESCRIPTION
This PR aims to address LOG4CXX-451.

Also included is support for automatic start of a watchdog when using automatic configuration by providing a positive integer value in the LOG4CXX_CONFIGURATION_WATCH_SECONDS environment variable.