### PR TITLE
Fix a few of the classes that did not get done during ABI stabilization

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -32,6 +32,5 @@
 --pad-comma
 --pad-header
 --pad-oper
---recursive
 --style=break
 --suffix=none

--- a/src/main/cpp/inetaddress.cpp
+++ b/src/main/cpp/inetaddress.cpp
@@ -28,6 +28,12 @@ using namespace log4cxx::helpers;
 
 IMPLEMENT_LOG4CXX_OBJECT(InetAddress)
 
+struct InetAddress::InetAddressPrivate{
+
+	LogString ipAddrString;
+	LogString hostNameString;
+};
+
 UnknownHostException::UnknownHostException(const LogString& msg1)
 	: Exception(msg1)
 {
@@ -46,10 +52,13 @@ UnknownHostException& UnknownHostException::operator=(const UnknownHostException
 
 
 InetAddress::InetAddress(const LogString& hostName, const LogString& hostAddr)
-	: ipAddrString(hostAddr), hostNameString(hostName)
+	: m_priv(std::make_unique<InetAddressPrivate>())
 {
+	m_priv->ipAddrString = hostAddr;
+	m_priv->hostNameString = hostName;
 }
 
+InetAddress::~InetAddress(){}
 
 /** Determines all the IP addresses of a host, given the host's name.
 */
@@ -119,14 +128,14 @@ InetAddressPtr InetAddress::getByName(const LogString& host)
 */
 LogString InetAddress::getHostAddress() const
 {
-	return ipAddrString;
+	return m_priv->ipAddrString;
 }
 
 /** Gets the host name for this IP address.
 */
 LogString InetAddress::getHostName() const
 {
-	return hostNameString;
+	return m_priv->hostNameString;
 }
 
 /** Returns the local host.

--- a/src/main/cpp/jsonlayout.cpp
+++ b/src/main/cpp/jsonlayout.cpp
@@ -32,16 +32,61 @@ using namespace log4cxx::spi;
 
 IMPLEMENT_LOG4CXX_OBJECT(JSONLayout)
 
+struct JSONLayout::JSONLayoutPrivate
+{
+	JSONLayoutPrivate() :
+		locationInfo(false),
+		prettyPrint(false),
+		dateFormat(),
+		ppIndentL1(LOG4CXX_STR("  ")),
+		ppIndentL2(LOG4CXX_STR("    ")) {}
+
+	// Print no location info by default
+	bool locationInfo; //= false
+	bool prettyPrint; //= false
+
+	helpers::ISO8601DateFormat dateFormat;
+
+	LogString ppIndentL1;
+	LogString ppIndentL2;
+};
 
 JSONLayout::JSONLayout() :
-	locationInfo(false),
-	prettyPrint(false),
-	dateFormat(),
-	ppIndentL1(LOG4CXX_STR("  ")),
-	ppIndentL2(LOG4CXX_STR("    "))
+	m_priv(std::make_unique<JSONLayoutPrivate>())
 {
 }
 
+JSONLayout::~JSONLayout(){}
+
+void JSONLayout::setLocationInfo(bool locationInfoFlag)
+{
+	m_priv->locationInfo = locationInfoFlag;
+}
+
+bool JSONLayout::getLocationInfo() const
+{
+	return m_priv->locationInfo;
+}
+
+void JSONLayout::setPrettyPrint(bool prettyPrintFlag)
+{
+	m_priv->prettyPrint = prettyPrintFlag;
+}
+
+bool JSONLayout::getPrettyPrint() const
+{
+	return m_priv->prettyPrint;
+}
+
+LogString JSONLayout::getContentType() const
+{
+	return LOG4CXX_STR("application/json");
+}
+
+void JSONLayout::activateOptions(helpers::Pool& /* p */)
+{
+
+}
 
 void JSONLayout::setOption(const LogString& option, const LogString& value)
 {
@@ -62,24 +107,24 @@ void JSONLayout::format(LogString& output,
 	Pool& p) const
 {
 	output.append(LOG4CXX_STR("{"));
-	output.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		output.append(ppIndentL1);
+		output.append(m_priv->ppIndentL1);
 	}
 
 	appendQuotedEscapedString(output, LOG4CXX_STR("timestamp"));
 	output.append(LOG4CXX_STR(": "));
 	LogString timestamp;
-	dateFormat.format(timestamp, event->getTimeStamp(), p);
+	m_priv->dateFormat.format(timestamp, event->getTimeStamp(), p);
 	appendQuotedEscapedString(output, timestamp);
 	output.append(LOG4CXX_STR(","));
-	output.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		output.append(ppIndentL1);
+		output.append(m_priv->ppIndentL1);
 	}
 
 	appendQuotedEscapedString(output, LOG4CXX_STR("level"));
@@ -88,22 +133,22 @@ void JSONLayout::format(LogString& output,
 	event->getLevel()->toString(level);
 	appendQuotedEscapedString(output, level);
 	output.append(LOG4CXX_STR(","));
-	output.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		output.append(ppIndentL1);
+		output.append(m_priv->ppIndentL1);
 	}
 
 	appendQuotedEscapedString(output, LOG4CXX_STR("logger"));
 	output.append(LOG4CXX_STR(": "));
 	appendQuotedEscapedString(output, event->getLoggerName());
 	output.append(LOG4CXX_STR(","));
-	output.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		output.append(ppIndentL1);
+		output.append(m_priv->ppIndentL1);
 	}
 
 	appendQuotedEscapedString(output, LOG4CXX_STR("message"));
