### PR TITLE
APR termination must be after destruction of all log4cxx objects

### DIFF
--- a/src/main/cpp/appenderattachableimpl.cpp
+++ b/src/main/cpp/appenderattachableimpl.cpp
@@ -68,24 +68,11 @@ int AppenderAttachableImpl::appendLoopOnAppenders(
 	const spi::LoggingEventPtr& event,
 	Pool& p)
 {
-
-	AppenderList allAppenders;
 	int numberAppended = 0;
+	std::unique_lock<std::mutex> lock( m_priv->m_mutex );
+	for (auto appender : m_priv->appenderList)
 	{
-		// There are occasions where we want to modify our list of appenders
-		// while we are iterating over them.  For example, if one of the
-		// appenders fails, we may want to swap it out for a new one.
-		// So, make a local copy of the appenders that we want to iterate over
-		// before actually iterating over them.
-		std::unique_lock<std::mutex> lock( m_priv->m_mutex );
-		allAppenders = m_priv->appenderList;
-	}
-
-	for (AppenderList::iterator it = allAppenders.begin();
-		it != allAppenders.end();
-		it++)
-	{
-		(*it)->doAppend(event, p);
+		appender->doAppend(event, p);
 		numberAppended++;
 	}
 

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -214,7 +214,6 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 	//
 	if (!priv->dispatcher.joinable() || priv->bufferSize <= 0)
 	{
-		std::unique_lock<std::mutex> lock(priv->appenders->getMutex());
 		priv->appenders->appendLoopOnAppenders(event, p);
 		return;
 	}
@@ -316,7 +315,6 @@ void AsyncAppender::close()
 	}
 
 	{
-		std::unique_lock<std::mutex> lock(priv->appenders->getMutex());
 		AppenderList appenderList = priv->appenders->getAllAppenders();
 
 		for (AppenderList::iterator iter = appenderList.begin();

--- a/src/main/cpp/asyncappender_nonblocking.cpp
+++ b/src/main/cpp/asyncappender_nonblocking.cpp
@@ -28,7 +28,6 @@
 #include <apr_thread_mutex.h>
 #include <apr_thread_cond.h>
 #include <log4cxx/helpers/condition.h>
-#include <log4cxx/helpers/synchronized.h>
 #include <log4cxx/helpers/stringhelper.h>
 #include <apr_atomic.h>
 #include <log4cxx/helpers/optionconverter.h>
@@ -78,7 +77,6 @@ void AsyncAppender::releaseRef() const
 
 void AsyncAppender::addAppender(const AppenderPtr& newAppender)
 {
-	synchronized sync(appenders->getMutex());
 	appenders->addAppender(newAppender);
 }
 
@@ -124,7 +122,6 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 	//
 	if (!dispatcher.isAlive() || bufferSize <= 0)
 	{
-		synchronized sync(appenders->getMutex());
 		appenders->appendLoopOnAppenders(event, p);
 		return;
 	}
@@ -196,7 +193,6 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 		}
 	}
 #else
-	synchronized sync(appenders->getMutex());
 	appenders->appendLoopOnAppenders(event, p);
 #endif
 }
