### PR TITLE
Use std::make_shared to create std::shared_ptr instances

### DIFF
--- a/src/main/cpp/aprsocket.cpp
+++ b/src/main/cpp/aprsocket.cpp
@@ -98,7 +98,7 @@ APRSocket::APRSocket(apr_socket_t* s, apr_pool_t* pool) :
 			Transcoder::decode(buf, remoteip);
 		}
 
-		_priv->address = InetAddressPtr(new InetAddress(remotename, remoteip));
+		_priv->address = std::make_shared<InetAddress>(remotename, remoteip);
 	}
 }
 

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -213,11 +213,10 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 		priv->dispatcher = ThreadUtility::instance()->createThread( LOG4CXX_STR("AsyncAppender"), &AsyncAppender::dispatch, this );
 	}
 
-	// Set the NDC and thread name for the calling thread as these
+	// Set the NDC and MDC for the calling thread as these
 	// LoggingEvent fields were not set at event creation time.
 	LogString ndcVal;
 	event->getNDC(ndcVal);
-	event->getThreadName();
 	// Get a copy of this thread's MDC.
 	event->getMDCCopy();
 
@@ -418,11 +417,11 @@ LoggingEventPtr DiscardSummary::createEvent(Pool& p)
 	StringHelper::toString(count, p, msg);
 	msg.append(LOG4CXX_STR(" messages due to a full event buffer including: "));
 	msg.append(maxEvent->getMessage());
-	return LoggingEventPtr( new LoggingEvent(
+	return std::make_shared<LoggingEvent>(
 				maxEvent->getLoggerName(),
 				maxEvent->getLevel(),
 				msg,
-				LocationInfo::getLocationUnavailable()) );
+				LocationInfo::getLocationUnavailable() );
 }
 
 ::log4cxx::spi::LoggingEventPtr
@@ -433,11 +432,11 @@ DiscardSummary::createEvent(::log4cxx::helpers::Pool& p,
 	StringHelper::toString(discardedCount, p, msg);
 	msg.append(LOG4CXX_STR(" messages due to a full event buffer"));
 
-	return LoggingEventPtr( new LoggingEvent(
+	return std::make_shared<LoggingEvent>(
 				LOG4CXX_STR(""),
 				log4cxx::Level::getError(),
 				msg,
-				LocationInfo::getLocationUnavailable()) );
+				LocationInfo::getLocationUnavailable() );
 }
 
 void AsyncAppender::dispatch()

--- a/src/main/cpp/basicconfigurator.cpp
+++ b/src/main/cpp/basicconfigurator.cpp
@@ -28,8 +28,8 @@ void BasicConfigurator::configure()
 	LogManager::getLoggerRepository()->setConfigured(true);
 	LoggerPtr root = Logger::getRootLogger();
 	static const LogString TTCC_CONVERSION_PATTERN(LOG4CXX_STR("%r [%t] %p %c %x - %m%n"));
-	LayoutPtr layout(new PatternLayout(TTCC_CONVERSION_PATTERN));
-	AppenderPtr appender(new ConsoleAppender(layout));
+	LayoutPtr layout = std::make_shared<PatternLayout>(TTCC_CONVERSION_PATTERN);
+	auto appender = std::make_shared<ConsoleAppender>(layout);
 	root->addAppender(appender);
 }
 

--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -547,7 +547,7 @@ CharsetDecoderPtr CharsetDecoder::getUTF8Decoder()
 	//
 	if (decoder == 0)
 	{
-		return CharsetDecoderPtr( new UTF8CharsetDecoder() );
+		return std::make_shared<UTF8CharsetDecoder>();
 	}
 
 	return decoder;
@@ -555,7 +555,7 @@ CharsetDecoderPtr CharsetDecoder::getUTF8Decoder()
 
 CharsetDecoderPtr CharsetDecoder::getISOLatinDecoder()
 {
-	return CharsetDecoderPtr( new ISOLatinCharsetDecoder() );
+	return std::make_shared<ISOLatinCharsetDecoder>();
 }
 
 
@@ -564,7 +564,7 @@ CharsetDecoderPtr CharsetDecoder::getDecoder(const LogString& charset)
 	if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-8"), LOG4CXX_STR("utf-8")) ||
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF8"), LOG4CXX_STR("utf8")))
 	{
-		return CharsetDecoderPtr( new UTF8CharsetDecoder() );
+		return std::make_shared<UTF8CharsetDecoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("C"), LOG4CXX_STR("c")) ||
 		charset == LOG4CXX_STR("646") ||
