### PR TITLE
Reduce std::ostream logging overhead

### DIFF
--- a/src/main/cpp/domconfigurator.cpp
+++ b/src/main/cpp/domconfigurator.cpp
@@ -1038,14 +1038,6 @@ void DOMConfigurator::parse(
 		m_priv->repository->setThreshold(thresholdStr);
 	}
 
-	LogString strstrValue = subst(getAttribute(utf8Decoder, element, STRINGSTREAM_ATTR));
-	LogLog::debug(LOG4CXX_STR("Stringstream =\"") + strstrValue + LOG4CXX_STR("\"."));
-
-	if (!strstrValue.empty() && strstrValue != NULL_STRING)
-	{
-		MessageBufferUseStaticStream();
-	}
-
 	LogString threadSignalValue = subst(getAttribute(utf8Decoder, element, THREAD_CONFIG_ATTR));
 
 	if ( !threadSignalValue.empty() && threadSignalValue != NULL_STRING )

--- a/src/main/cpp/propertyconfigurator.cpp
+++ b/src/main/cpp/propertyconfigurator.cpp
@@ -178,14 +178,6 @@ void PropertyConfigurator::doConfigure(helpers::Properties& properties,
 			+ LOG4CXX_STR("]."));
 	}
 
-	static const LogString STRINGSTREAM_KEY(LOG4CXX_STR("log4j.stringstream"));
-	LogString strstrValue(properties.getProperty(STRINGSTREAM_KEY));
-
-	if (strstrValue == LOG4CXX_STR("static"))
-	{
-		MessageBufferUseStaticStream();
-	}
-
 	LogString threadConfigurationValue(properties.getProperty(LOG4CXX_STR("log4j.threadConfiguration")));
 
 	if ( threadConfigurationValue == LOG4CXX_STR("NoConfiguration") )

--- a/src/main/include/log4cxx/helpers/messagebuffer.h
+++ b/src/main/include/log4cxx/helpers/messagebuffer.h
@@ -34,8 +34,6 @@ namespace log4cxx
 namespace helpers
 {
 
-void MessageBufferUseStaticStream();
-
 typedef std::ios_base& (*ios_base_manip)(std::ios_base&);
 
 /**


### PR DESCRIPTION
This PR reduces the overhead of logging values through `operator<<(std::ostream&` by using a thread local std::basic_ostringstream where available.

It retains the static string logging optimization,  thereby resolving the issue with the previous attempt ([LOGCXX-500](https://issues.apache.org/jira/browse/LOGCXX-500)) to introduce this optimization.