@@ -113,14 +158,14 @@ void JSONLayout::format(LogString& output,
 	appendSerializedMDC(output, event);
 	appendSerializedNDC(output, event);
 
-	if (locationInfo)
+	if (m_priv->locationInfo)
 	{
 		output.append(LOG4CXX_STR(","));
-		output.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+		output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 		appendSerializedLocationInfo(output, event, p);
 	}
 
-	output.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 	output.append(LOG4CXX_STR("}"));
 	output.append(LOG4CXX_EOL);
 }
@@ -234,23 +279,23 @@ void JSONLayout::appendSerializedMDC(LogString& buf,
 	}
 
 	buf.append(LOG4CXX_STR(","));
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL1);
+		buf.append(m_priv->ppIndentL1);
 	}
 
 	appendQuotedEscapedString(buf, LOG4CXX_STR("context_map"));
 	buf.append(LOG4CXX_STR(": {"));
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
 	for (LoggingEvent::KeySet::iterator it = keys.begin();
 		it != keys.end(); ++it)
 	{
-		if (prettyPrint)
+		if (m_priv->prettyPrint)
 		{
-			buf.append(ppIndentL2);
+			buf.append(m_priv->ppIndentL2);
 		}
 
 		appendQuotedEscapedString(buf, *it);
@@ -263,17 +308,17 @@ void JSONLayout::appendSerializedMDC(LogString& buf,
 		if (it + 1 != keys.end())
 		{
 			buf.append(LOG4CXX_STR(","));
-			buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+			buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 		}
 		else
 		{
-			buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+			buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 		}
 	}
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL1);
+		buf.append(m_priv->ppIndentL1);
 	}
 
 	buf.append(LOG4CXX_STR("}"));
@@ -290,28 +335,28 @@ void JSONLayout::appendSerializedNDC(LogString& buf,
 	}
 
 	buf.append(LOG4CXX_STR(","));
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL1);
+		buf.append(m_priv->ppIndentL1);
 	}
 
 	appendQuotedEscapedString(buf, LOG4CXX_STR("context_stack"));
 	buf.append(LOG4CXX_STR(": ["));
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL2);
+		buf.append(m_priv->ppIndentL2);
 	}
 
 	appendQuotedEscapedString(buf, ndcVal);
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL1);
+		buf.append(m_priv->ppIndentL1);
 	}
 
 	buf.append(LOG4CXX_STR("]"));
@@ -320,19 +365,19 @@ void JSONLayout::appendSerializedNDC(LogString& buf,
 void JSONLayout::appendSerializedLocationInfo(LogString& buf,
 	const LoggingEventPtr& event, Pool& p) const
 {
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL1);
+		buf.append(m_priv->ppIndentL1);
 	}
 
 	appendQuotedEscapedString(buf, LOG4CXX_STR("location_info"));
 	buf.append(LOG4CXX_STR(": {"));
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 	const LocationInfo& locInfo = event->getLocationInformation();
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL2);
+		buf.append(m_priv->ppIndentL2);
 	}
 
 	appendQuotedEscapedString(buf, LOG4CXX_STR("file"));