@@ -227,7 +223,6 @@ void AsyncAppender::close()
 #endif
 
 	{
-		synchronized sync(appenders->getMutex());
 		AppenderList appenderList = appenders->getAllAppenders();
 
 		for (AppenderList::iterator iter = appenderList.begin();
@@ -241,19 +236,16 @@ void AsyncAppender::close()
 
 AppenderList AsyncAppender::getAllAppenders() const
 {
-	synchronized sync(appenders->getMutex());
 	return appenders->getAllAppenders();
 }
 
 AppenderPtr AsyncAppender::getAppender(const LogString& n) const
 {
-	synchronized sync(appenders->getMutex());
 	return appenders->getAppender(n);
 }
 
 bool AsyncAppender::isAttached(const AppenderPtr& appender) const
 {
-	synchronized sync(appenders->getMutex());
 	return appenders->isAttached(appender);
 }
 
@@ -264,19 +256,16 @@ bool AsyncAppender::requiresLayout() const
 
 void AsyncAppender::removeAllAppenders()
 {
-	synchronized sync(appenders->getMutex());
 	appenders->removeAllAppenders();
 }
 
 void AsyncAppender::removeAppender(const AppenderPtr& appender)
 {
-	synchronized sync(appenders->getMutex());
 	appenders->removeAppender(appender);
 }
 
 void AsyncAppender::removeAppender(const LogString& n)
 {
-	synchronized sync(appenders->getMutex());
 	appenders->removeAppender(n);
 }
 
@@ -429,7 +418,6 @@ void* LOG4CXX_THREAD_FUNC AsyncAppender::dispatch(apr_thread_t* /*thread*/, void
 				iter != events.end();
 				iter++)
 			{
-				synchronized sync(pThis->appenders->getMutex());
 				pThis->appenders->appendLoopOnAppenders(*iter, p);
 			}
 		}

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -96,9 +96,13 @@ Hierarchy::~Hierarchy()
 	for (auto& item : m_priv->loggers)
 	{
 		if (auto& pLogger = item.second)
+		{
 			pLogger->removeHierarchy();
+			pLogger->removeAllAppenders();
+		}
 	}
 	m_priv->root->removeHierarchy();
+	m_priv->root->removeAllAppenders();
 }
 
 void Hierarchy::addHierarchyEventListener(const spi::HierarchyEventListenerPtr& listener)

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -101,7 +101,7 @@ void Logger::addAppender(const AppenderPtr newAppender)
 	m_priv->aai.addAppender(newAppender);
 	if (auto rep = getHierarchy())
 	{
-		m_priv->repositoryRaw->fireAddAppenderEvent(this, newAppender.get());
+		rep->fireAddAppenderEvent(this, newAppender.get());
 	}
 }
 
@@ -119,7 +119,7 @@ void Logger::reconfigure( const std::vector<AppenderPtr>& appenders, bool additi
 
 		if (auto rep = getHierarchy())
 		{
-			m_priv->repositoryRaw->fireAddAppenderEvent(this, it->get());
+			rep->fireAddAppenderEvent(this, it->get());
 		}
 	}
 }
@@ -144,7 +144,7 @@ void Logger::callAppenders(const spi::LoggingEventPtr& event, Pool& p) const
 
 	if (writes == 0 && rep)
 	{
-		m_priv->repositoryRaw->emitNoAppenderWarning(const_cast<Logger*>(this));
+		rep->emitNoAppenderWarning(const_cast<Logger*>(this));
 	}
 }
 
@@ -162,6 +162,8 @@ void Logger::closeNestedAppenders()
 void Logger::forcedLog(const LevelPtr& level1, const std::string& message,
 	const LocationInfo& location) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LOG4CXX_DECODE_CHAR(msg, message);
 	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg, location));
@@ -171,6 +173,8 @@ void Logger::forcedLog(const LevelPtr& level1, const std::string& message,
 
 void Logger::forcedLog(const LevelPtr& level1, const std::string& message) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LOG4CXX_DECODE_CHAR(msg, message);
 	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg,
@@ -181,6 +185,8 @@ void Logger::forcedLog(const LevelPtr& level1, const std::string& message) const
 void Logger::forcedLogLS(const LevelPtr& level1, const LogString& message,
 	const LocationInfo& location) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, message, location));
 	callAppenders(event, p);

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -500,6 +500,7 @@ void Logger::removeAppender(const LogString& name1)
 
 void Logger::removeHierarchy()
 {
+	std::unique_lock<std::mutex> lock( m_priv->aai.getMutex() ); // Wait for appenders to complete
 	m_priv->repository.reset();
 	m_priv->repositoryRaw = 0;
 }

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -500,7 +500,6 @@ void Logger::removeAppender(const LogString& name1)
 
 void Logger::removeHierarchy()
 {
-	std::unique_lock<std::mutex> lock( m_priv->aai.getMutex() ); // Wait for appenders to complete
 	m_priv->repository.reset();
 	m_priv->repositoryRaw = 0;
 }

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -701,6 +701,8 @@ LoggerPtr Logger::getLoggerLS(const LogString& name)
 void Logger::forcedLog(const LevelPtr& level1, const std::wstring& message,
 	const LocationInfo& location) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LOG4CXX_DECODE_WCHAR(msg, message);
 	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg, location));