@@ -572,16 +572,16 @@ CharsetDecoderPtr CharsetDecoder::getDecoder(const LogString& charset)
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO646-US"), LOG4CXX_STR("iso646-US")) ||
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ANSI_X3.4-1968"), LOG4CXX_STR("ansi_x3.4-1968")))
 	{
-		return CharsetDecoderPtr( new USASCIICharsetDecoder() );
+		return std::make_shared<USASCIICharsetDecoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO-8859-1"), LOG4CXX_STR("iso-8859-1")) ||
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO-LATIN-1"), LOG4CXX_STR("iso-latin-1")))
 	{
-		return CharsetDecoderPtr( new ISOLatinCharsetDecoder() );
+		return std::make_shared<ISOLatinCharsetDecoder>();
 	}
 
 #if APR_HAS_XLATE
-	return CharsetDecoderPtr( new APRCharsetDecoder(charset) );
+	return std::make_shared<APRCharsetDecoder>(charset);
 #else
 	throw IllegalArgumentException(charset);
 #endif

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -571,7 +571,7 @@ CharsetEncoder* CharsetEncoder::createDefaultEncoder()
 
 CharsetEncoderPtr CharsetEncoder::getUTF8Encoder()
 {
-	return CharsetEncoderPtr( new UTF8CharsetEncoder() );
+	return std::make_shared<UTF8CharsetEncoder>();
 }
 
 
@@ -580,7 +580,7 @@ CharsetEncoderPtr CharsetEncoder::getEncoder(const LogString& charset)
 {
 	if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-8"), LOG4CXX_STR("utf-8")))
 	{
-		return CharsetEncoderPtr( new UTF8CharsetEncoder() );
+		return std::make_shared<UTF8CharsetEncoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("C"), LOG4CXX_STR("c")) ||
 		charset == LOG4CXX_STR("646") ||
@@ -588,25 +588,25 @@ CharsetEncoderPtr CharsetEncoder::getEncoder(const LogString& charset)
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO646-US"), LOG4CXX_STR("iso646-US")) ||
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ANSI_X3.4-1968"), LOG4CXX_STR("ansi_x3.4-1968")))
 	{
-		return CharsetEncoderPtr( new USASCIICharsetEncoder() );
+		return std::make_shared<USASCIICharsetEncoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO-8859-1"), LOG4CXX_STR("iso-8859-1")) ||
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO-LATIN-1"), LOG4CXX_STR("iso-latin-1")))
 	{
-		return CharsetEncoderPtr( new ISOLatinCharsetEncoder() );
+		return std::make_shared<ISOLatinCharsetEncoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-16BE"), LOG4CXX_STR("utf-16be"))
 		|| StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-16"), LOG4CXX_STR("utf-16")))
 	{
-		return CharsetEncoderPtr( new UTF16BECharsetEncoder() );
+		return std::make_shared<UTF16BECharsetEncoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-16LE"), LOG4CXX_STR("utf-16le")))
 	{
-		return CharsetEncoderPtr( new UTF16LECharsetEncoder() );
+		return std::make_shared<UTF16LECharsetEncoder>();
 	}
 
 #if APR_HAS_XLATE
-	return CharsetEncoderPtr( new APRCharsetEncoder(charset) );
+	return std::make_shared<APRCharsetEncoder>(charset);
 #else
 	throw IllegalArgumentException(charset);
 #endif

--- a/src/main/cpp/classnamepatternconverter.cpp
+++ b/src/main/cpp/classnamepatternconverter.cpp
@@ -43,11 +43,11 @@ PatternConverterPtr ClassNamePatternConverter::newInstance(
 {
 	if (options.size() == 0)
 	{
-		static PatternConverterPtr def(new ClassNamePatternConverter(options));
+		static PatternConverterPtr def = std::make_shared<ClassNamePatternConverter>(options);
 		return def;
 	}
 
-	return PatternConverterPtr( new ClassNamePatternConverter(options) );
+	return std::make_shared<ClassNamePatternConverter>(options);
 }
 
 void ClassNamePatternConverter::format(

--- a/src/main/cpp/colorendpatternconverter.cpp
+++ b/src/main/cpp/colorendpatternconverter.cpp
@@ -40,7 +40,7 @@ ColorEndPatternConverter::ColorEndPatternConverter() :
 PatternConverterPtr ColorEndPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr instance(new ColorEndPatternConverter());
+	static PatternConverterPtr instance = std::make_shared<ColorEndPatternConverter>();
 	return instance;
 }
 

--- a/src/main/cpp/colorstartpatternconverter.cpp
+++ b/src/main/cpp/colorstartpatternconverter.cpp
@@ -40,7 +40,7 @@ ColorStartPatternConverter::ColorStartPatternConverter() :
 PatternConverterPtr ColorStartPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr instance(new ColorStartPatternConverter());
+	static PatternConverterPtr instance = std::make_shared<ColorStartPatternConverter>();
 	return instance;
 }
 

--- a/src/main/cpp/consoleappender.cpp
+++ b/src/main/cpp/consoleappender.cpp
@@ -50,8 +50,7 @@ ConsoleAppender::ConsoleAppender(const LayoutPtr& layout1)
 {
 	setLayout(layout1);
 	Pool p;
-	WriterPtr writer1(new SystemOutWriter());
-	setWriter(writer1);
+	setWriter(std::make_shared<SystemOutWriter>());
 	WriterAppender::activateOptions(p);
 }
 

--- a/src/main/cpp/datepatternconverter.cpp
+++ b/src/main/cpp/datepatternconverter.cpp
@@ -69,7 +69,7 @@ DateFormatPtr DatePatternConverter::getDateFormat(const OptionsList& options)
 
 	if (options.size() == 0)
 	{
-		df = DateFormatPtr(new ISO8601DateFormat());
+		df = std::make_shared<ISO8601DateFormat>();
 	}
 	else
 	{
@@ -79,17 +79,17 @@ DateFormatPtr DatePatternConverter::getDateFormat(const OptionsList& options)
 			StringHelper::equalsIgnoreCase(dateFormatStr,
 				LOG4CXX_STR("ISO8601"), LOG4CXX_STR("iso8601")))
 		{
-			df = DateFormatPtr(new ISO8601DateFormat());
+			df = std::make_shared<ISO8601DateFormat>();
 		}
 		else if (StringHelper::equalsIgnoreCase(dateFormatStr,
 				LOG4CXX_STR("ABSOLUTE"), LOG4CXX_STR("absolute")))
 		{
-			df = DateFormatPtr(new AbsoluteTimeDateFormat());
+			df = std::make_shared<AbsoluteTimeDateFormat>();
 		}
 		else if (StringHelper::equalsIgnoreCase(dateFormatStr,
 				LOG4CXX_STR("DATE"), LOG4CXX_STR("date")))
 		{
-			df = DateFormatPtr(new DateTimeDateFormat());
+			df = std::make_shared<DateTimeDateFormat>();
 		}
 		else
 		{
@@ -97,13 +97,13 @@ DateFormatPtr DatePatternConverter::getDateFormat(const OptionsList& options)
 			{
 				try
 				{
-					df = DateFormatPtr(new SimpleDateFormat(dateFormatStr));
+					df = std::make_shared<SimpleDateFormat>(dateFormatStr);
 					maximumCacheValidity =
 						CachedDateFormat::getMaximumCacheValidity(dateFormatStr);
 				}
 				catch (IllegalArgumentException& e)
 				{
-					df = DateFormatPtr(new ISO8601DateFormat());
+					df = std::make_shared<ISO8601DateFormat>();
 					LogLog::warn(((LogString)
 							LOG4CXX_STR("Could not instantiate SimpleDateFormat with pattern "))
 						+ dateFormatStr, e);
@@ -111,7 +111,7 @@ DateFormatPtr DatePatternConverter::getDateFormat(const OptionsList& options)
 			}
 			else
 			{
-				df = DateFormatPtr(new StrftimeDateFormat(dateFormatStr));
+				df = std::make_shared<StrftimeDateFormat>(dateFormatStr);
 			}
 		}
 
@@ -128,7 +128,7 @@ DateFormatPtr DatePatternConverter::getDateFormat(const OptionsList& options)
 
 	if (maximumCacheValidity > 0)
 	{
-		df = DateFormatPtr(new CachedDateFormat(df, maximumCacheValidity));
+		df = std::make_shared<CachedDateFormat>(df, maximumCacheValidity);
 	}
 
 	return df;
@@ -137,7 +137,7 @@ DateFormatPtr DatePatternConverter::getDateFormat(const OptionsList& options)
 PatternConverterPtr DatePatternConverter::newInstance(
 	const std::vector<LogString>& options)
 {
-	return PatternConverterPtr(new DatePatternConverter(options));
+	return std::make_shared<DatePatternConverter>(options);
 }
 
 void DatePatternConverter::format(

--- a/src/main/cpp/defaultloggerfactory.cpp
+++ b/src/main/cpp/defaultloggerfactory.cpp
@@ -26,5 +26,5 @@ LoggerPtr DefaultLoggerFactory::makeNewLoggerInstance(
 	log4cxx::helpers::Pool& pool,
 	const LogString& name) const
 {
-	return LoggerPtr(new Logger(pool, name));
+	return std::make_shared<Logger>(pool, name);
 }

--- a/src/main/cpp/domconfigurator.cpp
+++ b/src/main/cpp/domconfigurator.cpp
@@ -787,7 +787,7 @@ void DOMConfigurator::doConfigure(const File& filename, spi::LoggerRepositoryPtr
 	msg.append(LOG4CXX_STR("..."));
 	LogLog::debug(msg);
 
-	m_priv->loggerFactory = LoggerFactoryPtr(new DefaultLoggerFactory());
+	m_priv->loggerFactory = std::make_shared<DefaultLoggerFactory>();
 
 	Pool p;
 	apr_file_t* fd;

--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -342,7 +342,7 @@ void FileAppender::setFileInternal(
 
 	if (bufferedIO1)
 	{
-		newWriter = WriterPtr(new BufferedWriter(newWriter, bufferSize1));
+		newWriter = std::make_shared<BufferedWriter>(newWriter, bufferSize1);
 	}
 
 	setWriterInternal(newWriter);

--- a/src/main/cpp/filelocationpatternconverter.cpp
+++ b/src/main/cpp/filelocationpatternconverter.cpp
@@ -40,7 +40,7 @@ FileLocationPatternConverter::FileLocationPatternConverter() :
 PatternConverterPtr FileLocationPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */ )
 {
-	static PatternConverterPtr instance(new FileLocationPatternConverter());
+	static PatternConverterPtr instance = std::make_shared<FileLocationPatternConverter>();
 	return instance;
 }
 

--- a/src/main/cpp/fixedwindowrollingpolicy.cpp
+++ b/src/main/cpp/fixedwindowrollingpolicy.cpp
@@ -143,15 +143,14 @@ RolloverDescriptionPtr FixedWindowRollingPolicy::initialize(
 	if (!priv->explicitActiveFile)
 	{
 		LogString buf;
-		ObjectPtr obj(new Integer(priv->minIndex));
+		ObjectPtr obj = std::make_shared<Integer>(priv->minIndex);
 		formatFileName(obj, buf, pool);
 		newActiveFile = buf;
 	}
 
 	ActionPtr noAction;
 
-	return RolloverDescriptionPtr(
-			new RolloverDescription(newActiveFile, append, noAction, noAction));
+	return std::make_shared<RolloverDescription>(newActiveFile, append, noAction, noAction);
 }
 
 /**
@@ -182,7 +181,7 @@ RolloverDescriptionPtr FixedWindowRollingPolicy::rollover(
 	}
 
 	LogString buf;
-	ObjectPtr obj(new Integer(purgeStart));
+	ObjectPtr obj = std::make_shared<Integer>(purgeStart);
 	formatFileName(obj, buf, pool);
 
 	LogString renameTo(buf);
@@ -198,31 +197,28 @@ RolloverDescriptionPtr FixedWindowRollingPolicy::rollover(
 	if (StringHelper::endsWith(renameTo, LOG4CXX_STR(".gz")))
 	{
 		renameTo.resize(renameTo.size() - 3);
-		compressAction = ActionPtr(
-				new GZCompressAction(
+		compressAction = std::make_shared<GZCompressAction>(
 					File().setPath(renameTo),
 					File().setPath(compressedName),
-					true));
+					true);
 	}
 	else if (StringHelper::endsWith(renameTo, LOG4CXX_STR(".zip")))
 	{
 		renameTo.resize(renameTo.size() - 4);
-		compressAction = ActionPtr(
-				new ZipCompressAction(
+		compressAction = std::make_shared<ZipCompressAction>(
 					File().setPath(renameTo),
 					File().setPath(compressedName),
-					true));
+					true);
 	}
 
-	FileRenameActionPtr renameAction = FileRenameActionPtr(
-			new FileRenameAction(
+	auto renameAction = std::make_shared<FileRenameAction>(
 				File().setPath(currentActiveFile),
 				File().setPath(renameTo),
-				false));
+				false);
 
-	desc = RolloverDescriptionPtr(new RolloverDescription(
+	desc = std::make_shared<RolloverDescription>(
 				currentActiveFile,  append,
-				renameAction,       compressAction));
+				renameAction,       compressAction);
 
 	return desc;
 }
@@ -259,7 +255,7 @@ bool FixedWindowRollingPolicy::purge(int lowIndex, int highIndex, Pool& p) const
 
 	std::vector<FileRenameActionPtr> renames;
 	LogString buf;
-	ObjectPtr obj = ObjectPtr(new Integer(lowIndex));
+	ObjectPtr obj = std::make_shared<Integer>(lowIndex);
 	formatFileName(obj, buf, p);
 
 	LogString lowFilename(buf);
@@ -320,7 +316,7 @@ bool FixedWindowRollingPolicy::purge(int lowIndex, int highIndex, Pool& p) const
 			//   if intermediate index
 			//     add a rename action to the list
 			buf.erase(buf.begin(), buf.end());
-			obj = ObjectPtr(new Integer(i + 1));
+			obj = std::make_shared<Integer>(i + 1);
 			formatFileName(obj, buf, p);
 
 			LogString highFilename(buf);
@@ -332,7 +328,7 @@ bool FixedWindowRollingPolicy::purge(int lowIndex, int highIndex, Pool& p) const
 					highFilename.substr(0, highFilename.length() - suffixLength);
 			}
 
-			renames.push_back(FileRenameActionPtr(new FileRenameAction(*toRename, File().setPath(renameTo), true)));
+			renames.push_back(std::make_shared<FileRenameAction>(*toRename, File().setPath(renameTo), true));
 			lowFilename = highFilename;
 		}
 		else

--- a/src/main/cpp/formattinginfo.cpp
+++ b/src/main/cpp/formattinginfo.cpp
@@ -67,7 +67,7 @@ FormattingInfo::~FormattingInfo() {}
  */
 FormattingInfoPtr FormattingInfo::getDefault()
 {
-	static FormattingInfoPtr def(new FormattingInfo(false, 0, INT_MAX));
+	static FormattingInfoPtr def= std::make_shared<FormattingInfo>(false, 0, INT_MAX);
 	return def;
 }
 

--- a/src/main/cpp/fulllocationpatternconverter.cpp
+++ b/src/main/cpp/fulllocationpatternconverter.cpp
@@ -41,7 +41,7 @@ FullLocationPatternConverter::FullLocationPatternConverter() :
 PatternConverterPtr FullLocationPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr instance(new FullLocationPatternConverter());
+	static PatternConverterPtr instance = std::make_shared<FullLocationPatternConverter>();
 	return instance;
 }
 

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -448,7 +448,7 @@ bool Hierarchy::isConfigured()
 
 HierarchyPtr Hierarchy::create()
 {
-	HierarchyPtr ret( new Hierarchy() );
+	auto ret = std::make_shared<Hierarchy>();
 	ret->m_priv->root->setHierarchy(ret);
 	return ret;
 }

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -258,7 +258,7 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 	if (!result)
 	{
 		LoggerPtr logger(factory->makeNewLoggerInstance(m_priv->pool, name));
-		logger->setHierarchy(shared_from_this());
+		logger->setHierarchy(this);
 		m_priv->loggers.insert(LoggerMap::value_type(name, logger));
 
 		ProvisionNodeMap::iterator it2 = m_priv->provisionNodes.find(name);
@@ -448,7 +448,7 @@ bool Hierarchy::isConfigured()
 
 HierarchyPtr Hierarchy::create()
 {
-	auto ret = std::make_shared<Hierarchy>();
-	ret->m_priv->root->setHierarchy(ret);
+	HierarchyPtr ret(new Hierarchy);
+	ret->m_priv->root->setHierarchy(ret.get());
 	return ret;
 }

--- a/src/main/cpp/inetaddress.cpp
+++ b/src/main/cpp/inetaddress.cpp
@@ -103,7 +103,7 @@ std::vector<InetAddressPtr> InetAddress::getAllByName(const LogString& host)
 			Transcoder::decode(host, hostNameString);
 		}
 
-		result.push_back(InetAddressPtr(new InetAddress(hostNameString, ipAddrString)));
+		result.push_back(std::make_shared<InetAddress>(hostNameString, ipAddrString));
 		currentAddr = currentAddr->next;
 	}
 

--- a/src/main/cpp/integerpatternconverter.cpp
+++ b/src/main/cpp/integerpatternconverter.cpp
@@ -39,7 +39,7 @@ IntegerPatternConverter::IntegerPatternConverter() :
 PatternConverterPtr IntegerPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr instance(new IntegerPatternConverter());
+	static PatternConverterPtr instance = std::make_shared<IntegerPatternConverter>();
 	return instance;
 }
 

--- a/src/main/cpp/level.cpp
+++ b/src/main/cpp/level.cpp
@@ -32,50 +32,50 @@ IMPLEMENT_LOG4CXX_OBJECT_WITH_CUSTOM_CLASS(Level, LevelClass)
 
 LevelPtr Level::getOff()
 {
-	static LevelPtr offLevel(new Level(Level::OFF_INT, LOG4CXX_STR("OFF"), 0));
+	static LevelPtr offLevel = std::make_shared<Level>(Level::OFF_INT, LOG4CXX_STR("OFF"), 0);
 	return offLevel;
 }
 
 LevelPtr Level::getFatal()
 {
-	static LevelPtr fatalLevel(new Level(Level::FATAL_INT, LOG4CXX_STR("FATAL"), 0));
+	static LevelPtr fatalLevel = std::make_shared<Level>(Level::FATAL_INT, LOG4CXX_STR("FATAL"), 0);
 	return fatalLevel;
 }
 
 LevelPtr Level::getError()
 {
-	static LevelPtr errorLevel(new Level(Level::ERROR_INT, LOG4CXX_STR("ERROR"), 3));
+	static LevelPtr errorLevel = std::make_shared<Level>(Level::ERROR_INT, LOG4CXX_STR("ERROR"), 3);
 	return errorLevel;
 }
 
 LevelPtr Level::getWarn()
 {
-	static LevelPtr warnLevel(new Level(Level::WARN_INT, LOG4CXX_STR("WARN"), 4));
+	static LevelPtr warnLevel = std::make_shared<Level>(Level::WARN_INT, LOG4CXX_STR("WARN"), 4);
 	return warnLevel;
 }
 
 LevelPtr Level::getInfo()
 {
-	static LevelPtr infoLevel(new Level(Level::INFO_INT, LOG4CXX_STR("INFO"), 6));
+	static LevelPtr infoLevel = std::make_shared<Level>(Level::INFO_INT, LOG4CXX_STR("INFO"), 6);
 	return infoLevel;
 }
 
 LevelPtr Level::getDebug()
 {
-	static LevelPtr debugLevel(new Level(Level::DEBUG_INT, LOG4CXX_STR("DEBUG"), 7));
+	static LevelPtr debugLevel = std::make_shared<Level>(Level::DEBUG_INT, LOG4CXX_STR("DEBUG"), 7);
 	return debugLevel;
 }
 
 LevelPtr Level::getTrace()
 {
-	static LevelPtr traceLevel(new Level(Level::TRACE_INT, LOG4CXX_STR("TRACE"), 7));
+	static LevelPtr traceLevel = std::make_shared<Level>(Level::TRACE_INT, LOG4CXX_STR("TRACE"), 7);
 	return traceLevel;
 }
 
 
 LevelPtr Level::getAll()
 {
-	static LevelPtr allLevel(new Level(Level::ALL_INT, LOG4CXX_STR("ALL"), 7));
+	static LevelPtr allLevel = std::make_shared<Level>(Level::ALL_INT, LOG4CXX_STR("ALL"), 7);
 	return allLevel;
 }
 

--- a/src/main/cpp/levelpatternconverter.cpp
+++ b/src/main/cpp/levelpatternconverter.cpp
@@ -41,7 +41,7 @@ LevelPatternConverter::LevelPatternConverter() :
 PatternConverterPtr LevelPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr def(new LevelPatternConverter());
+	static PatternConverterPtr def = std::make_shared<LevelPatternConverter>();
 	return def;
 }
 

--- a/src/main/cpp/linelocationpatternconverter.cpp
+++ b/src/main/cpp/linelocationpatternconverter.cpp
@@ -40,7 +40,7 @@ LineLocationPatternConverter::LineLocationPatternConverter() :
 PatternConverterPtr LineLocationPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr instance(new LineLocationPatternConverter());
+	static PatternConverterPtr instance = std::make_shared<LineLocationPatternConverter>();
 	return instance;
 }
 

--- a/src/main/cpp/lineseparatorpatternconverter.cpp
+++ b/src/main/cpp/lineseparatorpatternconverter.cpp
@@ -40,7 +40,7 @@ LineSeparatorPatternConverter::LineSeparatorPatternConverter() :
 PatternConverterPtr LineSeparatorPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr instance(new LineSeparatorPatternConverter());
+	static PatternConverterPtr instance = std::make_shared<LineSeparatorPatternConverter>();
 	return instance;
 }
 

--- a/src/main/cpp/literalpatternconverter.cpp
+++ b/src/main/cpp/literalpatternconverter.cpp
@@ -56,12 +56,11 @@ PatternConverterPtr LiteralPatternConverter::newInstance(
 {
 	if (literal.length() == 1 && literal[0] == 0x20 /* ' ' */)
 	{
-		static PatternConverterPtr blank(new LiteralPatternConverter(literal));
+		static PatternConverterPtr blank = std::make_shared<LiteralPatternConverter>(literal);
 		return blank;
 	}
 
-	PatternConverterPtr pattern(new LiteralPatternConverter(literal));
-	return pattern;
+	return std::make_shared<LiteralPatternConverter>(literal);
 }
 
 void LiteralPatternConverter::format(

--- a/src/main/cpp/loader.cpp
+++ b/src/main/cpp/loader.cpp
@@ -65,7 +65,7 @@ InputStreamPtr Loader::getResourceAsStream(const LogString& name)
 
 	try
 	{
-		return InputStreamPtr( new FileInputStream(name) );
+		return std::make_shared<FileInputStream>(name);
 	}
 	catch (const IOException&)
 	{

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -70,7 +70,6 @@ struct Logger::LoggerPrivate
 
 
 	// Loggers need to know what Hierarchy they are in
-	log4cxx::spi::LoggerRepositoryWeakPtr repository;
 	log4cxx::spi::LoggerRepository* repositoryRaw;
 
 	helpers::AppenderAttachableImpl aai;
@@ -224,9 +223,9 @@ const LevelPtr& Logger::getEffectiveLevel() const
 #endif
 }
 
-LoggerRepositoryPtr Logger::getLoggerRepository() const
+LoggerRepository* Logger::getLoggerRepository() const
 {
-	return m_priv->repository.lock();
+	return m_priv->repositoryRaw;
 }
 
 LoggerRepository* Logger::getHierarchy() const
@@ -500,7 +499,6 @@ void Logger::removeAppender(const LogString& name1)
 
 void Logger::removeHierarchy()
 {
-	m_priv->repository.reset();
 	m_priv->repositoryRaw = 0;
 }
 
@@ -509,10 +507,9 @@ void Logger::setAdditivity(bool additive1)
 	m_priv->additive = additive1;
 }
 
-void Logger::setHierarchy(const spi::LoggerRepositoryPtr& repository1)
+void Logger::setHierarchy(spi::LoggerRepository* repository1)
 {
-	m_priv->repository = repository1;
-	m_priv->repositoryRaw = repository1.get();
+	m_priv->repositoryRaw = repository1;
 }
 
 void Logger::setParent(LoggerPtr parentLogger)

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -166,7 +166,7 @@ void Logger::forcedLog(const LevelPtr& level1, const std::string& message,
 		return;
 	Pool p;
 	LOG4CXX_DECODE_CHAR(msg, message);
-	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg, location));
+	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, msg, location);
 	callAppenders(event, p);
 }
 