@@ -340,11 +385,11 @@ void JSONLayout::appendSerializedLocationInfo(LogString& buf,
 	LOG4CXX_DECODE_CHAR(fileName, locInfo.getFileName());
 	appendQuotedEscapedString(buf, fileName);
 	buf.append(LOG4CXX_STR(","));
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL2);
+		buf.append(m_priv->ppIndentL2);
 	}
 
 	appendQuotedEscapedString(buf, LOG4CXX_STR("line"));
@@ -353,11 +398,11 @@ void JSONLayout::appendSerializedLocationInfo(LogString& buf,
 	StringHelper::toString(locInfo.getLineNumber(), p, lineNumber);
 	appendQuotedEscapedString(buf, lineNumber);
 	buf.append(LOG4CXX_STR(","));
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL2);
+		buf.append(m_priv->ppIndentL2);
 	}
 
 	appendQuotedEscapedString(buf, LOG4CXX_STR("class"));
@@ -365,22 +410,22 @@ void JSONLayout::appendSerializedLocationInfo(LogString& buf,
 	LOG4CXX_DECODE_CHAR(className, locInfo.getClassName());
 	appendQuotedEscapedString(buf, className);
 	buf.append(LOG4CXX_STR(","));
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL2);
+		buf.append(m_priv->ppIndentL2);
 	}
 
 	appendQuotedEscapedString(buf, LOG4CXX_STR("method"));
 	buf.append(LOG4CXX_STR(": "));
 	LOG4CXX_DECODE_CHAR(methodName, locInfo.getMethodName());
 	appendQuotedEscapedString(buf, methodName);