@@ -709,6 +711,8 @@ void Logger::forcedLog(const LevelPtr& level1, const std::wstring& message,
 
 void Logger::forcedLog(const LevelPtr& level1, const std::wstring& message) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LOG4CXX_DECODE_WCHAR(msg, message);
 	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg,
@@ -852,6 +856,8 @@ void Logger::warn(const std::wstring& msg) const
 void Logger::forcedLog(const LevelPtr& level1, const std::basic_string<UniChar>& message,
 	const LocationInfo& location) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LOG4CXX_DECODE_UNICHAR(msg, message);
 	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg, location));
@@ -860,6 +866,8 @@ void Logger::forcedLog(const LevelPtr& level1, const std::basic_string<UniChar>&
 
 void Logger::forcedLog(const LevelPtr& level1, const std::basic_string<UniChar>& message) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LOG4CXX_DECODE_UNICHAR(msg, message);
 	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg,
@@ -1000,6 +1008,8 @@ void Logger::warn(const std::basic_string<UniChar>& msg) const
 void Logger::forcedLog(const LevelPtr& level1, const CFStringRef& message,
 	const LocationInfo& location) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LOG4CXX_DECODE_CFSTRING(msg, message);
 	LoggingEventPtr event(new LoggingEvent(name, level1, msg, location));
@@ -1008,6 +1018,8 @@ void Logger::forcedLog(const LevelPtr& level1, const CFStringRef& message,
 
 void Logger::forcedLog(const LevelPtr& level1, const CFStringRef& message) const
 {
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
 	Pool p;
 	LOG4CXX_DECODE_CFSTRING(msg, message);
 	LoggingEventPtr event(new LoggingEvent(name, level1, msg,

--- a/src/main/include/log4cxx/helpers/appenderattachableimpl.h
+++ b/src/main/include/log4cxx/helpers/appenderattachableimpl.h
@@ -102,8 +102,6 @@ class LOG4CXX_EXPORT AppenderAttachableImpl :
 		 */
 		virtual void removeAppender(const LogString& name);
 
-		std::mutex& getMutex();
-
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(priv_data, m_priv)
 

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -28,11 +28,6 @@
 namespace log4cxx
 {
 
-namespace helpers
-{
-class synchronized;
-}
-
 namespace spi
 {
 class LoggerRepository;

--- a/src/test/cpp/varia/errorhandlertestcase.cpp
+++ b/src/test/cpp/varia/errorhandlertestcase.cpp
@@ -20,6 +20,7 @@
 #include <log4cxx/fileappender.h>
 #include <log4cxx/varia/fallbackerrorhandler.h>
 #include <log4cxx/appender.h>
+#include <log4cxx/helpers/loglog.h>
 #include "../logunit.h"
 #include "../util/transformer.h"
 #include "../util/compare.h"
@@ -40,7 +41,14 @@ LOGUNIT_CLASS(ErrorHandlerTestCase)
 
 	LoggerPtr root;
 	LoggerPtr logger;
-
+#ifdef _DEBUG
+	struct Fixture
+	{
+		Fixture() {
+			helpers::LogLog::setInternalDebugging(true);
+		}
+	} suiteFixture;
+#endif
 
 public:
 	void setUp()
@@ -107,7 +115,7 @@ public:
 		log4cxx::spi::ErrorHandlerPtr errHandle = primary->getErrorHandler();
 		eh = log4cxx::cast<log4cxx::varia::FallbackErrorHandler>(errHandle);
 		LOGUNIT_ASSERT(eh != 0);
-
+		eh->setLogger(logger);
 		common();
 
 		std::string TEST1_PAT =

--- a/src/test/cpp/varia/errorhandlertestcase.cpp
+++ b/src/test/cpp/varia/errorhandlertestcase.cpp
@@ -35,6 +35,7 @@ LOGUNIT_CLASS(ErrorHandlerTestCase)
 {
 	LOGUNIT_TEST_SUITE(ErrorHandlerTestCase);
 	LOGUNIT_TEST(test1);
+	LOGUNIT_TEST(test2);
 	LOGUNIT_TEST_SUITE_END();
 
 	LoggerPtr root;
@@ -85,7 +86,7 @@ public:
 
 		try
 		{
-			Transformer::transform("output/fallback", "output/fallbackfiltered", filters);
+			Transformer::transform("output/fallback1", "output/fallbackfiltered1", filters);
 		}
 		catch (UnexpectedFormatException& e)
 		{
@@ -94,7 +95,45 @@ public:
 		}
 
 
-		LOGUNIT_ASSERT(Compare::compare("output/fallbackfiltered", "witness/fallback1"));
+		LOGUNIT_ASSERT(Compare::compare("output/fallbackfiltered1", "witness/fallback1"));
+	}
+
+	void test2()
+	{
+		DOMConfigurator::configure("input/xml/fallback2.xml");
+		AppenderPtr appender = root->getAppender(LOG4CXX_STR("PRIMARY"));
+		FileAppenderPtr primary = log4cxx::cast<FileAppender>(appender);
+		log4cxx::varia::FallbackErrorHandlerPtr eh;
+		log4cxx::spi::ErrorHandlerPtr errHandle = primary->getErrorHandler();
+		eh = log4cxx::cast<log4cxx::varia::FallbackErrorHandler>(errHandle);
+		LOGUNIT_ASSERT(eh != 0);
+
+		common();
+
+		std::string TEST1_PAT =
+			"FALLBACK - (root|test) - Message {0-9}";
+
+		ControlFilter cf;
+		cf << TEST1_PAT;
+
+		LineNumberFilter lineNumberFilter;
+
+		std::vector<Filter*> filters;
+		filters.push_back(&cf);
+		filters.push_back(&lineNumberFilter);
+
+		try
+		{
+			Transformer::transform("output/fallback2", "output/fallbackfiltered2", filters);
+		}
+		catch (UnexpectedFormatException& e)
+		{
+			std::cout << "UnexpectedFormatException :" << e.what() << std::endl;
+			throw;
+		}
+
+
+		LOGUNIT_ASSERT(Compare::compare("output/fallbackfiltered2", "witness/fallback1"));
 	}
 
 	void common()

--- a/src/test/resources/input/xml/fallback2.xml
+++ b/src/test/resources/input/xml/fallback2.xml
@@ -45,17 +45,24 @@
   </appender>
 
   <appender name="FALLBACK" class="org.apache.log4j.FileAppender">
-    <param name="File" value="output/fallback1" />
+    <param name="File" value="output/fallback2" />
     <param name="Append" value="false" />
     <layout class="org.apache.log4j.PatternLayout">
       <param name="ConversionPattern" value="FALLBACK - %c - %m%n"/>
     </layout>
   </appender>
 
+  <appender name="STDOUT" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="STDOUT - %m%n"/>
+    </layout>
+  </appender>
 
   <root>
     <priority value ="debug" />
     <appender-ref ref="PRIMARY" />
+    <appender-ref ref="STDOUT" />
   </root>
 
 </log4j:configuration>


### PR DESCRIPTION
As the APRInitializer class has member variables whose destructors call apr_* functions, apr_terminate() cannot be called the the APRInitializer class destructor.