@@ -177,8 +177,8 @@ void Logger::forcedLog(const LevelPtr& level1, const std::string& message) const
 		return;
 	Pool p;
 	LOG4CXX_DECODE_CHAR(msg, message);
-	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg,
-			LocationInfo::getLocationUnavailable()));
+	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, msg,
+			LocationInfo::getLocationUnavailable());
 	callAppenders(event, p);
 }
 
@@ -188,7 +188,7 @@ void Logger::forcedLogLS(const LevelPtr& level1, const LogString& message,
 	if (!getHierarchy()) // Has removeHierarchy() been called?
 		return;
 	Pool p;
-	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, message, location));
+	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, message, location);
 	callAppenders(event, p);
 }
 
@@ -704,7 +704,7 @@ void Logger::forcedLog(const LevelPtr& level1, const std::wstring& message,
 		return;
 	Pool p;
 	LOG4CXX_DECODE_WCHAR(msg, message);
-	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg, location));
+	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, msg, location);
 	callAppenders(event, p);
 }
 
@@ -714,8 +714,8 @@ void Logger::forcedLog(const LevelPtr& level1, const std::wstring& message) cons
 		return;
 	Pool p;
 	LOG4CXX_DECODE_WCHAR(msg, message);
-	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg,
-			LocationInfo::getLocationUnavailable()));
+	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, msg,
+			LocationInfo::getLocationUnavailable());
 	callAppenders(event, p);
 }
 
