### PR TITLE
Reduce logging overhead by holding references

### DIFF
--- a/src/cmake/test-thread-local.cpp
+++ b/src/cmake/test-thread-local.cpp
@@ -1,0 +1,11 @@
+#include <string>
+
+std::string& getCurrentThreadVar()
+{
+	thread_local std::string thread_id_string;
+    return thread_id_string;
+}
+
+int main(){
+	getCurrentThreadVar() = "name";
+}

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -304,8 +304,30 @@ LoggingEvent::KeySet LoggingEvent::getPropertyKeySet() const
 
 const LogString& LoggingEvent::getCurrentThreadName()
 {
-	thread_local LogString thread_id_string;
+#if defined(_WIN32)
+	using ThreadIdType = DWORD;
+	ThreadIdType threadId = GetCurrentThreadId();
+#elif APR_HAS_THREADS
+	using ThreadIdType = apr_os_thread_t;
+	ThreadIdType threadId = apr_os_thread_current();
+#else
+	using ThreadIdType = int;
+	ThreadIdType threadId = 0;
+#endif
 
+#if defined(__BORLANDC__)
+	using ListItem = std::pair<ThreadIdType, LogString>;
+	static std::list<ListItem> thread_id_map;
+	static std::mutex mutex;
+	std::lock_guard<std::mutex> lock(mutex);
+	auto pThreadId = std::find_if(thread_id_map.begin(), thread_id_map.end()
+		, [threadId](const ListItem& item) { return threadId == item.first; });
+	if (thread_id_map.end() == pThreadId)
+		pThreadId = thread_id_map.insert(thread_id_map.begin(), ListItem(threadId, LogString()));
+	LogString& thread_id_string = pThreadId->second;
+#else
+	LOG4CXX_THREAD_LOCAL LogString thread_id_string;
+#endif
 	if ( !thread_id_string.empty() )
 	{
 		return thread_id_string;
@@ -314,13 +336,11 @@ const LogString& LoggingEvent::getCurrentThreadName()
 #if APR_HAS_THREADS
 #if defined(_WIN32)
 	char result[20];
-	auto threadId = GetCurrentThreadId();
 	apr_snprintf(result, sizeof(result), LOG4CXX_WIN32_THREAD_FMTSPEC, threadId);
 #else
 	// apr_os_thread_t encoded in HEX takes needs as many characters
 	// as two times the size of the type, plus an additional null byte.
 	char result[sizeof(apr_os_thread_t) * 3 + 10];
-	auto threadId = apr_os_thread_current();
 	apr_snprintf(result, sizeof(result), LOG4CXX_APR_THREAD_FMTSPEC, (void*) &threadId);
 #endif /* _WIN32 */
 
@@ -334,7 +354,11 @@ const LogString& LoggingEvent::getCurrentThreadName()
 
 const LogString& LoggingEvent::getCurrentThreadUserName()
 {
-	thread_local LogString thread_name;
+#if defined(__BORLANDC__)
+	static LogString thread_name;
+#else
+	LOG4CXX_THREAD_LOCAL LogString thread_name;
+#endif
 	if( !thread_name.empty() ){
 		return thread_name;
 	}

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -305,12 +305,13 @@ LoggingEvent::KeySet LoggingEvent::getPropertyKeySet() const
 const LogString& LoggingEvent::getCurrentThreadName()
 {
 #if defined(_WIN32)
-    using ThreadIdType = DWORD;
+	using ThreadIdType = DWORD;
 	ThreadIdType threadId = GetCurrentThreadId();
 #elif APR_HAS_THREADS
-    using ThreadIdType = apr_os_thread_t;
+	using ThreadIdType = apr_os_thread_t;
 	ThreadIdType threadId = apr_os_thread_current();
 #else
+	using ThreadIdType = int;
 	ThreadIdType threadId = 0;
 #endif
 

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -315,7 +315,9 @@ const LogString& LoggingEvent::getCurrentThreadName()
 	ThreadIdType threadId = 0;
 #endif
 
-#if defined(__BORLANDC__)
+#if LOG4CXX_HAS_THREAD_LOCAL
+	thread_local LogString thread_id_string;
+#else
 	using ListItem = std::pair<ThreadIdType, LogString>;
 	static std::list<ListItem> thread_id_map;
 	static std::mutex mutex;
@@ -325,8 +327,6 @@ const LogString& LoggingEvent::getCurrentThreadName()
 	if (thread_id_map.end() == pThreadId)
 		pThreadId = thread_id_map.insert(thread_id_map.begin(), ListItem(threadId, LogString()));
 	LogString& thread_id_string = pThreadId->second;
-#else
-	LOG4CXX_THREAD_LOCAL LogString thread_id_string;
 #endif
 	if ( !thread_id_string.empty() )
 	{
@@ -354,10 +354,10 @@ const LogString& LoggingEvent::getCurrentThreadName()
 
 const LogString& LoggingEvent::getCurrentThreadUserName()
 {
-#if defined(__BORLANDC__)
-	static LogString thread_name;
+#if LOG4CXX_HAS_THREAD_LOCAL
+	thread_local LogString thread_name;
 #else
-	LOG4CXX_THREAD_LOCAL LogString thread_name;
+	static LogString thread_name = LOG4CXX_STR("(noname)");
 #endif
 	if( !thread_name.empty() ){
 		return thread_name;

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -318,6 +318,8 @@ const LogString& LoggingEvent::getCurrentThreadName()
 #if defined(__BORLANDC__)
 	using ListItem = std::pair<ThreadIdType, LogString>;
 	static std::list<ListItem> thread_id_map;
+	static std::mutex mutex;
+	std::lock_guard<std::mutex> lock(mutex);
 	auto pThreadId = std::find_if(thread_id_map.begin(), thread_id_map.end()
 		, [threadId](const ListItem& item) { return threadId == item.first; });
 	if (thread_id_map.end() == pThreadId)

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -304,8 +304,11 @@ LoggingEvent::KeySet LoggingEvent::getPropertyKeySet() const
 
 const LogString& LoggingEvent::getCurrentThreadName()
 {
+#if APR_HAS_THREADS
 	thread_local LogString thread_id_string;
-
+#else
+	static LogString thread_id_string;
+#endif
 	if ( !thread_id_string.empty() )
 	{
 		return thread_id_string;
@@ -314,13 +317,13 @@ const LogString& LoggingEvent::getCurrentThreadName()
 #if APR_HAS_THREADS
 #if defined(_WIN32)
 	char result[20];
-	auto threadId = GetCurrentThreadId();
+	DWORD threadId = GetCurrentThreadId();
 	apr_snprintf(result, sizeof(result), LOG4CXX_WIN32_THREAD_FMTSPEC, threadId);
 #else
 	// apr_os_thread_t encoded in HEX takes needs as many characters
 	// as two times the size of the type, plus an additional null byte.
 	char result[sizeof(apr_os_thread_t) * 3 + 10];
-	auto threadId = apr_os_thread_current();
+	apr_os_thread_t threadId = apr_os_thread_current();
 	apr_snprintf(result, sizeof(result), LOG4CXX_APR_THREAD_FMTSPEC, (void*) &threadId);
 #endif /* _WIN32 */
 
@@ -334,7 +337,11 @@ const LogString& LoggingEvent::getCurrentThreadName()
 
 const LogString& LoggingEvent::getCurrentThreadUserName()
 {
+#if APR_HAS_THREADS
 	thread_local LogString thread_name;
+#else
+	static LogString thread_name;
+#endif
 	if( !thread_name.empty() ){
 		return thread_name;
 	}

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -304,8 +304,24 @@ LoggingEvent::KeySet LoggingEvent::getPropertyKeySet() const
 
 const LogString& LoggingEvent::getCurrentThreadName()
 {
+#if defined(_WIN32)
+    using ThreadIdType = DWORD;
+	ThreadIdType threadId = GetCurrentThreadId();
+#elif APR_HAS_THREADS
+    using ThreadIdType = apr_os_thread_t;
+	ThreadIdType threadId = apr_os_thread_current();
+#else
+	ThreadIdType threadId = 0;
+#endif
+
 #if defined(__BORLANDC__)
-	static LogString thread_id_string;
+	using ListItem = std::pair<ThreadIdType, LogString>;
+	static std::list<ListItem> thread_id_map;
+	auto pThreadId = std::find_if(thread_id_map.begin(), thread_id_map.end()
+		, [threadId](const ListItem& item) { return threadId == item.first; });
+	if (thread_id_map.end() == pThreadId)
+		pThreadId = thread_id_map.insert(thread_id_map.begin(), ListItem(threadId, LogString()));
+	LogString& thread_id_string = pThreadId->second;
 #else
 	LOG4CXX_THREAD_LOCAL LogString thread_id_string;
 #endif
@@ -317,13 +333,11 @@ const LogString& LoggingEvent::getCurrentThreadName()
 #if APR_HAS_THREADS
 #if defined(_WIN32)
 	char result[20];
-	DWORD threadId = GetCurrentThreadId();
 	apr_snprintf(result, sizeof(result), LOG4CXX_WIN32_THREAD_FMTSPEC, threadId);
 #else
 	// apr_os_thread_t encoded in HEX takes needs as many characters
 	// as two times the size of the type, plus an additional null byte.
 	char result[sizeof(apr_os_thread_t) * 3 + 10];
-	apr_os_thread_t threadId = apr_os_thread_current();
 	apr_snprintf(result, sizeof(result), LOG4CXX_APR_THREAD_FMTSPEC, (void*) &threadId);
 #endif /* _WIN32 */
 

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -304,11 +304,8 @@ LoggingEvent::KeySet LoggingEvent::getPropertyKeySet() const
 
 const LogString& LoggingEvent::getCurrentThreadName()
 {
-#if APR_HAS_THREADS
 	thread_local LogString thread_id_string;
-#else
-	static LogString thread_id_string;
-#endif
+
 	if ( !thread_id_string.empty() )
 	{
 		return thread_id_string;
@@ -317,13 +314,13 @@ const LogString& LoggingEvent::getCurrentThreadName()
 #if APR_HAS_THREADS
 #if defined(_WIN32)
 	char result[20];
-	DWORD threadId = GetCurrentThreadId();
+	auto threadId = GetCurrentThreadId();
 	apr_snprintf(result, sizeof(result), LOG4CXX_WIN32_THREAD_FMTSPEC, threadId);
 #else
 	// apr_os_thread_t encoded in HEX takes needs as many characters
 	// as two times the size of the type, plus an additional null byte.
 	char result[sizeof(apr_os_thread_t) * 3 + 10];
-	apr_os_thread_t threadId = apr_os_thread_current();
+	auto threadId = apr_os_thread_current();
 	apr_snprintf(result, sizeof(result), LOG4CXX_APR_THREAD_FMTSPEC, (void*) &threadId);
 #endif /* _WIN32 */
 
@@ -337,11 +334,7 @@ const LogString& LoggingEvent::getCurrentThreadName()
 
 const LogString& LoggingEvent::getCurrentThreadUserName()
 {
-#if APR_HAS_THREADS
 	thread_local LogString thread_name;
-#else
-	static LogString thread_name;
-#endif
 	if( !thread_name.empty() ){
 		return thread_name;
 	}

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -305,13 +305,13 @@ LoggingEvent::KeySet LoggingEvent::getPropertyKeySet() const
 const LogString& LoggingEvent::getCurrentThreadName()
 {
 #if defined(__BORLANDC__)
-	static LogString thread_name;
+	static LogString thread_id_string;
 #else
-	LOG4CXX_THREAD_LOCAL LogString thread_name;
+	LOG4CXX_THREAD_LOCAL LogString thread_id_string;
 #endif
-	if ( !thread_name.empty() )
+	if ( !thread_id_string.empty() )
 	{
-		return thread_name;
+		return thread_id_string;
 	}
 
 #if APR_HAS_THREADS
@@ -327,47 +327,47 @@ const LogString& LoggingEvent::getCurrentThreadName()
 	apr_snprintf(result, sizeof(result), LOG4CXX_APR_THREAD_FMTSPEC, (void*) &threadId);
 #endif /* _WIN32 */
 
-	log4cxx::helpers::Transcoder::decode(reinterpret_cast<const char*>(result), thread_name);
+	log4cxx::helpers::Transcoder::decode(reinterpret_cast<const char*>(result), thread_id_string);
 
 #else
-    thread_name = LOG4CXX_STR("0x00000000");
+    thread_id_string = LOG4CXX_STR("0x00000000");
 #endif /* APR_HAS_THREADS */
-	return thread_name;
+	return thread_id_string;
 }
 
 const LogString& LoggingEvent::getCurrentThreadUserName()
 {
 #if defined(__BORLANDC__)
-	static LogString user_name;
+	static LogString thread_name;
 #else
-	LOG4CXX_THREAD_LOCAL LogString user_name;
+	LOG4CXX_THREAD_LOCAL LogString thread_name;
 #endif
-	if( !user_name.empty() ){
-		return user_name;
+	if( !thread_name.empty() ){
+		return thread_name;
 	}
 
 #if LOG4CXX_HAS_PTHREAD_GETNAME
 	char result[16];
 	pthread_t current_thread = pthread_self();
 	if( pthread_getname_np( current_thread, result, sizeof(result) ) < 0 ){
-		user_name = LOG4CXX_STR("(noname)");
+		thread_name = LOG4CXX_STR("(noname)");
 	}
 
-	log4cxx::helpers::Transcoder::decode(reinterpret_cast<const char*>(result), user_name);
+	log4cxx::helpers::Transcoder::decode(reinterpret_cast<const char*>(result), thread_name);
 #elif LOG4CXX_HAS_GETTHREADDESCRIPTION
 	PWSTR result;
 	HANDLE threadId = GetCurrentThread();
 	if( GetThreadDescription( threadId, &result ) == 0 ){
 		// Success
-		log4cxx::helpers::Transcoder::decode(reinterpret_cast<const char*>(result), user_name);
+		log4cxx::helpers::Transcoder::decode(reinterpret_cast<const char*>(result), thread_name);
 		LocalFree(result);
 	}else{
-		user_name = LOG4CXX_STR("(noname)");
+		thread_name = LOG4CXX_STR("(noname)");
 	}
 #else
-	user_name = LOG4CXX_STR("(noname)");
+	thread_name = LOG4CXX_STR("(noname)");
 #endif
-	return user_name;
+	return thread_name;
 }
 
 void LoggingEvent::setProperty(const LogString& key, const LogString& value)

--- a/src/main/include/CMakeLists.txt
+++ b/src/main/include/CMakeLists.txt
@@ -108,6 +108,16 @@ CHECK_FUNCTION_EXISTS(wcstombs HAS_WCSTOMBS)
 CHECK_FUNCTION_EXISTS(fwide HAS_FWIDE)
 CHECK_LIBRARY_EXISTS(esmtp smtp_create_session "" HAS_LIBESMTP)
 CHECK_FUNCTION_EXISTS(syslog HAS_SYSLOG)
+
+try_compile(THREAD_LOCAL_IS_SUPPORTED "${CMAKE_BINARY_DIR}/thread-local-test"
+    "${LOG4CXX_SOURCE_DIR}/src/cmake/test-thread-local.cpp"
+    CXX_STANDARD 11
+    )
+if(THREAD_LOCAL_IS_SUPPORTED)
+    set(HAS_THREAD_LOCAL 1)
+else()
+    set(HAS_THREAD_LOCAL 0)
+endif()
 if(UNIX)
     set(CMAKE_REQUIRED_LIBRARIES "pthread")
     CHECK_SYMBOL_EXISTS(pthread_sigmask "signal.h" HAS_PTHREAD_SIGMASK)

--- a/src/main/include/CMakeLists.txt
+++ b/src/main/include/CMakeLists.txt
@@ -108,16 +108,10 @@ CHECK_FUNCTION_EXISTS(wcstombs HAS_WCSTOMBS)
 CHECK_FUNCTION_EXISTS(fwide HAS_FWIDE)
 CHECK_LIBRARY_EXISTS(esmtp smtp_create_session "" HAS_LIBESMTP)
 CHECK_FUNCTION_EXISTS(syslog HAS_SYSLOG)
-
-try_compile(THREAD_LOCAL_IS_SUPPORTED "${CMAKE_BINARY_DIR}/thread-local-test"
+try_compile(HAS_THREAD_LOCAL "${CMAKE_BINARY_DIR}/thread-local-test"
     "${LOG4CXX_SOURCE_DIR}/src/cmake/test-thread-local.cpp"
     CXX_STANDARD 11
     )
-if(THREAD_LOCAL_IS_SUPPORTED)
-    set(HAS_THREAD_LOCAL 1)
-else()
-    set(HAS_THREAD_LOCAL 0)
-endif()
 if(UNIX)
     set(CMAKE_REQUIRED_LIBRARIES "pthread")
     CHECK_SYMBOL_EXISTS(pthread_sigmask "signal.h" HAS_PTHREAD_SIGMASK)
@@ -141,16 +135,28 @@ if(WIN32)
     CHECK_SYMBOL_EXISTS(GetThreadDescription "windows.h;processthreadsapi.h" HAS_GETTHREADDESCRIPTION)
 endif(WIN32)
 
-foreach(varName HAS_STD_LOCALE  HAS_ODBC  HAS_MBSRTOWCS  HAS_WCSTOMBS  HAS_FWIDE  HAS_LIBESMTP  HAS_SYSLOG HAS_PTHREAD_SIGMASK HAS_PTHREAD_SETNAME HAS_PTHREAD_GETNAME HAS_SETTHREADDESCRIPTION HAS_GETTHREADDESCRIPTION)
+foreach(varName
+  HAS_THREAD_LOCAL
+  HAS_STD_LOCALE
+  HAS_ODBC
+  HAS_MBSRTOWCS
+  HAS_WCSTOMBS
+  HAS_FWIDE
+  HAS_LIBESMTP
+  HAS_SYSLOG
+  HAS_PTHREAD_SIGMASK
+  HAS_PTHREAD_SETNAME
+  HAS_PTHREAD_GETNAME
+  HAS_SETTHREADDESCRIPTION
+  HAS_GETTHREADDESCRIPTION
+  )
   if(${varName} EQUAL 0)
     continue()
   elseif(${varName} EQUAL 1)
     continue()
-  elseif("${varName}" STREQUAL "ON")
+  elseif("${varName}" STREQUAL "ON" OR "${varName}" STREQUAL "TRUE")
     set(${varName} 1 )
-  elseif("${varName}" STREQUAL "OFF")
-    set(${varName} 0 )
-  else()
+ else()
     set(${varName} 0 )
   endif()
 endforeach()

--- a/src/main/include/log4cxx/private/log4cxx_private.h.in
+++ b/src/main/include/log4cxx/private/log4cxx_private.h.in
@@ -62,15 +62,6 @@
 #define LOG4CXX_HAS_PTHREAD_GETNAME @HAS_PTHREAD_GETNAME@
 #define LOG4CXX_HAS_SETTHREADDESCRIPTION @HAS_SETTHREADDESCRIPTION@
 #define LOG4CXX_HAS_GETTHREADDESCRIPTION @HAS_GETTHREADDESCRIPTION@
-
-#ifdef __BORLANDC__
-/*
- * embarcadero/RAD Studio compilers don't support thread_local:
- * http://docwiki.embarcadero.com/RADStudio/Sydney/en/Modern_C%2B%2B_Language_Features_Compliance_Status
- */
-#define LOG4CXX_THREAD_LOCAL
-#else
-#define LOG4CXX_THREAD_LOCAL thread_local
-#endif
+#define LOG4CXX_HAS_THREAD_LOCAL @HAS_THREAD_LOCAL@
 
 #endif

--- a/src/main/include/log4cxx/private/log4cxx_private.h.in
+++ b/src/main/include/log4cxx/private/log4cxx_private.h.in
@@ -63,4 +63,14 @@
 #define LOG4CXX_HAS_SETTHREADDESCRIPTION @HAS_SETTHREADDESCRIPTION@
 #define LOG4CXX_HAS_GETTHREADDESCRIPTION @HAS_GETTHREADDESCRIPTION@
 
+#ifdef __BORLANDC__
+/*
+ * embarcadero/RAD Studio compilers don't support thread_local:
+ * http://docwiki.embarcadero.com/RADStudio/Sydney/en/Modern_C%2B%2B_Language_Features_Compliance_Status
+ */
+#define LOG4CXX_THREAD_LOCAL
+#else
+#define LOG4CXX_THREAD_LOCAL thread_local
+#endif
+
 #endif

--- a/src/main/include/log4cxx/private/log4cxx_private.h.in
+++ b/src/main/include/log4cxx/private/log4cxx_private.h.in
@@ -63,14 +63,4 @@
 #define LOG4CXX_HAS_SETTHREADDESCRIPTION @HAS_SETTHREADDESCRIPTION@
 #define LOG4CXX_HAS_GETTHREADDESCRIPTION @HAS_GETTHREADDESCRIPTION@
 
-#ifdef __BORLANDC__
-/*
- * embarcadero/RAD Studio compilers don't support thread_local:
- * http://docwiki.embarcadero.com/RADStudio/Sydney/en/Modern_C%2B%2B_Language_Features_Compliance_Status
- */
-#define LOG4CXX_THREAD_LOCAL
-#else
-#define LOG4CXX_THREAD_LOCAL thread_local
-#endif
-
 #endif

--- a/src/main/include/log4cxx/spi/loggingevent.h
+++ b/src/main/include/log4cxx/spi/loggingevent.h
@@ -182,8 +182,8 @@ class LOG4CXX_EXPORT LoggingEvent :
 		//
 		LoggingEvent(const LoggingEvent&);
 		LoggingEvent& operator=(const LoggingEvent&);
-		static const LogString getCurrentThreadName();
-		static const LogString getCurrentThreadUserName();
+		static const LogString& getCurrentThreadName();
+		static const LogString& getCurrentThreadUserName();
 
 };
 

--- a/src/test/cpp/helpers/timezonetestcase.cpp
+++ b/src/test/cpp/helpers/timezonetestcase.cpp
@@ -38,9 +38,7 @@ LOGUNIT_CLASS(TimeZoneTestCase)
 	LOGUNIT_TEST_SUITE(TimeZoneTestCase);
 	LOGUNIT_TEST(test1);
 	LOGUNIT_TEST(test2);
-#if !defined(__BORLANDC__)
 	LOGUNIT_TEST(test3);
-#endif
 	LOGUNIT_TEST(test4);
 	LOGUNIT_TEST(test5);
 	LOGUNIT_TEST(test6);


### PR DESCRIPTION
1. Do not copy the (const global) thread name into every LoggingEvent
2. Thread user name was always empty
 