### PR TITLE
Change AsynchAppender to not switch to synchronous behaviour

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -454,7 +454,7 @@ void AsyncAppender::dispatch()
 		{
 			std::unique_lock<std::mutex> lock(priv->bufferMutex);
 			priv->bufferNotEmpty.wait(lock, [this]() -> bool
-				{ return 0 < priv->bufferSize || priv->closed; }
+				{ return 0 < priv->buffer.size() || priv->closed; }
 			);
 			isActive = !priv->closed;
 

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -256,7 +256,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 		void testLocationInfoTrue()
 		{
 			BlockableVectorAppenderPtr blockableAppender = BlockableVectorAppenderPtr(new BlockableVectorAppender());
-			async->setName(LOG4CXX_STR("async-blockableVector"));
+			blockableAppender->setName(LOG4CXX_STR("async-blockableVector"));
 			AsyncAppenderPtr async = AsyncAppenderPtr(new AsyncAppender());
 			async->setName(LOG4CXX_STR("async-testLocationInfoTrue"));
 			async->addAppender(blockableAppender);


### PR DESCRIPTION
 Allow a FallbackErrorHandler to replace the bad appender when an attached appender throws an exception.

Resolves LOGCXX-432