@@ -859,7 +859,7 @@ void Logger::forcedLog(const LevelPtr& level1, const std::basic_string<UniChar>&
 		return;
 	Pool p;
 	LOG4CXX_DECODE_UNICHAR(msg, message);
-	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg, location));
+	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, msg, location);
 	callAppenders(event, p);
 }
 
@@ -869,8 +869,8 @@ void Logger::forcedLog(const LevelPtr& level1, const std::basic_string<UniChar>&
 		return;
 	Pool p;
 	LOG4CXX_DECODE_UNICHAR(msg, message);
-	LoggingEventPtr event(new LoggingEvent(m_priv->name, level1, msg,
-			LocationInfo::getLocationUnavailable()));
+	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, msg,
+			LocationInfo::getLocationUnavailable());
 	callAppenders(event, p);
 }
 #endif
@@ -1011,7 +1011,7 @@ void Logger::forcedLog(const LevelPtr& level1, const CFStringRef& message,
 		return;
 	Pool p;
 	LOG4CXX_DECODE_CFSTRING(msg, message);
-	LoggingEventPtr event(new LoggingEvent(name, level1, msg, location));
+	auto event = std::make_shared<LoggingEvent>(name, level1, msg, location);
 	callAppenders(event, p);
 }
 
@@ -1021,8 +1021,8 @@ void Logger::forcedLog(const LevelPtr& level1, const CFStringRef& message) const
 		return;
 	Pool p;
 	LOG4CXX_DECODE_CFSTRING(msg, message);
-	LoggingEventPtr event(new LoggingEvent(name, level1, msg,
-			LocationInfo::getLocationUnavailable()));
+	auto event = std::make_shared<LoggingEvent>(name, level1, msg,
+			LocationInfo::getLocationUnavailable());
 	callAppenders(event, p);
 }
 

--- a/src/main/cpp/loggerpatternconverter.cpp
+++ b/src/main/cpp/loggerpatternconverter.cpp
@@ -42,11 +42,11 @@ PatternConverterPtr LoggerPatternConverter::newInstance(
 {
 	if (options.size() == 0)
 	{
-		static PatternConverterPtr def(new LoggerPatternConverter(options));
+		static PatternConverterPtr def = std::make_shared<LoggerPatternConverter>(options);
 		return def;
 	}
 
-	return PatternConverterPtr(new LoggerPatternConverter(options));
+	return std::make_shared<LoggerPatternConverter>(options);
 }
 
 void LoggerPatternConverter::format(

--- a/src/main/cpp/logmanager.cpp
+++ b/src/main/cpp/logmanager.cpp
@@ -53,7 +53,7 @@ RepositorySelectorPtr LogManager::getRepositorySelector()
 	auto result = APRInitializer::getOrAddUnique<spi::RepositorySelector>( []() -> ObjectPtr
 		{
 			LoggerRepositoryPtr hierarchy = Hierarchy::create();
-			return ObjectPtr(new DefaultRepositorySelector(hierarchy));
+			return std::make_shared<DefaultRepositorySelector>(hierarchy);
 		}
 	);
 	return result;

--- a/src/main/cpp/messagepatternconverter.cpp
+++ b/src/main/cpp/messagepatternconverter.cpp
@@ -41,7 +41,7 @@ MessagePatternConverter::MessagePatternConverter() :
 PatternConverterPtr MessagePatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr def(new MessagePatternConverter());
+	static PatternConverterPtr def = std::make_shared<MessagePatternConverter>();
 	return def;
 }
 

--- a/src/main/cpp/methodlocationpatternconverter.cpp
+++ b/src/main/cpp/methodlocationpatternconverter.cpp
@@ -41,7 +41,7 @@ MethodLocationPatternConverter::MethodLocationPatternConverter() :
 PatternConverterPtr MethodLocationPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */ )
 {
-	static PatternConverterPtr def(new MethodLocationPatternConverter());
+	static PatternConverterPtr def = std::make_shared<MethodLocationPatternConverter>();
 	return def;
 }
 

--- a/src/main/cpp/nameabbreviator.cpp
+++ b/src/main/cpp/nameabbreviator.cpp
@@ -291,7 +291,7 @@ NameAbbreviatorPtr NameAbbreviator::getAbbreviator(const LogString& pattern)
 		//
 		if (i == trimmed.length())
 		{
-			return NameAbbreviatorPtr(new MaxElementAbbreviator(StringHelper::toInt(trimmed)));
+			return std::make_shared<MaxElementAbbreviator>(StringHelper::toInt(trimmed));
 		}
 
 		std::vector<PatternAbbreviatorFragment> fragments;
@@ -345,8 +345,7 @@ NameAbbreviatorPtr NameAbbreviator::getAbbreviator(const LogString& pattern)
 			pos++;
 		}
 
-		NameAbbreviatorPtr abbrev(new PatternAbbreviator(fragments));
-		return abbrev;
+		return std::make_shared<PatternAbbreviator>(fragments);
 	}
 
 	//
@@ -362,7 +361,7 @@ NameAbbreviatorPtr NameAbbreviator::getAbbreviator(const LogString& pattern)
  */
 NameAbbreviatorPtr NameAbbreviator::getDefaultAbbreviator()
 {
-	static NameAbbreviatorPtr def(new NOPAbbreviator());
+	static NameAbbreviatorPtr def = std::make_shared<NOPAbbreviator>();
 	return def;
 }
 

--- a/src/main/cpp/ndcpatternconverter.cpp
+++ b/src/main/cpp/ndcpatternconverter.cpp
@@ -42,7 +42,7 @@ NDCPatternConverter::NDCPatternConverter() :
 PatternConverterPtr NDCPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr def(new NDCPatternConverter());
+	static PatternConverterPtr def = std::make_shared<NDCPatternConverter>();
 	return def;
 }
 