-	buf.append(prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
+	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
-	if (prettyPrint)
+	if (m_priv->prettyPrint)
 	{
-		buf.append(ppIndentL1);
+		buf.append(m_priv->ppIndentL1);
 	}
 
 	buf.append(LOG4CXX_STR("}"));

--- a/src/main/cpp/onlyonceerrorhandler.cpp
+++ b/src/main/cpp/onlyonceerrorhandler.cpp
@@ -26,11 +26,23 @@ using namespace log4cxx::spi;
 
 IMPLEMENT_LOG4CXX_OBJECT(OnlyOnceErrorHandler)
 
+struct OnlyOnceErrorHandler::OnlyOnceErrorHandlerPrivate{
+	OnlyOnceErrorHandlerPrivate() :
+		WARN_PREFIX(LOG4CXX_STR("log4cxx warning: ")),
+		ERROR_PREFIX(LOG4CXX_STR("log4cxx error: ")),
+		firstTime(true){}
+
+	LogString WARN_PREFIX;
+	LogString ERROR_PREFIX;
+	mutable bool firstTime;
+};
+
 OnlyOnceErrorHandler::OnlyOnceErrorHandler() :
-	WARN_PREFIX(LOG4CXX_STR("log4cxx warning: ")),
-	ERROR_PREFIX(LOG4CXX_STR("log4cxx error: ")), firstTime(true)
+	m_priv(std::make_unique<OnlyOnceErrorHandlerPrivate>())
 {
 }
+
+OnlyOnceErrorHandler::~OnlyOnceErrorHandler(){}
 
 void OnlyOnceErrorHandler::setLogger(const LoggerPtr&)
 {
@@ -47,10 +59,10 @@ void OnlyOnceErrorHandler::setOption(const LogString&, const LogString&)
 void OnlyOnceErrorHandler::error(const LogString& message, const std::exception& e,
 	int) const
 {
-	if (firstTime)
+	if (m_priv->firstTime)
 	{
 		LogLog::error(message, e);
-		firstTime = false;
+		m_priv->firstTime = false;
 	}
 }
 
@@ -63,10 +75,10 @@ void OnlyOnceErrorHandler::error(const LogString& message, const std::exception&
 
 void OnlyOnceErrorHandler::error(const LogString& message) const
 {
-	if (firstTime)
+	if (m_priv->firstTime)
 	{
 		LogLog::error(message);
-		firstTime = false;
+		m_priv->firstTime = false;
 	}
 }
 

--- a/src/main/cpp/rolloverdescription.cpp
+++ b/src/main/cpp/rolloverdescription.cpp
@@ -24,8 +24,46 @@ using namespace log4cxx::helpers;
 
 IMPLEMENT_LOG4CXX_OBJECT(RolloverDescription)
 
+struct RolloverDescription::RolloverDescriptionPrivate{
+	RolloverDescriptionPrivate(){}
 
-RolloverDescription::RolloverDescription()
+	RolloverDescriptionPrivate(
+		const LogString& activeFileName1,
+		const bool append1,
+		const ActionPtr& synchronous1,
+		const ActionPtr& asynchronous1)
+		: activeFileName(activeFileName1),
+		  append(append1),
+		  synchronous(synchronous1),
+		  asynchronous(asynchronous1)
+	{}
+
+	/**
+	 * Active log file name after rollover.
+	 */
+	LogString activeFileName;
+
+	/**
+	 * Should active file be opened for appending.
+	 */
+	bool append;
+
+	/**
+	 * Action to be completed after close of current active log file
+	 * before returning control to caller.
+	 */
+	ActionPtr synchronous;
+
+	/**
+	 * Action to be completed after close of current active log file
+	 * and before next rollover attempt, may be executed asynchronously.
+	 */
+	ActionPtr asynchronous;
+};
+
+
+RolloverDescription::RolloverDescription() :
+	m_priv(std::make_unique<RolloverDescriptionPrivate>())
 {
 }
 
@@ -34,26 +72,25 @@ RolloverDescription::RolloverDescription(
 	const bool append1,
 	const ActionPtr& synchronous1,
 	const ActionPtr& asynchronous1)
-	: activeFileName(activeFileName1),
-	  append(append1),
-	  synchronous(synchronous1),
-	  asynchronous(asynchronous1)
+	: m_priv(std::make_unique<RolloverDescriptionPrivate>(activeFileName1, append1, synchronous1, asynchronous1))
 {
 }
 
+RolloverDescription::~RolloverDescription(){}
+
 LogString RolloverDescription::getActiveFileName() const
 {
-	return activeFileName;
+	return m_priv->activeFileName;
 }
 
 bool RolloverDescription::getAppend() const
 {
-	return append;
+	return m_priv->append;
 }
 
 ActionPtr RolloverDescription::getSynchronous() const
 {
-	return synchronous;
+	return m_priv->synchronous;
 }
 
 /**
@@ -64,5 +101,5 @@ ActionPtr RolloverDescription::getSynchronous() const
  */
 ActionPtr RolloverDescription::getAsynchronous() const
 {
-	return asynchronous;
+	return m_priv->asynchronous;
 }

--- a/src/main/cpp/simpledateformat.cpp
+++ b/src/main/cpp/simpledateformat.cpp
@@ -796,35 +796,51 @@ void SimpleDateFormat::parsePattern( const LogString& fmt, const std::locale* lo
 }
 
 
-SimpleDateFormat::SimpleDateFormat( const LogString& fmt ) : timeZone( TimeZone::getDefault() )
+struct SimpleDateFormat::SimpleDateFormatPrivate{
+	SimpleDateFormatPrivate() :
+		timeZone(TimeZone::getDefault())
+	{}
+
+	/**
+	 * Time zone.
+	 */
+	TimeZonePtr timeZone;
+
+	/**
+	 * List of tokens.
+	 */
+	PatternTokenList pattern;
+};
+
+SimpleDateFormat::SimpleDateFormat( const LogString& fmt ) : m_priv(std::make_unique<SimpleDateFormatPrivate>())
 {
 #if LOG4CXX_HAS_STD_LOCALE
 	std::locale defaultLocale;
-	parsePattern( fmt, & defaultLocale, pattern );
+	parsePattern( fmt, & defaultLocale, m_priv->pattern );
 #else
-	parsePattern( fmt, NULL, pattern );
+	parsePattern( fmt, NULL, m_priv->pattern );
 #endif
 
-	for ( PatternTokenList::iterator iter = pattern.begin(); iter != pattern.end(); iter++ )
+	for ( PatternTokenList::iterator iter = m_priv->pattern.begin(); iter != m_priv->pattern.end(); iter++ )
 	{
-		( * iter )->setTimeZone( timeZone );
+		( * iter )->setTimeZone( m_priv->timeZone );
 	}
 }
 
-SimpleDateFormat::SimpleDateFormat( const LogString& fmt, const std::locale* locale ) : timeZone( TimeZone::getDefault() )
+SimpleDateFormat::SimpleDateFormat( const LogString& fmt, const std::locale* locale ) : m_priv(std::make_unique<SimpleDateFormatPrivate>())
 {
-	parsePattern( fmt, locale, pattern );
+	parsePattern( fmt, locale, m_priv->pattern );
 
-	for ( PatternTokenList::iterator iter = pattern.begin(); iter != pattern.end(); iter++ )
+	for ( PatternTokenList::iterator iter = m_priv->pattern.begin(); iter != m_priv->pattern.end(); iter++ )
 	{
-		( * iter )->setTimeZone( timeZone );
+		( * iter )->setTimeZone( m_priv->timeZone );
 	}
 }
 
 
 SimpleDateFormat::~SimpleDateFormat()
 {
-	for ( PatternTokenList::iterator iter = pattern.begin(); iter != pattern.end(); iter++ )
+	for ( PatternTokenList::iterator iter = m_priv->pattern.begin(); iter != m_priv->pattern.end(); iter++ )
 	{
 		delete * iter;
 	}
@@ -834,11 +850,11 @@ SimpleDateFormat::~SimpleDateFormat()
 void SimpleDateFormat::format( LogString& s, log4cxx_time_t time, Pool& p ) const
 {
 	apr_time_exp_t exploded;
-	apr_status_t stat = timeZone->explode( & exploded, time );
+	apr_status_t stat = m_priv->timeZone->explode( & exploded, time );
 
 	if ( stat == APR_SUCCESS )
 	{
-		for ( PatternTokenList::const_iterator iter = pattern.begin(); iter != pattern.end(); iter++ )
+		for ( PatternTokenList::const_iterator iter = m_priv->pattern.begin(); iter != m_priv->pattern.end(); iter++ )
 		{
 			( * iter )->format( s, exploded, p );
 		}
@@ -847,5 +863,5 @@ void SimpleDateFormat::format( LogString& s, log4cxx_time_t time, Pool& p ) cons
 
 void SimpleDateFormat::setTimeZone( const TimeZonePtr& zone )
 {
-	timeZone = zone;
+	m_priv->timeZone = zone;
 }

--- a/src/main/include/log4cxx/helpers/aprinitializer.h
+++ b/src/main/include/log4cxx/helpers/aprinitializer.h
@@ -82,12 +82,7 @@ class APRInitializer
 		const ObjectPtr& findOrAddObject(size_t key, std::function<ObjectPtr()> creator);
 		void stopWatchDogs();
 	private: // Attributes
-		apr_pool_t* p;
-		std::mutex mutex;
-		std::list<FileWatchdog*> watchdogs;
-		log4cxx_time_t startTime;
-		apr_threadkey_t* tlsKey;
-		std::map<size_t, ObjectPtr> objects;
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(APRInitializerPrivate, m_priv)
 	private: // Class methods
 		static APRInitializer& getInstance();
 

--- a/src/main/include/log4cxx/helpers/inetaddress.h
+++ b/src/main/include/log4cxx/helpers/inetaddress.h
@@ -50,6 +50,8 @@ class LOG4CXX_EXPORT InetAddress : public Object
 
 		InetAddress(const LogString& hostName, const LogString& hostAddr);
 
+		~InetAddress();
+
 		/** Determines all the IP addresses of a host, given the host's name.
 		*/
 		static InetAddressList getAllByName(const LogString& host);
@@ -81,8 +83,7 @@ class LOG4CXX_EXPORT InetAddress : public Object
 		LogString toString() const;
 
 	private:
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(LogString, ipAddrString)
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(LogString, hostNameString)
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(InetAddressPrivate, m_priv)
 }; // class InetAddress
 }  // namespace helpers
 } // namespace log4cxx

--- a/src/main/include/log4cxx/helpers/inputstreamreader.h
+++ b/src/main/include/log4cxx/helpers/inputstreamreader.h
@@ -40,8 +40,7 @@ LOG4CXX_INSTANTIATE_EXPORTED_PTR(CharsetDecoder);
 class LOG4CXX_EXPORT InputStreamReader : public Reader
 {
 	private:
-		InputStreamPtr in;
-		CharsetDecoderPtr dec;
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(InputStreamReaderPrivate, m_priv)
 
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(InputStreamReader)

--- a/src/main/include/log4cxx/helpers/onlyonceerrorhandler.h
+++ b/src/main/include/log4cxx/helpers/onlyonceerrorhandler.h
@@ -40,9 +40,7 @@ class LOG4CXX_EXPORT OnlyOnceErrorHandler :
 	public virtual Object
 {
 	private:
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(LogString, WARN_PREFIX)
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(LogString, ERROR_PREFIX)
-		mutable bool firstTime;
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(OnlyOnceErrorHandlerPrivate, m_priv)
 
 	public:
 		DECLARE_LOG4CXX_OBJECT(OnlyOnceErrorHandler)
@@ -52,6 +50,8 @@ class LOG4CXX_EXPORT OnlyOnceErrorHandler :
 		END_LOG4CXX_CAST_MAP()
 
 		OnlyOnceErrorHandler();
+
+		~OnlyOnceErrorHandler();
 
 		/**
 		 Does not do anything.

--- a/src/main/include/log4cxx/helpers/simpledateformat.h
+++ b/src/main/include/log4cxx/helpers/simpledateformat.h
@@ -66,15 +66,7 @@ class LOG4CXX_EXPORT SimpleDateFormat : public DateFormat
 		void setTimeZone(const TimeZonePtr& zone);
 
 	private:
-		/**
-		 * Time zone.
-		 */
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(TimeZonePtr, timeZone)
-
-		/**
-		 * List of tokens.
-		 */
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(PatternTokenList, pattern)
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(SimpleDateFormatPrivate, m_priv)
 
 		static void addToken(const logchar spec, const int repeat, const std::locale* locale, PatternTokenList& pattern);
 		static void parsePattern(const LogString& spec, const std::locale* locale, PatternTokenList& pattern);

--- a/src/main/include/log4cxx/helpers/strftimedateformat.h
+++ b/src/main/include/log4cxx/helpers/strftimedateformat.h
@@ -54,11 +54,7 @@ class LOG4CXX_EXPORT StrftimeDateFormat : public DateFormat
 
 
 	private:
-		/**
-		*    Time zone.
-		*/
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(TimeZonePtr, timeZone)
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(std::string, pattern)
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(StrftimeDateFormatPrivate, m_priv)
 };
 
 

--- a/src/main/include/log4cxx/jsonlayout.h
+++ b/src/main/include/log4cxx/jsonlayout.h
@@ -31,17 +31,9 @@ This layout outputs events in a JSON dictionary.
 class LOG4CXX_EXPORT JSONLayout : public Layout
 {
 	private:
-		// Print no location info by default
-		bool locationInfo; //= false
-		bool prettyPrint; //= false
-
-		helpers::ISO8601DateFormat dateFormat;
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(JSONLayoutPrivate, m_priv)
 
 	protected:
-
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(LogString, ppIndentL1)
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(LogString, ppIndentL2)
-
 		void appendQuotedEscapedString(LogString& buf, const LogString& input) const;
 		void appendSerializedMDC(LogString& buf,
 			const spi::LoggingEventPtr& event) const;
@@ -59,6 +51,8 @@ class LOG4CXX_EXPORT JSONLayout : public Layout
 
 		JSONLayout();
 
+		~JSONLayout();
+
 		/**
 		The <b>LocationInfo</b> option takes a boolean value. By
 		default, it is set to false which means there will be no location
@@ -66,19 +60,13 @@ class LOG4CXX_EXPORT JSONLayout : public Layout
 		true, then the file name and line number of the statement
 		at the origin of the log statement will be output.
 		*/
-		inline void setLocationInfo(bool locationInfoFlag)
-		{
-			this->locationInfo = locationInfoFlag;
-		}
+		void setLocationInfo(bool locationInfoFlag);
 
 
 		/**
 		Returns the current value of the <b>LocationInfo</b> option.
 		*/
-		inline bool getLocationInfo() const
-		{
-			return locationInfo;
-		}
+		bool getLocationInfo() const;
 
 		/**
 		The <b>PrettyPrint</b> option takes a boolean value. By
@@ -87,32 +75,20 @@ class LOG4CXX_EXPORT JSONLayout : public Layout
 		then each log event will produce multiple lines, each indented
 		for readability.
 		*/
-		inline void setPrettyPrint(bool prettyPrintFlag)
-		{
-			this->prettyPrint = prettyPrintFlag;
-		}
+		void setPrettyPrint(bool prettyPrintFlag);
 
 		/**
 		Returns the current value of the <b>PrettyPrint</b> option.
 		*/
-		inline bool getPrettyPrint() const
-		{
-			return prettyPrint;
-		}
+		bool getPrettyPrint() const;
 
 
 		/**
 		Returns the content type output by this layout, i.e "application/json".
 		*/
-		LogString getContentType() const override
-		{
-			return LOG4CXX_STR("application/json");
-		}
+		LogString getContentType() const override;
 
-		/**
-		No options to activate.
-		*/
-		void activateOptions(helpers::Pool& /* p */) override {}
+		void activateOptions(helpers::Pool& /* p */) override;
 
 		/**
 		Set options

--- a/src/main/include/log4cxx/rolling/filterbasedtriggeringpolicy.h
+++ b/src/main/include/log4cxx/rolling/filterbasedtriggeringpolicy.h
@@ -56,15 +56,7 @@ class LOG4CXX_EXPORT FilterBasedTriggeringPolicy : public TriggeringPolicy
 		LOG4CXX_CAST_ENTRY_CHAIN(TriggeringPolicy)
 		END_LOG4CXX_CAST_MAP()
 
-		/**
-		 * The first filter in the filter chain. Set to <code>null</code> initially.
-		 */
-		log4cxx::spi::FilterPtr headFilter;
-
-		/**
-		 * The last filter in the filter chain.
-		 */
-		log4cxx::spi::FilterPtr tailFilter;
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(FilterBasedTriggeringPolicyPrivate, m_priv)
 
 	public:
 		/**

--- a/src/main/include/log4cxx/rolling/rolloverdescription.h
+++ b/src/main/include/log4cxx/rolling/rolloverdescription.h
@@ -32,27 +32,8 @@ class RolloverDescription : public log4cxx::helpers::Object
 		BEGIN_LOG4CXX_CAST_MAP()
 		LOG4CXX_CAST_ENTRY(RolloverDescription)
 		END_LOG4CXX_CAST_MAP()
-		/**
-		 * Active log file name after rollover.
-		 */
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(LogString, activeFileName)
 
-		/**
-		 * Should active file be opened for appending.
-		 */
-		bool append;
-
-		/**
-		 * Action to be completed after close of current active log file
-		 * before returning control to caller.
-		 */
-		ActionPtr synchronous;
-
-		/**
-		 * Action to be completed after close of current active log file
-		 * and before next rollover attempt, may be executed asynchronously.
-		 */
-		ActionPtr asynchronous;
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(RolloverDescriptionPrivate, m_priv)
 
 	public:
 		RolloverDescription();
@@ -69,6 +50,8 @@ class RolloverDescription : public log4cxx::helpers::Object
 			const bool append,
 			const ActionPtr& synchronous,
 			const ActionPtr& asynchronous);
+
+		~RolloverDescription();
 
 		/**
 		 * Active log file name after rollover.

--- a/src/test/cpp/jsonlayouttest.cpp
+++ b/src/test/cpp/jsonlayouttest.cpp
@@ -35,6 +35,10 @@ using namespace log4cxx::spi;
 #else
 	#error __LOG4CXX_FUNC__ expected to be defined
 #endif
+
+static LogString ppIndentL1(LOG4CXX_STR("  "));
+static LogString ppIndentL2(LOG4CXX_STR("    "));
+
 /**
  * Test for JSONLayout.
  *


### PR DESCRIPTION
This should fix the remainder of the classes that for one reason or another did not get caught during the efforts to make log4cxx ABI stable.

There are still a handful of classes that have private data members, but these are unlikely to change at this point.

The ABI symbols have been updated as well 