--- a/src/main/cpp/odbcappender.cpp
+++ b/src/main/cpp/odbcappender.cpp
@@ -345,7 +345,7 @@ void ODBCAppender::setSql(const LogString& s)
 
 	if (getLayout() == 0)
 	{
-		this->setLayout(PatternLayoutPtr(new PatternLayout(s)));
+		this->setLayout(std::make_shared<PatternLayout>(s));
 	}
 	else
 	{

--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -442,7 +442,7 @@ void OptionConverter::selectAndConfigure(const File& configFileName,
 	}
 	else
 	{
-		configurator = ConfiguratorPtr(new PropertyConfigurator());
+		configurator = std::make_shared<PropertyConfigurator>();
 	}
 
 #if APR_HAS_THREADS

--- a/src/main/cpp/patternparser.cpp
+++ b/src/main/cpp/patternparser.cpp
@@ -179,10 +179,9 @@ void PatternParser::parse(
 				switch (c)
 				{
 					case 0x2D: // '-'
-						formattingInfo = FormattingInfoPtr(
-								new FormattingInfo(
+						formattingInfo = std::make_shared<FormattingInfo>(
 									true, formattingInfo->getMinLength(),
-									formattingInfo->getMaxLength()));
+									formattingInfo->getMaxLength());
 
 						break;
 
@@ -195,10 +194,9 @@ void PatternParser::parse(
 
 						if ((c >= 0x30 /* '0' */) && (c <= 0x39 /* '9' */))
 						{
-							formattingInfo = FormattingInfoPtr(
-									new FormattingInfo(
+							formattingInfo = std::make_shared<FormattingInfo>(
 										formattingInfo->isLeftAligned(), c - 0x30 /* '0' */,
-										formattingInfo->getMaxLength()));
+										formattingInfo->getMaxLength());
 							state = MIN_STATE;
 						}
 						else
@@ -225,11 +223,10 @@ void PatternParser::parse(
 
 				if ((c >= 0x30 /* '0' */) && (c <= 0x39 /* '9' */))
 				{
-					formattingInfo = FormattingInfoPtr(
-							new FormattingInfo(
+					formattingInfo = std::make_shared<FormattingInfo>(
 								formattingInfo->isLeftAligned(),
 								(formattingInfo->getMinLength() * 10) + (c - 0x30 /* '0' */),
-								formattingInfo->getMaxLength()));
+								formattingInfo->getMaxLength());
 				}
 				else if (c == 0x2E /* '.' */)
 				{
@@ -256,10 +253,9 @@ void PatternParser::parse(
 
 				if ((c >= 0x30 /* '0' */) && (c <= 0x39 /* '9' */))
 				{
-					formattingInfo = FormattingInfoPtr(
-							new FormattingInfo(
+					formattingInfo = std::make_shared<FormattingInfo>(
 								formattingInfo->isLeftAligned(), formattingInfo->getMinLength(),
-								c - 0x30 /* '0' */));
+								c - 0x30 /* '0' */);
 					state = MAX_STATE;
 				}
 				else
@@ -276,10 +272,9 @@ void PatternParser::parse(
 
 				if ((c >= 0x30 /* '0' */) && (c <= 0x39 /* '9' */))
 				{
-					formattingInfo = FormattingInfoPtr(
-							new FormattingInfo(
+					formattingInfo = std::make_shared<FormattingInfo>(
 								formattingInfo->isLeftAligned(), formattingInfo->getMinLength(),
-								(formattingInfo->getMaxLength() * 10) + (c - 0x30 /* '0' */)));
+								(formattingInfo->getMaxLength() * 10) + (c - 0x30 /* '0' */));
 				}
 				else
 				{

--- a/src/main/cpp/properties.cpp
+++ b/src/main/cpp/properties.cpp
@@ -430,8 +430,7 @@ LogString Properties::get(const LogString& key) const
 void Properties::load(InputStreamPtr inStream)
 {
 	Pool pool;
-	InputStreamReaderPtr lineReader(
-		new InputStreamReader(inStream, CharsetDecoder::getISOLatinDecoder()));
+	auto lineReader = std::make_shared<InputStreamReader>(inStream, CharsetDecoder::getISOLatinDecoder());
 	LogString contents = lineReader->read(pool);
 	properties->clear();
 	PropertyParser parser;

--- a/src/main/cpp/propertiespatternconverter.cpp
+++ b/src/main/cpp/propertiespatternconverter.cpp
@@ -60,17 +60,15 @@ PatternConverterPtr PropertiesPatternConverter::newInstance(
 {
 	if (options.size() == 0)
 	{
-		static PatternConverterPtr def(new PropertiesPatternConverter(
-				LOG4CXX_STR("Properties"), LOG4CXX_STR("")));
+		static PatternConverterPtr def = std::make_shared<PropertiesPatternConverter>(
+				LOG4CXX_STR("Properties"), LOG4CXX_STR(""));
 		return def;
 	}
 
 	LogString converterName(LOG4CXX_STR("Property{"));
 	converterName.append(options[0]);
 	converterName.append(LOG4CXX_STR("}"));
-	PatternConverterPtr converter(new PropertiesPatternConverter(
-			converterName, options[0]));
-	return converter;
+	return std::make_shared<PropertiesPatternConverter>(converterName, options[0]);
 }
 
 void PropertiesPatternConverter::format(

--- a/src/main/cpp/relativetimepatternconverter.cpp
+++ b/src/main/cpp/relativetimepatternconverter.cpp
@@ -41,7 +41,7 @@ RelativeTimePatternConverter::RelativeTimePatternConverter() :
 PatternConverterPtr RelativeTimePatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr def(new RelativeTimePatternConverter());
+	static PatternConverterPtr def = std::make_shared<RelativeTimePatternConverter>();
 	return def;
 }
 

--- a/src/main/cpp/resourcebundle.cpp
+++ b/src/main/cpp/resourcebundle.cpp
@@ -92,7 +92,7 @@ ResourceBundlePtr ResourceBundle::getBundle(const LogString& baseName,
 
 			try
 			{
-				current = PropertyResourceBundlePtr(new PropertyResourceBundle(bundleStream));
+				current = std::make_shared<PropertyResourceBundle>(bundleStream);
 			}
 			catch (Exception&)
 			{

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -95,7 +95,7 @@ void RollingFileAppender::activateOptions(Pool& p)
 {
 	if (_priv->rollingPolicy == NULL)
 	{
-		FixedWindowRollingPolicyPtr fwrp = FixedWindowRollingPolicyPtr(new FixedWindowRollingPolicy());
+		auto fwrp = std::make_shared<FixedWindowRollingPolicy>();
 		fwrp->setFileNamePattern(getFile() + LOG4CXX_STR(".%i"));
 		_priv->rollingPolicy = fwrp;
 	}
@@ -115,7 +115,7 @@ void RollingFileAppender::activateOptions(Pool& p)
 
 	if (_priv->triggeringPolicy == NULL)
 	{
-		_priv->triggeringPolicy = TriggeringPolicyPtr(new ManualTriggeringPolicy());
+		_priv->triggeringPolicy = std::make_shared<ManualTriggeringPolicy>();
 	}
 
 	{
@@ -226,7 +226,7 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 			std::string fileName(getFile());
 			RollingPolicyBase* basePolicy = dynamic_cast<RollingPolicyBase* >(&(*rollingPolicy));
 			apr_time_t n = apr_time_now();
-			ObjectPtr obj(new Date(n));
+			ObjectPtr obj = std::make_shared<Date>(n);
 			LogString fileNamePattern;
 
 			if (basePolicy)
@@ -463,7 +463,7 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 void RollingFileAppenderSkeleton::reopenLatestFile(Pool& p)
 {
 	closeWriter();
-	OutputStreamPtr os(new FileOutputStream(getFile(), true));
+	OutputStreamPtr os = std::make_shared<FileOutputStream(getFile>(), true);
 	WriterPtr newWriter(createWriter(os));
 	setFile(getFile());
 	setWriter(newWriter);
@@ -669,7 +669,7 @@ class CountingOutputStream : public OutputStream
  */
 WriterPtr RollingFileAppender::createWriter(OutputStreamPtr& os)
 {
-	OutputStreamPtr cos(new CountingOutputStream(os, this));
+	OutputStreamPtr cos = std::make_shared<CountingOutputStream>(os, this);
 	return FileAppender::createWriter(cos);
 }
 

--- a/src/main/cpp/rollingpolicybase.cpp
+++ b/src/main/cpp/rollingpolicybase.cpp
@@ -114,7 +114,7 @@ void RollingPolicyBase::parseFileNamePattern()
  * @param buf string buffer to which formatted file name is appended, may not be null.
  */
 void RollingPolicyBase::formatFileName(
-	ObjectPtr& obj,
+	const ObjectPtr& obj,
 	LogString& toAppendTo,
 	Pool& pool) const
 {

--- a/src/main/cpp/syslogwriter.cpp
+++ b/src/main/cpp/syslogwriter.cpp
@@ -71,9 +71,9 @@ void SyslogWriter::write(const LogString& source)
 	{
 		LOG4CXX_ENCODE_CHAR(data, source);
 
-		DatagramPacketPtr packet(
-			new DatagramPacket((void*) data.data(), data.length(),
-				m_priv->address, m_priv->syslogHostPort));
+		auto packet = std::make_shared<DatagramPacket>(
+				(void*) data.data(), data.length(),
+				m_priv->address, m_priv->syslogHostPort);
 
 		m_priv->ds->send(packet);
 	}

--- a/src/main/cpp/threadpatternconverter.cpp
+++ b/src/main/cpp/threadpatternconverter.cpp
@@ -39,7 +39,7 @@ ThreadPatternConverter::ThreadPatternConverter() :
 PatternConverterPtr ThreadPatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr def(new ThreadPatternConverter());
+	static PatternConverterPtr def = std::make_shared<ThreadPatternConverter>();
 	return def;
 }
 

--- a/src/main/cpp/threadusernamepatternconverter.cpp
+++ b/src/main/cpp/threadusernamepatternconverter.cpp
@@ -39,7 +39,7 @@ ThreadUsernamePatternConverter::ThreadUsernamePatternConverter() :
 PatternConverterPtr ThreadUsernamePatternConverter::newInstance(
 	const std::vector<LogString>& /* options */)
 {
-	static PatternConverterPtr def(new ThreadUsernamePatternConverter());
+	static PatternConverterPtr def = std::make_shared<ThreadUsernamePatternConverter>();
 	return def;
 }
 

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -62,15 +62,15 @@ ThreadUtility::ThreadUtility() :
 
 ThreadUtility::~ThreadUtility() {}
 
-std::shared_ptr<ThreadUtility> ThreadUtility::instance()
+ThreadUtility* ThreadUtility::instance()
 {
-	static std::shared_ptr<ThreadUtility> instance = std::make_shared<ThreadUtility>();
-	return instance;
+	static ThreadUtility instance;
+	return &instance;
 }
 
 void ThreadUtility::configure( ThreadConfigurationType type )
 {
-	std::shared_ptr<ThreadUtility> utility = instance();
+	auto utility = instance();
 
 	if ( type == ThreadConfigurationType::NoConfiguration )
 	{

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -64,7 +64,7 @@ ThreadUtility::~ThreadUtility() {}
 
 std::shared_ptr<ThreadUtility> ThreadUtility::instance()
 {
-	static std::shared_ptr<ThreadUtility> instance( new ThreadUtility() );
+	static std::shared_ptr<ThreadUtility> instance = std::make_shared<ThreadUtility>();
 	return instance;
 }
 

--- a/src/main/cpp/throwableinformationpatternconverter.cpp
+++ b/src/main/cpp/throwableinformationpatternconverter.cpp
@@ -61,11 +61,11 @@ PatternConverterPtr ThrowableInformationPatternConverter::newInstance(
 {
 	if (options.size() > 0 && options[0].compare(LOG4CXX_STR("short")) == 0)
 	{
-		static PatternConverterPtr shortConverter(new ThrowableInformationPatternConverter(true));
+		static PatternConverterPtr shortConverter = std::make_shared<ThrowableInformationPatternConverter>(true);
 		return shortConverter;
 	}
 
-	static PatternConverterPtr converter(new ThrowableInformationPatternConverter(false));
+	static PatternConverterPtr converter = std::make_shared<ThrowableInformationPatternConverter>(false);
 	return converter;
 }
 

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -196,7 +196,7 @@ void TimeBasedRollingPolicy::activateOptions(log4cxx::helpers::Pool& pool)
 	}
 
 	LogString buf;
-	auto obj = std::make_shared<Date>();
+	ObjectPtr obj = std::make_shared<Date>();
 	formatFileName(obj, buf, pool);
 	lastFileName = buf;
 

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -196,7 +196,7 @@ void TimeBasedRollingPolicy::activateOptions(log4cxx::helpers::Pool& pool)
 	}
 
 	LogString buf;
-	ObjectPtr obj(new Date());
+	auto obj = std::make_shared<Date>();
 	formatFileName(obj, buf, pool);
 	lastFileName = buf;
 
@@ -267,7 +267,7 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::initialize(
 	File currentFile(currentActiveFile);
 
 	LogString buf;
-	ObjectPtr obj(new Date(currentFile.exists(pool) ? currentFile.lastModified(pool) : n));
+	ObjectPtr obj = std::make_shared<Date>(currentFile.exists(pool) ? currentFile.lastModified(pool) : n);
 	formatFileName(obj, buf, pool);
 	lastFileName = buf;
 
@@ -275,15 +275,15 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::initialize(
 
 	if (currentActiveFile.length() > 0)
 	{
-		return RolloverDescriptionPtr(new RolloverDescription(
-					currentActiveFile, append, noAction, noAction));
+		return std::make_shared<RolloverDescription>(
+					currentActiveFile, append, noAction, noAction);
 	}
 	else
 	{
 		bRefreshCurFile = true;
-		return RolloverDescriptionPtr(new RolloverDescription(
+		return std::make_shared<RolloverDescription>(
 					lastFileName.substr(0, lastFileName.length() - suffixLength), append,
-					noAction, noAction));
+					noAction, noAction);
 	}
 }
 
@@ -297,7 +297,7 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::rollover(
 	nextCheck = now.getNextSecond();
 
 	LogString buf;
-	ObjectPtr obj(new Date(n));
+	ObjectPtr obj = std::make_shared<Date>(n);
 	formatFileName(obj, buf, pool);
 
 	LogString newFileName(buf);
@@ -348,24 +348,21 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::rollover(
 	//        and requires a rename plus maintaining the same name
 	if (currentActiveFile != lastBaseName)
 	{
-		renameAction = FileRenameActionPtr(
-				new FileRenameAction(
-					File().setPath(currentActiveFile), File().setPath(lastBaseName), true));
+		renameAction = std::make_shared<FileRenameAction>(
+					File().setPath(currentActiveFile), File().setPath(lastBaseName), true);
 		nextActiveFile = currentActiveFile;
 	}
 
 	if (suffixLength == 3)
 	{
-		compressAction = GZCompressActionPtr(
-				new GZCompressAction(
-					File().setPath(lastBaseName), File().setPath(lastFileName), true));
+		compressAction = std::make_shared<GZCompressAction>(
+					File().setPath(lastBaseName), File().setPath(lastFileName), true);
 	}
 
 	if (suffixLength == 4)
 	{
-		compressAction = ZipCompressActionPtr(
-				new ZipCompressAction(
-					File().setPath(lastBaseName), File().setPath(lastFileName), true));
+		compressAction = std::make_shared<ZipCompressAction>(
+					File().setPath(lastBaseName), File().setPath(lastFileName), true);
 	}
 
 #ifdef LOG4CXX_MULTI_PROCESS
@@ -387,7 +384,7 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::rollover(
 	lastFileName = newFileName;
 #endif
 
-	return RolloverDescriptionPtr(new RolloverDescription(nextActiveFile, append, renameAction, compressAction));
+	return std::make_shared<RolloverDescription>(nextActiveFile, append, renameAction, compressAction);
 }
 
 bool TimeBasedRollingPolicy::isTriggeringEvent(

--- a/src/main/cpp/timezone.cpp
+++ b/src/main/cpp/timezone.cpp
@@ -50,7 +50,7 @@ class GMTTimeZone : public TimeZone
 		/** Class factory. */
 		static const TimeZonePtr& getInstance()
 		{
-			static TimeZonePtr tz( new GMTTimeZone() );
+			static TimeZonePtr tz = std::make_shared<GMTTimeZone>();
 			return tz;
 		}
 
@@ -75,7 +75,6 @@ class GMTTimeZone : public TimeZone
 			return stat;
 		}
 
-	private:
 		GMTTimeZone() : TimeZone( LOG4CXX_STR("GMT") )
 		{
 		}
@@ -90,7 +89,7 @@ class LocalTimeZone : public TimeZone
 		/** Class factory. */
 		static const TimeZonePtr& getInstance()
 		{
-			static TimeZonePtr tz( new LocalTimeZone() );
+			static TimeZonePtr tz = std::make_shared<LocalTimeZone>();
 			return tz;
 		}
 
@@ -116,11 +115,11 @@ class LocalTimeZone : public TimeZone
 		}
 
 
-	private:
 		LocalTimeZone() : TimeZone( getTimeZoneName() )
 		{
 		}
 
+	private:
 		static const LogString getTimeZoneName()
 		{
 			const int MAX_TZ_LENGTH = 255;
@@ -276,7 +275,7 @@ const TimeZonePtr TimeZone::getTimeZone( const LogString& id )
 
 		s.append(mm);
 		apr_int32_t offset = sign * (hours * 3600 + minutes * 60);
-		return TimeZonePtr(new log4cxx::helpers::TimeZoneImpl::FixedTimeZone( s, offset ));
+		return std::make_shared<helpers::TimeZoneImpl::FixedTimeZone>( s, offset );
 	}
 
 	const TimeZonePtr& ltz = getDefault();

--- a/src/main/cpp/xmlsocketappender.cpp
+++ b/src/main/cpp/xmlsocketappender.cpp
@@ -100,10 +100,10 @@ int XMLSocketAppender::getDefaultPort() const
 
 void XMLSocketAppender::setSocket(log4cxx::helpers::SocketPtr& socket, Pool& p)
 {
-	OutputStreamPtr os(new SocketOutputStream(socket));
+	OutputStreamPtr os = std::make_shared<SocketOutputStream>(socket);
 	CharsetEncoderPtr charset(CharsetEncoder::getUTF8Encoder());
 	std::lock_guard<std::recursive_mutex> lock(_priv->mutex);
-	_priv->writer = OutputStreamWriterPtr(new OutputStreamWriter(os, charset));
+	_priv->writer = std::make_shared<OutputStreamWriter>(os, charset);
 }
 
 void XMLSocketAppender::cleanUp(Pool& p)

--- a/src/main/include/log4cxx/helpers/threadutility.h
+++ b/src/main/include/log4cxx/helpers/threadutility.h
@@ -69,8 +69,6 @@ LOG4CXX_PTR_DEF(ThreadUtility);
 class LOG4CXX_EXPORT ThreadUtility
 {
 	private:
-		ThreadUtility();
-
 		log4cxx::helpers::ThreadStartPre preStartFunction();
 		log4cxx::helpers::ThreadStarted threadStartedFunction();
 		log4cxx::helpers::ThreadStartPost postStartFunction();
@@ -78,6 +76,7 @@ class LOG4CXX_EXPORT ThreadUtility
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(priv_data, m_priv)
 
 	public:
+		ThreadUtility();
 		~ThreadUtility();
 
 		static std::shared_ptr<ThreadUtility> instance();

--- a/src/main/include/log4cxx/helpers/threadutility.h
+++ b/src/main/include/log4cxx/helpers/threadutility.h
@@ -69,17 +69,17 @@ LOG4CXX_PTR_DEF(ThreadUtility);
 class LOG4CXX_EXPORT ThreadUtility
 {
 	private:
+		ThreadUtility();
+
 		log4cxx::helpers::ThreadStartPre preStartFunction();
 		log4cxx::helpers::ThreadStarted threadStartedFunction();
 		log4cxx::helpers::ThreadStartPost postStartFunction();
 
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(priv_data, m_priv)
-
 	public:
-		ThreadUtility();
 		~ThreadUtility();
 
-		static std::shared_ptr<ThreadUtility> instance();
+		static ThreadUtility* instance();
 
 		/**
 		 * Utility method for configuring the ThreadUtility in a standard

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -66,10 +66,15 @@ class LOG4CXX_EXPORT Hierarchy :
 		LOG4CXX_CAST_ENTRY(spi::LoggerRepository)
 		END_LOG4CXX_CAST_MAP()
 
+	private:
+		/**
+		Create a new logger hierarchy.
+		*/
+		Hierarchy();
+
 	public:
 		static HierarchyPtr create();
 
-		Hierarchy();
 		~Hierarchy();
 
 		void addHierarchyEventListener(const spi::HierarchyEventListenerPtr& listener);

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -66,15 +66,10 @@ class LOG4CXX_EXPORT Hierarchy :
 		LOG4CXX_CAST_ENTRY(spi::LoggerRepository)
 		END_LOG4CXX_CAST_MAP()
 
-	private:
-		/**
-		Create a new logger hierarchy.
-		*/
-		Hierarchy();
-
 	public:
 		static HierarchyPtr create();
 
+		Hierarchy();
 		~Hierarchy();
 
 		void addHierarchyEventListener(const spi::HierarchyEventListenerPtr& listener);

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -60,22 +60,18 @@ class LOG4CXX_EXPORT Logger :
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(LoggerPrivate, m_priv)
 
-	protected:
-		friend class DefaultLoggerFactory;
-
+	public:
 		/**
-		This constructor created a new <code>logger</code> instance and
+		This constructor initializes a new <code>logger</code> instance and
 		sets its name.
 
-		<p>It is intended to be used by sub-classes only. You should not
-		create categories directly.
+		<p>It is intended to be only used by factory-classes.
 
 		@param pool lifetime of pool must be longer than logger.
 		@param name The name of the logger.
 		*/
-		Logger(log4cxx::helpers::Pool& pool, const LogString& name);
+		Logger(helpers::Pool& pool, const LogString& name);
 
-	public:
 		~Logger();
 
 

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -564,7 +564,7 @@ class LOG4CXX_EXPORT Logger :
 		Return the the LoggerRepository where this
 		<code>Logger</code> is attached.
 		*/
-		log4cxx::spi::LoggerRepositoryPtr getLoggerRepository() const;
+		log4cxx::spi::LoggerRepository* getLoggerRepository() const;
 
 
 		/**
@@ -1404,7 +1404,7 @@ class LOG4CXX_EXPORT Logger :
 		/**
 		Only the Hierarchy class can set the hierarchy of a logger.*/
 		void removeHierarchy();
-		void setHierarchy(const spi::LoggerRepositoryPtr& repository);
+		void setHierarchy(spi::LoggerRepository* repository);
 		void setParent(LoggerPtr parentLogger);
 		spi::LoggerRepository* getHierarchy() const;
 

--- a/src/main/include/log4cxx/pattern/classnamepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/classnamepatternconverter.h
@@ -35,15 +35,13 @@ namespace pattern
  */
 class LOG4CXX_EXPORT ClassNamePatternConverter : public NamePatternConverter
 {
+	public:
 		/**
-		 * Private constructor.
 		 * @param options options, may be null.
 		 * @param logger logger for diagnostic messages, may be null.
 		 */
-		ClassNamePatternConverter(
-			const std::vector<LogString>& options);
+		ClassNamePatternConverter(const std::vector<LogString>& options);
 
-	public:
 		DECLARE_LOG4CXX_PATTERN(ClassNamePatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(ClassNamePatternConverter)

--- a/src/main/include/log4cxx/pattern/colorendpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/colorendpatternconverter.h
@@ -35,17 +35,14 @@ namespace pattern
 class LOG4CXX_EXPORT ColorEndPatternConverter
 	: public LoggingEventPatternConverter
 {
-		/**
-		 * Private constructor.
-		 */
-		ColorEndPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(ColorEndPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(ColorEndPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		ColorEndPatternConverter();
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/colorstartpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/colorstartpatternconverter.h
@@ -35,17 +35,15 @@ namespace pattern
 class LOG4CXX_EXPORT ColorStartPatternConverter
 	: public LoggingEventPatternConverter
 {
-		/**
-		 * Private constructor.
-		 */
-		ColorStartPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(ColorStartPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(ColorStartPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		ColorStartPatternConverter();
+
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/datepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/datepatternconverter.h
@@ -40,13 +40,6 @@ class LOG4CXX_EXPORT DatePatternConverter : public LoggingEventPatternConverter
 		struct DatePatternConverterPrivate;
 
 		/**
-		 * Private constructor.
-		 * @param options options, may be null.
-		 * @param logger logger for diagnostic messages, may be null.
-		 */
-		DatePatternConverter(const OptionsList& options);
-
-		/**
 		 * Obtains an instance of pattern converter.
 		 * @param options options, may be null.
 		 * @return instance of pattern converter.
@@ -58,6 +51,8 @@ class LOG4CXX_EXPORT DatePatternConverter : public LoggingEventPatternConverter
 		LOG4CXX_CAST_ENTRY(DatePatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		DatePatternConverter(const OptionsList& options);
 
 		~DatePatternConverter();
 

--- a/src/main/include/log4cxx/pattern/filelocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/filelocationpatternconverter.h
@@ -35,17 +35,14 @@ namespace pattern
 class LOG4CXX_EXPORT FileLocationPatternConverter
 	: public LoggingEventPatternConverter
 {
-		/**
-		 * Private constructor.
-		 */
-		FileLocationPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(FileLocationPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(FileLocationPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		FileLocationPatternConverter();
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/fulllocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/fulllocationpatternconverter.h
@@ -35,17 +35,14 @@ namespace pattern
 class LOG4CXX_EXPORT FullLocationPatternConverter
 	: public LoggingEventPatternConverter
 {
-		/**
-		 * Private constructor.
-		 */
-		FullLocationPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(FullLocationPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(FullLocationPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		FullLocationPatternConverter();
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/integerpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/integerpatternconverter.h
@@ -34,17 +34,14 @@ namespace pattern
  */
 class LOG4CXX_EXPORT IntegerPatternConverter : public PatternConverter
 {
-		/**
-		 * Private constructor.
-		 */
-		IntegerPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(IntegerPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(IntegerPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(PatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		IntegerPatternConverter();
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/levelpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/levelpatternconverter.h
@@ -34,17 +34,14 @@ namespace pattern
  */
 class LOG4CXX_EXPORT LevelPatternConverter : public LoggingEventPatternConverter
 {
-		/**
-		 * Private constructor.
-		 */
-		LevelPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(LevelPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(LevelPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		LevelPatternConverter();
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/linelocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/linelocationpatternconverter.h
@@ -35,17 +35,14 @@ namespace pattern
 class LOG4CXX_EXPORT LineLocationPatternConverter
 	: public LoggingEventPatternConverter
 {
-		/**
-		 * Private constructor.
-		 */
-		LineLocationPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(LineLocationPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(LineLocationPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		LineLocationPatternConverter();
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/lineseparatorpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/lineseparatorpatternconverter.h
@@ -35,12 +35,6 @@ namespace pattern
 class LOG4CXX_EXPORT LineSeparatorPatternConverter
 	: public LoggingEventPatternConverter
 {
-
-		/**
-		 * Private constructor.
-		 */
-		LineSeparatorPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(LineSeparatorPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
@@ -48,6 +42,7 @@ class LOG4CXX_EXPORT LineSeparatorPatternConverter
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
 
+		LineSeparatorPatternConverter();
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/literalpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/literalpatternconverter.h
@@ -41,19 +41,14 @@ class LOG4CXX_EXPORT LiteralPatternConverter : public LoggingEventPatternConvert
 {
 		struct LiteralPatternConverterPrivate;
 
-		/**
-		 * Create a new instance.
-		 * @param literal string literal.
-		 */
-		LiteralPatternConverter(const LogString& literal);
-
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(LiteralPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(LiteralPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		LiteralPatternConverter(const LogString& literal);
 
 		static PatternConverterPtr newInstance(const LogString& literal);
 

--- a/src/main/include/log4cxx/pattern/loggerpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/loggerpatternconverter.h
@@ -35,20 +35,14 @@ namespace pattern
  */
 class LOG4CXX_EXPORT LoggerPatternConverter : public NamePatternConverter
 {
-
-		/**
-		 * Private constructor.
-		 * @param options options, may be null.
-		 * @param logger logger for diagnostic messages, may be null.
-		 */
-		LoggerPatternConverter(const std::vector<LogString>& options);
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(LoggerPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(LoggerPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(NamePatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		LoggerPatternConverter(const std::vector<LogString>& options);
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/messagepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/messagepatternconverter.h
@@ -34,18 +34,14 @@ namespace pattern
  */
 class LOG4CXX_EXPORT MessagePatternConverter : public LoggingEventPatternConverter
 {
-
-		/**
-		 * Private constructor.
-		 */
-		MessagePatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(MessagePatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(MessagePatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		MessagePatternConverter();
 
 		/**
 		 * Obtains an instance of pattern converter.

--- a/src/main/include/log4cxx/pattern/methodlocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/methodlocationpatternconverter.h
@@ -35,18 +35,14 @@ namespace pattern
 class LOG4CXX_EXPORT MethodLocationPatternConverter
 	: public LoggingEventPatternConverter
 {
-
-		/**
-		 * Private constructor.
-		 */
-		MethodLocationPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(MethodLocationPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(MethodLocationPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		MethodLocationPatternConverter();
 
 		/**
 		 * Obtains an instance of MethodLocationPatternConverter.

--- a/src/main/include/log4cxx/pattern/ndcpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/ndcpatternconverter.h
@@ -34,18 +34,14 @@ namespace pattern
  */
 class LOG4CXX_EXPORT NDCPatternConverter : public LoggingEventPatternConverter
 {
-
-		/**
-		 * Private constructor.
-		 */
-		NDCPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(NDCPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(NDCPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		NDCPatternConverter();
 
 		/**
 		 * Obtains an instance of NDCPatternConverter.

--- a/src/main/include/log4cxx/pattern/propertiespatternconverter.h
+++ b/src/main/include/log4cxx/pattern/propertiespatternconverter.h
@@ -41,19 +41,18 @@ class LOG4CXX_EXPORT PropertiesPatternConverter
 {
 		struct PropertiesPatternConverterPrivate;
 
-		/**
-		 * Private constructor.
-		 * @param options options, may be null.
-		 * @param logger logger for diagnostic messages, may be null.
-		 */
-		PropertiesPatternConverter(const LogString& name, const LogString& option);
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(PropertiesPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(PropertiesPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		/**
+		 * @param options options, may be null.
+		 * @param logger logger for diagnostic messages, may be null.
+		 */
+		PropertiesPatternConverter(const LogString& name, const LogString& option);
 
 		/**
 		 * Obtains an instance of PropertiesPatternConverter.

--- a/src/main/include/log4cxx/pattern/threadpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/threadpatternconverter.h
@@ -34,17 +34,14 @@ namespace pattern
  */
 class LOG4CXX_EXPORT ThreadPatternConverter : public LoggingEventPatternConverter
 {
-		/**
-		 * Private constructor.
-		 */
-		ThreadPatternConverter();
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(ThreadPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(ThreadPatternConverter)
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
+
+		ThreadPatternConverter();
 
 		/**
 		 * Obtains an instance of ThreadPatternConverter.

--- a/src/main/include/log4cxx/pattern/threadusernamepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/threadusernamepatternconverter.h
@@ -29,7 +29,6 @@ namespace pattern
 
 class LOG4CXX_EXPORT ThreadUsernamePatternConverter : public LoggingEventPatternConverter
 {
-        ThreadUsernamePatternConverter();
 
     public:
 	    DECLARE_LOG4CXX_PATTERN(ThreadUsernamePatternConverter)
@@ -37,6 +36,8 @@ class LOG4CXX_EXPORT ThreadUsernamePatternConverter : public LoggingEventPattern
 	    LOG4CXX_CAST_ENTRY(ThreadUsernamePatternConverter)
 	    LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 	    END_LOG4CXX_CAST_MAP()
+
+		ThreadUsernamePatternConverter();
 
 	    static PatternConverterPtr newInstance(
 	            const std::vector<LogString>& options);

--- a/src/main/include/log4cxx/pattern/throwableinformationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/throwableinformationpatternconverter.h
@@ -39,11 +39,6 @@ class LOG4CXX_EXPORT ThrowableInformationPatternConverter
 {
 		struct ThrowableInformationPatternConverterPrivate;
 
-		/**
-		 * Private constructor.
-		 */
-		ThrowableInformationPatternConverter(bool shortReport);
-
 	public:
 		DECLARE_LOG4CXX_PATTERN(ThrowableInformationPatternConverter)
 		BEGIN_LOG4CXX_CAST_MAP()
@@ -51,6 +46,7 @@ class LOG4CXX_EXPORT ThrowableInformationPatternConverter
 		LOG4CXX_CAST_ENTRY_CHAIN(LoggingEventPatternConverter)
 		END_LOG4CXX_CAST_MAP()
 
+		ThrowableInformationPatternConverter(bool shortReport);
 
 		/**
 		 * Gets an instance of the class.

--- a/src/main/include/log4cxx/rolling/rollingpolicybase.h
+++ b/src/main/include/log4cxx/rolling/rollingpolicybase.h
@@ -98,8 +98,8 @@ class LOG4CXX_EXPORT RollingPolicyBase :
 		 * @param buf string buffer to which formatted file name is appended, may not be null.
 		 * @param p memory pool.
 		 */
-		void formatFileName(log4cxx::helpers::ObjectPtr& obj,
-			LogString& buf, log4cxx::helpers::Pool& p) const;
+		void formatFileName(const helpers::ObjectPtr& obj,
+			LogString& buf, helpers::Pool& p) const;
 
 		log4cxx::pattern::PatternConverterPtr getIntegerPatternConverter() const;
 		log4cxx::pattern::PatternConverterPtr getDatePatternConverter() const;

--- a/src/test/cpp/helpers/threadutilitytestcase.cpp
+++ b/src/test/cpp/helpers/threadutilitytestcase.cpp
@@ -33,7 +33,7 @@ LOGUNIT_CLASS(ThreadUtilityTest)
 public:
 	void testNullFunctions()
 	{
-		ThreadUtilityPtr thrUtil = ThreadUtility::instance();
+		auto thrUtil = ThreadUtility::instance();
 
 		thrUtil->configureFuncs( nullptr, nullptr, nullptr );
 
@@ -44,7 +44,7 @@ public:
 
 	void testCustomFunctions()
 	{
-		ThreadUtilityPtr thrUtil = ThreadUtility::instance();
+		auto thrUtil = ThreadUtility::instance();
 		int num_pre = 0;
 		int num_started = 0;
 		int num_post = 0;
@@ -79,7 +79,7 @@ public:
 	{
 		ThreadUtility::configure( ThreadConfigurationType::BlockSignalsAndNameThread );
 
-		ThreadUtilityPtr thrUtil = ThreadUtility::instance();
+		auto thrUtil = ThreadUtility::instance();
 
 		std::thread t = thrUtil->createThread( LOG4CXX_STR("FooName"), []() {} );
 

--- a/src/test/cpp/loggertestcase.cpp
+++ b/src/test/cpp/loggertestcase.cpp
@@ -228,7 +228,7 @@ public:
 		LoggerPtr root = Logger::getRootLogger();
 		root->addAppender(caRoot);
 
-		LoggerRepositoryPtr h = LogManager::getLoggerRepository();
+		auto h = LogManager::getLoggerRepository();
 
 		//h.disableDebug();
 		h->setThreshold(Level::getInfo());


### PR DESCRIPTION
This is a performance improvement as std::make_shared makes only one allocation.

Some previously private constructors have been made public as std::make_shared needs access to the constructor. While these constructors are not intended for client use, [alternative](https://stackoverflow.com/questions/8147027/how-do-i-call-stdmake-shared-on-a-class-with-only-protected-or-private-const) approaches seem unnessessaryly complex.