### PR TITLE
Improve documentation of Logger methods

### DIFF
--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -106,7 +106,7 @@ class LOG4CXX_EXPORT Logger :
 		void closeNestedAppenders();
 
 		/**
-		Log a message string with the DEBUG level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -120,7 +120,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the DEBUG level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -134,7 +134,7 @@ class LOG4CXX_EXPORT Logger :
 		void debug(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Log a message string with the DEBUG level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -148,7 +148,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the DEBUG level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -163,7 +163,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Log a message string with the DEBUG level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -177,7 +177,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the DEBUG level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -192,7 +192,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Log a message string with the DEBUG level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -206,7 +206,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the DEBUG level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -221,7 +221,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -235,7 +235,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -249,7 +249,7 @@ class LOG4CXX_EXPORT Logger :
 		void error(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -262,7 +262,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::wstring& msg) const;
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -278,7 +278,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -292,7 +292,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -307,7 +307,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -321,7 +321,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -336,7 +336,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Log a message string with the FATAL level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for FATAL messages.
 
 		<p>This method first checks if this logger is <code>FATAL</code>
 		enabled by comparing the level of this logger with the
@@ -350,7 +350,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -364,7 +364,7 @@ class LOG4CXX_EXPORT Logger :
 		void fatal(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -378,7 +378,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -393,7 +393,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -407,7 +407,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -422,7 +422,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -436,7 +436,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the ERROR level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -451,7 +451,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -460,7 +460,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const std::string& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -469,7 +469,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -478,7 +478,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const std::wstring& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -487,7 +487,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API || LOG4CXX_CFSTRING_API
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -496,7 +496,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const std::basic_string<UniChar>& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -505,7 +505,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -514,7 +514,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const CFStringRef& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -522,7 +522,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const CFStringRef& message) const;
 #endif
 		/**
-		This method creates a new logging event and logs the event
+		Add a new logging event to the appender(s) attached to this logger
 		without further checks.
 		@param level the level to log.
 		@param message the message string to log.
@@ -574,34 +574,34 @@ class LOG4CXX_EXPORT Logger :
 		const LogString& getName() const;
 
 		/**
-		* Get logger name in current encoding.
+		* Put name of this logger into \c name in current encoding.
 		* @param name buffer to which name is appended.
 		*/
 		void getName(std::string& name) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		* Get logger name.
+		* Put name of this logger into \c name.
 		* @param name buffer to which name is appended.
 		*/
 		void getName(std::wstring& name) const;
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		* Get logger name.
+		* Put name of this logger into \c name.
 		* @param name buffer to which name is appended.
 		*/
 		void getName(std::basic_string<UniChar>& name) const;
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		* Get logger name.
+		* Put name of this logger into \c name.
 		* @param name buffer to which name is appended.
 		*/
 		void getName(CFStringRef& name) const;
 #endif
 
 		/**
-		Returns the parent of this logger. Note that the parent of a
+		The parent of this logger. Note that the parent of a
 		given logger may change during the lifetime of the logger.
 
 		<p>The root logger will return <code>0</code>.
@@ -770,7 +770,7 @@ class LOG4CXX_EXPORT Logger :
 
 	public:
 		/**
-		Log a message string with the INFO level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -786,7 +786,7 @@ class LOG4CXX_EXPORT Logger :
 		void info(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Log a message string with the INFO level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -800,7 +800,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the INFO level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -815,7 +815,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Log a message string with the INFO level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -829,7 +829,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the INFO level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -844,7 +844,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Log a message string with the INFO level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -858,7 +858,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the INFO level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -873,103 +873,158 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Is the appender passed as parameter attached to this logger?
+		Is \c appender attached to this logger?
 		*/
 		bool isAttached(const AppenderPtr appender) const override;
 
 		/**
-		 *  Check whether this logger is enabled for the <code>DEBUG</code>
-		 *  Level.
+		 *  Is this logger is enabled for <code>DEBUG</code> level messages?
 		 *
-		 *  <p> This function is intended to lessen the computational cost of
-		 *  disabled log debug statements.
-		 *
-		 *  <p> For some <code>logger</code> Logger object, when you write,
-		 *  <pre>
-		 *      logger->debug("debug message");
-		 *  </pre>
-		 *
-		 *  <p>You incur the cost constructing the message, concatenation in
-		 *  this case, regardless of whether the message is logged or not.
-		 *
-		 *  <p>If you are worried about speed, then you should write
+		 *  <p>By writing
 		 *  <pre>
 		 *    if(logger->isDebugEnabled()) {
-		 *      logger->debug("debug message");
+		 *      logger->debug("Component: " + std::to_string(componentNumber));
 		 *    }
+		 *  </pre>you will not incur the cost of parameter construction
+		 *  (integer to string conversion plus string concatonation in this case)
+		 *  if debugging is disabled for <code>logger</code>.
+		 *  You avoid the cost constructing the message
+		 *  when the message is not logged.
+		 *
+		 *  <p>This function allows you to reduce the computational cost of
+		 *  disabled log debug statements compared to writing:
+		 *  <pre>
+		 *      logger->debug("Component: " + std::to_string(componentNumber));
 		 *  </pre>
 		 *
-		 *  <p>This way you will not incur the cost of parameter
-		 *  construction if debugging is disabled for <code>logger</code>. On
-		 *  the other hand, if the <code>logger</code> is debug enabled, you
+		 *  <p>On the other hand, if the <code>logger</code> is debug enabled, you
 		 *  will incur the cost of evaluating whether the logger is debug
 		 *  enabled twice. Once in <code>isDebugEnabled</code> and once in
 		 *  the <code>debug</code>.  This is an insignificant overhead
 		 *  since evaluating a logger takes about 1%% of the time it
-		 *  takes to actually log.
+		 *  takes to send the message to the appender.
+
+		 * See also #isDebugEnabledFor.
+		 * See also #LOG4CXX_DEBUG.
 		 *
 		 *  @return bool - <code>true</code> if this logger is debug
 		 *  enabled, <code>false</code> otherwise.
-		 *   */
+		 **/
 		bool isDebugEnabled() const;
+
+		/**
+		 *  Is \c logger is enabled for <code>DEBUG</code> level messages?
+		 *
+		 *  <p>By writing
+		 *  <pre>
+		 *    if(log4cxx::Logger::isDebugEnabledFor(logger)) {
+		 *      logger->forcedLog(log4cxx::Level::getDebug(), "Component: " + std::to_string(componentNumber));
+		 *    }
+		 *  </pre>you will not incur the cost of a function call and parameter construction
+		 *  if debugging is disabled for <code>logger</code>.
+		 *  You avoid the cost constructing the message
+		 *  when the message is not logged.
+		 *
+		 *  <p>This function minimises the computational cost of
+		 *  disabled log debug statements.
+		 *
+		 * See also #LOG4CXX_DEBUG.
+		 *
+		 *  @return bool - <code>true</code> if this logger is debug
+		 *  enabled, <code>false</code> otherwise.
+		 **/
 		inline static bool isDebugEnabledFor(const LoggerPtr& logger)
 		{
 			return logger && logger->m_threshold <= Level::DEBUG_INT && logger->isDebugEnabled();
 		}
 
 		/**
-		Check whether this logger is enabled for a given
-		Level passed as parameter.
+		Is this logger is enabled for messages at \c level?
 
-		See also #isDebugEnabled.
-
-		@return bool True if this logger is enabled for <code>level</code>.
+		@return bool True if this logger is enabled for <code>level</code> messages.
 		*/
 		bool isEnabledFor(const LevelPtr& level) const;
 
 
 		/**
-		Check whether this logger is enabled for the info Level.
-		See also #isDebugEnabled.
+		Is this logger is enabled for <code>INFO</code> level messages?
+
+		See #isDebugEnabled.
+		See also #LOG4CXX_INFO.
 
 		@return bool - <code>true</code> if this logger is enabled
 		for level info, <code>false</code> otherwise.
 		*/
 		bool isInfoEnabled() const;
+
+		/**
+		Is this logger is enabled for <code>INFO</code> level messages?
+
+		See #isDebugEnabledFor.
+		See also #LOG4CXX_INFO.
+
+		@return bool - <code>true</code> if this logger is enabled
+		for level info, <code>false</code> otherwise.
+		*/
 		inline static bool isInfoEnabledFor(const LoggerPtr& logger)
 		{
 			return logger && logger->m_threshold <= Level::INFO_INT && logger->isInfoEnabled();
 		}
 
 		/**
-		Check whether this logger is enabled for the warn Level.
+		Is this logger is enabled for <code>WARN</code> level messages?
+
 		See also #isDebugEnabled.
+		See also #LOG4CXX_WARN.
 
 		@return bool - <code>true</code> if this logger is enabled
 		for level warn, <code>false</code> otherwise.
 		*/
 		bool isWarnEnabled() const;
+
+		/**
+		Is this logger is enabled for <code>INFO</code> level messages?
+
+		See #isDebugEnabledFor.
+		See also #LOG4CXX_WARN.
+
+		@return bool - <code>true</code> if this logger is enabled
+		for level info, <code>false</code> otherwise.
+		*/
 		inline static bool isWarnEnabledFor(const LoggerPtr& logger)
 		{
 			return logger && logger->m_threshold <= Level::WARN_INT && logger->isWarnEnabled();
 		}
 
 		/**
-		Check whether this logger is enabled for the error Level.
+		Is this logger is enabled for error level messages?
+
 		See also #isDebugEnabled.
+		See also #LOG4CXX_ERROR.
 
 		@return bool - <code>true</code> if this logger is enabled
 		for level error, <code>false</code> otherwise.
 		*/
 		bool isErrorEnabled() const;
+
+		/**
+		Is this logger is enabled for <code>INFO</code> level messages?
+
+		See #isDebugEnabledFor.
+		See also #LOG4CXX_ERROR.
+
+		@return bool - <code>true</code> if this logger is enabled
+		for level info, <code>false</code> otherwise.
+		*/
 		inline static bool isErrorEnabledFor(const LoggerPtr& logger)
 		{
 			return logger && logger->m_threshold <= Level::ERROR_INT && logger->isErrorEnabled();
 		}
 
 		/**
-		Check whether this logger is enabled for the fatal Level.
+		Is this logger is enabled for fatal level messages?
 		See also #isDebugEnabled.
+		See also #LOG4CXX_FATAL.
 
 		@return bool - <code>true</code> if this logger is enabled
 		for level fatal, <code>false</code> otherwise.
@@ -981,8 +1036,9 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Check whether this logger is enabled for the trace level.
+		Is this logger is enabled for trace level messages?
 		See also #isDebugEnabled.
+		See also #LOG4CXX_FATAL.
 
 		@return bool - <code>true</code> if this logger is enabled
 		for level trace, <code>false</code> otherwise.
@@ -1449,7 +1505,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Log a message string with the WARN level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1463,7 +1519,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the WARN level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1478,7 +1534,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Log a message string with the WARN level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1492,7 +1548,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the WARN level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1507,7 +1563,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Log a message string with the WARN level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1521,7 +1577,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the WARN level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1535,7 +1591,7 @@ class LOG4CXX_EXPORT Logger :
 		void warn(const CFStringRef& msg) const;
 #endif
 		/**
-		Log a message string with the WARN level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1549,7 +1605,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the WARN level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1564,7 +1620,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Log a message string with the TRACE level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1578,7 +1634,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the TRACE level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1593,7 +1649,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Log a message string with the TRACE level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1607,7 +1663,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the TRACE level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1622,7 +1678,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Log a message string with the TRACE level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1636,7 +1692,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the TRACE level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1650,7 +1706,7 @@ class LOG4CXX_EXPORT Logger :
 		void trace(const CFStringRef& msg) const;
 #endif
 		/**
-		Log a message string with the TRACE level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1664,7 +1720,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Log a message string with the TRACE level.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1720,7 +1776,7 @@ LOG4CXX_LIST_DEF(LoggerList, LoggerPtr);
 
 
 /**
-Logs a message to a specified logger with a specified level.
+Conditionally sends \c message to the appender attached to \c logger.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1732,7 +1788,7 @@ Logs a message to a specified logger with a specified level.
 			logger->forcedLog(level, oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a message to a specified logger with a specified level, formatting utilizing libfmt
+Conditionally sends \c ... to the appender attached to \c logger, formatting utilizing libfmt
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1743,7 +1799,7 @@ Logs a message to a specified logger with a specified level, formatting utilizin
 			logger->forcedLog(level, fmt::format( __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a message to a specified logger with a specified level.
+Conditionally sends \c message to the appender attached to \c logger.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1756,7 +1812,14 @@ Logs a message to a specified logger with a specified level.
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 10000
 /**
-Logs a message to a specified logger with the DEBUG level.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for DEBUG messages.
+
+<p>Equivalent to writing:
+<pre>
+    if (log4cxx::Logger::isDebugEnabledFor(logger)) {
+      logger->forcedLog(log4cxx::Level::getDebug(), ..., LOG4CXX_LOCATION));
+    }
+</pre>
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1767,7 +1830,7 @@ Logs a message to a specified logger with the DEBUG level.
 			logger->forcedLog(::log4cxx::Level::getDebug(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a message to a specified logger with the DEBUG level, formatting with libfmt
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for DEBUG messages, formatting with libfmt
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1782,7 +1845,7 @@ Logs a message to a specified logger with the DEBUG level, formatting with libfm
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 5000
 /**
-Logs a message to a specified logger with the TRACE level.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for TRACE messages.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1793,7 +1856,7 @@ Logs a message to a specified logger with the TRACE level.
 			logger->forcedLog(::log4cxx::Level::getTrace(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a message to a specified logger with the TRACE level, formatting with libfmt.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for TRACE messages, formatting with libfmt.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1808,7 +1871,7 @@ Logs a message to a specified logger with the TRACE level, formatting with libfm
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 20000
 /**
-Logs a message to a specified logger with the INFO level.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for INFO messages.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1819,7 +1882,7 @@ Logs a message to a specified logger with the INFO level.
 			logger->forcedLog(::log4cxx::Level::getInfo(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a message to a specified logger with the INFO level, formatting with libfmt.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for INFO messages, formatting with libfmt.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1835,7 +1898,7 @@ Logs a message to a specified logger with the INFO level, formatting with libfmt
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 30000
 /**
-Logs a message to a specified logger with the WARN level.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for WARN messages.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1846,7 +1909,7 @@ Logs a message to a specified logger with the WARN level.
 			logger->forcedLog(::log4cxx::Level::getWarn(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a message to a specified logger with the WARN level, formatting with libfmt
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for WARN messages, formatting with libfmt
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1861,7 +1924,7 @@ Logs a message to a specified logger with the WARN level, formatting with libfmt
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 40000
 /**
-Logs a message to a specified logger with the ERROR level.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR messages.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1872,7 +1935,7 @@ Logs a message to a specified logger with the ERROR level.
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a message to a specified logger with the ERROR level, formatting with libfmt
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR messages, formatting with libfmt
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1913,7 +1976,7 @@ Logs a error if the condition is not true, formatting with libfmt
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 50000
 /**
-Logs a message to a specified logger with the FATAL level.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for FATAL messages.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1924,7 +1987,7 @@ Logs a message to a specified logger with the FATAL level.
 			logger->forcedLog(::log4cxx::Level::getFatal(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a message to a specified logger with the FATAL level, formatting with libfmt
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for FATAL messages, formatting with libfmt
 
 @param logger the logger to be used.
 @param ... The format string and message to log

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -804,7 +804,7 @@ class LOG4CXX_EXPORT Logger :
 
 	protected:
 		/**
-		Returns the string resource coresponding to <code>key</code> in this
+		Returns the string resource corresponding to <code>key</code> in this
 		logger's inherited resource bundle.
 
 		If the resource cannot be found, then an {@link #error error} message
@@ -1664,6 +1664,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_WARN.
 		*/
 		void warn(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -1677,6 +1679,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_WARN.
 		*/
 		void warn(const std::wstring& msg) const;
 #endif
@@ -1693,6 +1697,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_WARN.
 		*/
 		void warn(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -1706,6 +1712,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_WARN.
 		*/
 		void warn(const std::basic_string<UniChar>& msg) const;
 #endif
@@ -1722,6 +1730,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_WARN.
 		*/
 		void warn(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -1735,6 +1745,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_WARN.
 		*/
 		void warn(const CFStringRef& msg) const;
 #endif
@@ -1750,6 +1762,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_WARN.
 		*/
 		void warn(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -1763,6 +1777,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_WARN.
 		*/
 		void warn(const std::string& msg) const;
 
@@ -1779,6 +1795,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_TRACE.
 		*/
 		void trace(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -1792,6 +1810,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_TRACE.
 		*/
 		void trace(const std::wstring& msg) const;
 #endif
@@ -1808,6 +1828,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_TRACE.
 		*/
 		void trace(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -1821,6 +1843,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_TRACE.
 		*/
 		void trace(const std::basic_string<UniChar>& msg) const;
 #endif
@@ -1837,6 +1861,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_TRACE.
 		*/
 		void trace(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -1850,6 +1876,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_TRACE.
 		*/
 		void trace(const CFStringRef& msg) const;
 #endif
@@ -1865,6 +1893,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_TRACE.
 		*/
 		void trace(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -1878,6 +1908,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_TRACE.
 		*/
 		void trace(const std::string& msg) const;
 

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -532,7 +532,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& location) const;
 
 		/**
-		Get the additivity flag for this Logger instance.
+		Get the additivity flag for this logger.
 		*/
 		bool getAdditivity() const;
 
@@ -610,7 +610,7 @@ class LOG4CXX_EXPORT Logger :
 
 
 		/**
-		Returns the assigned Level, if any, for this Logger.
+		The assigned Level, if any, for this logger.
 
 		@return Level - the assigned Level, can be null.
 		*/
@@ -995,7 +995,7 @@ class LOG4CXX_EXPORT Logger :
 		bool isWarnEnabled() const;
 
 		/**
-		Is \c logger is enabled for <code>INFO</code> level logging events?
+		Is \c logger is enabled for <code>WARN</code> level logging events?
 
 		See #isDebugEnabledFor.
 		See also #LOG4CXX_WARN.
@@ -1010,7 +1010,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Is this logger is enabled for error level logging events?
+		Is this logger is enabled for <code>ERROR</code> level logging events?
 
 		See also #isDebugEnabled.
 		See also #LOG4CXX_ERROR.
@@ -1021,7 +1021,7 @@ class LOG4CXX_EXPORT Logger :
 		bool isErrorEnabled() const;
 
 		/**
-		Is \c logger is enabled for <code>INFO</code> level logging events?
+		Is \c logger is enabled for <code>ERROR</code> level logging events?
 
 		See #isDebugEnabledFor.
 		See also #LOG4CXX_ERROR.
@@ -1036,7 +1036,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Is this logger is enabled for fatal level logging events?
+		Is this logger is enabled for <code>FATAL</code> level logging events?
 		See also #isDebugEnabled.
 		See also #LOG4CXX_FATAL.
 
@@ -1061,7 +1061,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Is this logger is enabled for trace level logging events?
+		Is this logger is enabled for <code>TRACE</code> level logging events?
 		See also #isDebugEnabled.
 		See also #LOG4CXX_FATAL.
 
@@ -1156,7 +1156,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val1, const std::string& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and val3 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1230,7 +1230,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val1, const std::wstring& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and val3 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1304,7 +1304,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val1, const std::basic_string<UniChar>& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and val3 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1379,7 +1379,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1, const CFStringRef& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and val3 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1515,7 +1515,7 @@ class LOG4CXX_EXPORT Logger :
 		void removeAppender(const LogString& name) override;
 
 		/**
-		 Set the additivity flag for this Logger instance.
+		 Set the additivity flag for this logger.
 		  */
 		void setAdditivity(bool additive);
 
@@ -1531,7 +1531,7 @@ class LOG4CXX_EXPORT Logger :
 
 	public:
 		/**
-		Set the level of this Logger.
+		Set the level of this logger.
 
 		<p>As in <pre> &nbsp;&nbsp;&nbsp;logger->setLevel(Level::getDebug()); </pre>
 

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -1097,6 +1097,7 @@ class LOG4CXX_EXPORT Logger :
 
 		/**
 		Is this logger is enabled for <code>FATAL</code> level logging events?
+
 		See also #isDebugEnabled.
 		See also #LOG4CXX_FATAL.
 
@@ -1122,6 +1123,7 @@ class LOG4CXX_EXPORT Logger :
 
 		/**
 		Is this logger is enabled for <code>TRACE</code> level logging events?
+
 		See also #isDebugEnabled.
 		See also #LOG4CXX_FATAL.
 
@@ -1616,12 +1618,24 @@ class LOG4CXX_EXPORT Logger :
 	protected:
 		friend class Hierarchy;
 		/**
-		Only the Hierarchy class can set the hierarchy of a logger.*/
+		Only the Hierarchy class can remove the hierarchy of a logger.
+		*/
 		void removeHierarchy();
+		/**
+		Only the Hierarchy class can set the hierarchy of a logger.
+		*/
 		void setHierarchy(spi::LoggerRepository* repository);
+		/**
+		Only the Hierarchy class can set the parent of a logger.
+		*/
 		void setParent(LoggerPtr parentLogger);
-		spi::LoggerRepository* getHierarchy() const;
+		/**
+		Only the Hierarchy class can change the threshold of a logger.
+		*/
 		void updateThreshold();
+
+	private:
+		spi::LoggerRepository* getHierarchy() const;
 
 	public:
 		/**

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -130,6 +130,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_DEBUG.
 		*/
 		void debug(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
@@ -145,6 +147,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_DEBUG.
 		*/
 		void debug(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -158,6 +162,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_DEBUG.
 		*/
 		void debug(const std::wstring& msg) const;
 #endif
@@ -174,6 +180,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_DEBUG.
 		*/
 		void debug(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -187,6 +195,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_DEBUG.
 		*/
 		void debug(const std::basic_string<UniChar>& msg) const;
 #endif
@@ -203,6 +213,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_DEBUG.
 		*/
 		void debug(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -216,6 +228,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_DEBUG.
 		*/
 		void debug(const CFStringRef& msg) const;
 #endif
@@ -232,6 +246,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_ERROR.
 		*/
 		void error(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -245,6 +261,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_ERROR.
 		*/
 		void error(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
@@ -259,6 +277,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_ERROR.
 		*/
 		void error(const std::wstring& msg) const;
 		/**
@@ -273,6 +293,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_ERROR.
 		*/
 		void error(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 #endif
@@ -289,6 +311,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_ERROR.
 		*/
 		void error(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -302,6 +326,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_ERROR.
 		*/
 		void error(const std::basic_string<UniChar>& msg) const;
 #endif
@@ -318,6 +344,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_ERROR.
 		*/
 		void error(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -331,6 +359,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_ERROR.
 		*/
 		void error(const CFStringRef& msg) const;
 #endif
@@ -347,6 +377,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_FATAL.
 		*/
 		void fatal(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -360,6 +392,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_FATAL.
 		*/
 		void fatal(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
@@ -375,6 +409,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_FATAL.
 		*/
 		void fatal(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -388,6 +424,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_FATAL.
 		*/
 		void fatal(const std::wstring& msg) const;
 #endif
@@ -404,6 +442,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_FATAL.
 		*/
 		void fatal(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -417,6 +457,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_FATAL.
 		*/
 		void fatal(const std::basic_string<UniChar>& msg) const;
 #endif
@@ -433,6 +475,8 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
+
+		See also #LOG4CXX_FATAL.
 		*/
 		void fatal(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
@@ -446,6 +490,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_FATAL.
 		*/
 		void fatal(const CFStringRef& msg) const;
 #endif
@@ -781,7 +827,9 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
-		        */
+
+		See also #LOG4CXX_INFO.
+		*/
 		void info(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
 		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
@@ -794,6 +842,8 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
+
+		See also #LOG4CXX_INFO.
 		*/
 		void info(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
@@ -809,7 +859,9 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
-		        */
+
+		See also #LOG4CXX_INFO.
+		*/
 		void info(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
 		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
@@ -822,7 +874,9 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
-		        */
+
+		See also #LOG4CXX_INFO.
+		*/
 		void info(const std::wstring& msg) const;
 #endif
 #if LOG4CXX_UNICHAR_API
@@ -851,7 +905,9 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
-		        */
+
+		See also #LOG4CXX_INFO.
+		*/
 		void info(const std::basic_string<UniChar>& msg) const;
 #endif
 #if LOG4CXX_CFSTRING_API
@@ -867,7 +923,9 @@ class LOG4CXX_EXPORT Logger :
 
 		@param msg the message string to log.
 		@param location location of source of logging request.
-		        */
+
+		See also #LOG4CXX_INFO.
+		*/
 		void info(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
 		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
@@ -880,7 +938,9 @@ class LOG4CXX_EXPORT Logger :
 		hierarchy depending on the value of the additivity flag.
 
 		@param msg the message string to log.
-		        */
+
+		See also #LOG4CXX_INFO.
+		*/
 		void info(const CFStringRef& msg) const;
 #endif
 
@@ -1086,7 +1146,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1099,12 +1159,14 @@ class LOG4CXX_EXPORT Logger :
 		              <code>{1}</code> etc. within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG.
 		*/
 		void l7dlog(const LevelPtr& level, const LogString& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::vector<LogString>& values) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1115,11 +1177,13 @@ class LOG4CXX_EXPORT Logger :
 		@param locationInfo The location info of the logging request.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG.
 		*/
 		void l7dlog(const LevelPtr& level, const std::string& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1132,12 +1196,14 @@ class LOG4CXX_EXPORT Logger :
 		@param val The first value for the placeholders within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG1.
 		*/
 		void l7dlog(const LevelPtr& level, const std::string& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1151,12 +1217,14 @@ class LOG4CXX_EXPORT Logger :
 		@param val2 The second value for the placeholders within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG2.
 		*/
 		void l7dlog(const LevelPtr& level, const std::string& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val1, const std::string& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1171,6 +1239,8 @@ class LOG4CXX_EXPORT Logger :
 		@param val3 The value for the third placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG3.
 		*/
 		void l7dlog(const LevelPtr& level, const std::string& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
@@ -1178,7 +1248,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1189,11 +1259,13 @@ class LOG4CXX_EXPORT Logger :
 		@param locationInfo The location info of the logging request.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG.
 		*/
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1206,12 +1278,14 @@ class LOG4CXX_EXPORT Logger :
 		@param val1 The value for the first placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG1.
 		*/
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1225,12 +1299,14 @@ class LOG4CXX_EXPORT Logger :
 		@param val2 The value for the second placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG2.
 		*/
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val1, const std::wstring& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1245,6 +1321,8 @@ class LOG4CXX_EXPORT Logger :
 		@param val3 The value for the third placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG3.
 		*/
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
@@ -1252,7 +1330,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1263,11 +1341,13 @@ class LOG4CXX_EXPORT Logger :
 		@param locationInfo The location info of the logging request.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG.
 		*/
 		void l7dlog(const LevelPtr& level, const std::basic_string<UniChar>& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1280,12 +1360,14 @@ class LOG4CXX_EXPORT Logger :
 		@param val1 The value for the first placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG1.
 		*/
 		void l7dlog(const LevelPtr& level, const std::basic_string<UniChar>& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1299,12 +1381,14 @@ class LOG4CXX_EXPORT Logger :
 		@param val2 The value for the second placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG2.
 		*/
 		void l7dlog(const LevelPtr& level, const std::basic_string<UniChar>& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val1, const std::basic_string<UniChar>& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1319,6 +1403,8 @@ class LOG4CXX_EXPORT Logger :
 		@param val3 The value for the third placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG3.
 		*/
 		void l7dlog(const LevelPtr& level, const std::basic_string<UniChar>& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
@@ -1327,7 +1413,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1338,11 +1424,13 @@ class LOG4CXX_EXPORT Logger :
 		@param locationInfo The location info of the logging request.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG.
 		*/
 		void l7dlog(const LevelPtr& level, const CFStringRef& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1355,12 +1443,14 @@ class LOG4CXX_EXPORT Logger :
 		@param val1 The value for the first placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG1.
 		*/
 		void l7dlog(const LevelPtr& level, const CFStringRef& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1374,12 +1464,14 @@ class LOG4CXX_EXPORT Logger :
 		@param val2 The value for the second placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG2.
 		*/
 		void l7dlog(const LevelPtr& level, const CFStringRef& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1, const CFStringRef& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1394,6 +1486,8 @@ class LOG4CXX_EXPORT Logger :
 		@param val3 The value for the third placeholder within the pattern.
 
 		@see #setResourceBundle
+
+		See also #LOG4CXX_L7DLOG3.
 		*/
 		void l7dlog(const LevelPtr& level, const CFStringRef& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
@@ -1828,7 +1922,7 @@ Add a new logging event containing \c message to attached appender(s) if this lo
 			logger->forcedLog(level, oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to attached appender(s) if this logger is enabled for \c events.
+Add a new logging event containing libfmt formatted <code>...</code> to attached appender(s) if this logger is enabled for \c events.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1852,17 +1946,22 @@ Add a new logging event containing \c message to attached appender(s) if this lo
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 10000
 /**
-Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>DEBUG</code> events.
+Add a new logging event containing \c message to attached appender(s) if \c logger is enabled for <code>DEBUG</code> events.
 
-<p>Equivalent to writing:
+@param logger the logger that has the enabled status.
+@param message a valid r-value expression of an <code>operator<<(std::basic::ostream&. ...)</code> overload.
+
+<p>Example:
 <pre>
-    if (log4cxx::Logger::isDebugEnabledFor(logger)) {
-      logger->forcedLog(log4cxx::Level::getDebug(), ..., LOG4CXX_LOCATION));
-    }
+LOG4CXX_DEBUG(m_log, "AddMesh:"
+	<< " name " << meshName
+	<< " type 0x" << std:: hex << traits.Type
+	<< " materialName " << meshObject.GetMaterialName()
+	<< " visible " << traits.IsDefaultVisible
+	<< " at " << obj->getBoundingBox().getCenter()
+	<< " +/- " << obj->getBoundingBox().getHalfSize()
+	);
 </pre>
-
-@param logger the logger to be used.
-@param message the message string to log.
 */
 #define LOG4CXX_DEBUG(logger, message) do { \
 		if (LOG4CXX_UNLIKELY(::log4cxx::Logger::isDebugEnabledFor(logger))) {\
@@ -1870,7 +1969,7 @@ Add a new logging event containing \c message to attached appender(s) if it is e
 			logger->forcedLog(::log4cxx::Level::getDebug(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>DEBUG</code> events.
+Add a new logging event containing libfmt formatted <code>...</code> to attached appender(s) if \c logger is enabled for <code>DEBUG</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1885,10 +1984,16 @@ Add a new logging event containing libfmt formatted \c ... to attached appender(
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 5000
 /**
-Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>TRACE</code> events.
+Add a new logging event containing \c message to attached appender(s) if \c logger is enabled for <code>TRACE</code> events.
 
-@param logger the logger to be used.
-@param message the message string to log.
+@param logger the logger that has the enabled status.
+@param message a valid r-value expression of an <code>operator<<(std::basic::ostream&. ...)</code> overload.
+
+<p>Example:
+<pre>
+    LOG4CXX_TRACE(m_log, "AddVertex:" << " p " << p[j] << " n " << n << ' ' << color);
+</pre>
+
 */
 #define LOG4CXX_TRACE(logger, message) do { \
 		if (LOG4CXX_UNLIKELY(::log4cxx::Logger::isTraceEnabledFor(logger))) {\
@@ -1896,7 +2001,7 @@ Add a new logging event containing \c message to attached appender(s) if it is e
 			logger->forcedLog(::log4cxx::Level::getTrace(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>TRACE</code> events.
+Add a new logging event containing libfmt formatted <code>...</code> to attached appender(s) if \c logger is enabled for <code>TRACE</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1911,10 +2016,20 @@ Add a new logging event containing libfmt formatted \c ... to attached appender(
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 20000
 /**
-Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>INFO</code> events.
+Add a new logging event containing \c message to attached appender(s) if \c logger is enabled for <code>INFO</code> events.
 
-@param logger the logger to be used.
-@param message the message string to log.
+@param logger the logger that has the enabled status.
+@param message a valid r-value expression of an <code>operator<<(std::basic::ostream&. ...)</code> overload.
+
+<p>Example:
+<pre>
+LOG4CXX_INFO(m_log, surface->GetName()
+	<< " successfully planned " << std::fixed << std::setprecision(1) << ((plannedArea  / (plannedArea + unplannedArea)) * 100.0) << "%"
+	<< " planned area " << std::fixed << std::setprecision(4) << plannedArea << "m^2"
+	<< " unplanned area " << unplannedArea << "m^2"
+	<< " planned segments " << surface->GetSegmentPlanCount() << " of " << surface->GetSegmentCount()
+	);
+</pre>
 */
 #define LOG4CXX_INFO(logger, message) do { \
 		if (::log4cxx::Logger::isInfoEnabledFor(logger)) {\
@@ -1922,10 +2037,9 @@ Add a new logging event containing \c message to attached appender(s) if it is e
 			logger->forcedLog(::log4cxx::Level::getInfo(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>INFO</code> events.
+Add a new logging event containing libfmt formatted <code>...</code> to attached appender(s) if \c logger is enabled for <code>INFO</code> events.
 
 @param logger the logger to be used.
-@param message the message string to log.
 @param ... The format string and message to log
 */
 #define LOG4CXX_INFO_FMT(logger, ...) do { \
@@ -1938,10 +2052,18 @@ Add a new logging event containing libfmt formatted \c ... to attached appender(
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 30000
 /**
-Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>WARN</code> events.
+Add a new logging event containing \c message to attached appender(s) if \c logger is enabled for <code>WARN</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
+
+<p>Example:
+<pre>
+catch (const std::exception& ex)
+{
+    LOG4CXX_WARN(m_log, ex.what() << ": in " << m_task->GetParamFilePath());
+}
+</pre>
 */
 #define LOG4CXX_WARN(logger, message) do { \
 		if (::log4cxx::Logger::isWarnEnabledFor(logger)) {\
@@ -1949,7 +2071,7 @@ Add a new logging event containing \c message to attached appender(s) if it is e
 			logger->forcedLog(::log4cxx::Level::getWarn(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>WARN</code> events.
+Add a new logging event containing libfmt formatted <code>...</code> to attached appender(s) if \c logger is enabled for <code>WARN</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1964,10 +2086,18 @@ Add a new logging event containing libfmt formatted \c ... to attached appender(
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 40000
 /**
-Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>ERROR</code> events.
+Add a new logging event containing \c message to attached appender(s) if \c logger is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
+
+<p>Example:
+<pre>
+catch (std::exception& ex)
+{
+	LOG4CXX_ERROR(m_log, ex.what() << " in AddScanData");
+}
+</pre>
 */
 #define LOG4CXX_ERROR(logger, message) do { \
 		if (::log4cxx::Logger::isErrorEnabledFor(logger)) {\
@@ -1975,7 +2105,7 @@ Add a new logging event containing \c message to attached appender(s) if it is e
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>ERROR</code> events.
+Add a new logging event containing libfmt formatted <code>...</code> to attached appender(s) if \c logger is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1985,7 +2115,7 @@ Add a new logging event containing libfmt formatted \c ... to attached appender(
 			logger->forcedLog(::log4cxx::Level::getError(), fmt::format( __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 
 /**
-If \c condition is not true, add a new logging event containing \c message to attached appender(s) if it is enabled for <code>ERROR</code> events.
+If \c condition is not true, add a new logging event containing \c message to attached appender(s) if \c logger is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param condition condition
@@ -1997,7 +2127,7 @@ If \c condition is not true, add a new logging event containing \c message to at
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-If \c condition is not true, add a new logging event containing libfmt formatted \c message to attached appender(s) if it is enabled for <code>ERROR</code> events.
+If \c condition is not true, add a new logging event containing libfmt formatted \c message to attached appender(s) if \c logger is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param condition condition
@@ -2016,10 +2146,15 @@ If \c condition is not true, add a new logging event containing libfmt formatted
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 50000
 /**
-Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>FATAL</code> events.
+Add a new logging event containing \c message to attached appender(s) if \c logger is enabled for <code>FATAL</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
+
+<p>Example:
+<pre>
+LOG4CXX_FATAL(m_log, m_renderSystem->getName() << " is not supported");
+</pre>
 */
 #define LOG4CXX_FATAL(logger, message) do { \
 		if (::log4cxx::Logger::isFatalEnabledFor(logger)) {\
@@ -2027,7 +2162,7 @@ Add a new logging event containing \c message to attached appender(s) if it is e
 			logger->forcedLog(::log4cxx::Level::getFatal(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>FATAL</code> events.
+Add a new logging event containing libfmt formatted <code>...</code> to attached appender(s) if \c logger is enabled for <code>FATAL</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -2041,7 +2176,7 @@ Add a new logging event containing libfmt formatted \c ... to attached appender(
 #endif
 
 /**
-Add a new logging event containing the localized message \c key to attached appender(s) if it is enabled for \c level events.
+Add a new logging event containing the localized message \c key to attached appender(s) if \c logger is enabled for \c level events.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2052,7 +2187,7 @@ Add a new logging event containing the localized message \c key to attached appe
 			logger->l7dlog(level, key, LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing the localized message \c key to attached appender(s) if it is enabled for \c level events with one parameter.
+Add a new logging event containing the localized message \c key to attached appender(s) if \c logger is enabled for \c level events with one parameter.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2064,7 +2199,7 @@ Add a new logging event containing the localized message \c key to attached appe
 			logger->l7dlog(level, key, LOG4CXX_LOCATION, p1); }} while (0)
 
 /**
-Add a new logging event containing the localized message \c key to attached appender(s) if it is enabled for \c level events with two parameters.
+Add a new logging event containing the localized message \c key to attached appender(s) if \c logger is enabled for \c level events with two parameters.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2077,7 +2212,7 @@ Add a new logging event containing the localized message \c key to attached appe
 			logger->l7dlog(level, key, LOG4CXX_LOCATION, p1, p2); }} while (0)
 
 /**
-Add a new logging event containing the localized message \c key to attached appender(s) if it is enabled for \c level events with three parameters.
+Add a new logging event containing the localized message \c key to attached appender(s) if \c logger is enabled for \c level events with three parameters.
 
 @param logger the logger to be used.
 @param level the level to log.

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -1148,7 +1148,8 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if this logger is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using \c values for parameter substitution
+		to attached appender(s) if this logger is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1162,7 +1163,7 @@ class LOG4CXX_EXPORT Logger :
 
 		@see #setResourceBundle
 
-		See also #LOG4CXX_L7DLOG.
+		See also #LOG4CXX_L7DLOG1.
 		*/
 		void l7dlog(const LevelPtr& level, const LogString& key,
 			const log4cxx::spi::LocationInfo& locationInfo,

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -106,7 +106,7 @@ class LOG4CXX_EXPORT Logger :
 		void closeNestedAppenders();
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -120,7 +120,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -134,7 +134,7 @@ class LOG4CXX_EXPORT Logger :
 		void debug(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -148,7 +148,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -163,7 +163,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -177,7 +177,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -192,7 +192,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -206,7 +206,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -221,7 +221,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -235,7 +235,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -249,7 +249,7 @@ class LOG4CXX_EXPORT Logger :
 		void error(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -262,7 +262,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::wstring& msg) const;
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -278,7 +278,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -292,7 +292,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -307,7 +307,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -321,7 +321,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -336,7 +336,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>FATAL</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>FATAL</code> events.
 
 		<p>This method first checks if this logger is <code>FATAL</code>
 		enabled by comparing the level of this logger with the
@@ -350,7 +350,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -364,7 +364,7 @@ class LOG4CXX_EXPORT Logger :
 		void fatal(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -378,7 +378,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -393,7 +393,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -407,7 +407,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -422,7 +422,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg and \c location to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -436,7 +436,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -451,7 +451,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message and \c location to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -460,7 +460,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const std::string& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -469,7 +469,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message and \c location to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -478,7 +478,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const std::wstring& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -487,7 +487,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API || LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message and \c location to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -496,7 +496,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const std::basic_string<UniChar>& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -505,7 +505,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message and \c location to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -514,7 +514,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const CFStringRef& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message message.
@@ -522,7 +522,7 @@ class LOG4CXX_EXPORT Logger :
 		void forcedLog(const LevelPtr& level, const CFStringRef& message) const;
 #endif
 		/**
-		Add a new logging event to the appender(s) attached to this logger
+		Add a new logging event containing \c message and \c location to attached appender(s).
 		without further checks.
 		@param level the level to log.
 		@param message the message string to log.
@@ -770,7 +770,7 @@ class LOG4CXX_EXPORT Logger :
 
 	public:
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -784,7 +784,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -798,7 +798,7 @@ class LOG4CXX_EXPORT Logger :
 		void info(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -812,7 +812,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -827,7 +827,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -841,7 +841,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -856,7 +856,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -870,7 +870,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -1086,7 +1086,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1104,7 +1104,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::vector<LogString>& values) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1119,7 +1119,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::string& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1137,7 +1137,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1156,7 +1156,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val1, const std::string& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1178,7 +1178,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1193,7 +1193,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1211,7 +1211,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1230,7 +1230,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val1, const std::wstring& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1252,7 +1252,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1267,7 +1267,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::basic_string<UniChar>& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1285,7 +1285,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1304,7 +1304,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val1, const std::basic_string<UniChar>& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1327,7 +1327,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1342,7 +1342,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const CFStringRef& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1360,7 +1360,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1379,7 +1379,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1, const CFStringRef& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to attached appender(s) if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1545,7 +1545,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1559,7 +1559,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1574,7 +1574,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1588,7 +1588,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1603,7 +1603,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1617,7 +1617,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1631,7 +1631,7 @@ class LOG4CXX_EXPORT Logger :
 		void warn(const CFStringRef& msg) const;
 #endif
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1645,7 +1645,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1660,7 +1660,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1674,7 +1674,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1689,7 +1689,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1703,7 +1703,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1718,7 +1718,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1732,7 +1732,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1746,7 +1746,7 @@ class LOG4CXX_EXPORT Logger :
 		void trace(const CFStringRef& msg) const;
 #endif
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1760,7 +1760,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
+		Add a new logging event containing \c msg to attached appender(s) if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1816,7 +1816,7 @@ LOG4CXX_LIST_DEF(LoggerList, LoggerPtr);
 
 
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if this logger is enabled for \c events..
+Add a new logging event containing \c message to attached appender(s) if this logger is enabled for \c events..
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1828,7 +1828,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(level, oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if this logger is enabled for \c events.
+Add a new logging event containing libfmt formatted \c ... to attached appender(s) if this logger is enabled for \c events.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1839,7 +1839,7 @@ Add a new logging event containing libfmt formatted \c ... to the appender(s) at
 			logger->forcedLog(level, fmt::format( __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if this logger is enabled for \c events..
+Add a new logging event containing \c message to attached appender(s) if this logger is enabled for \c events..
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1852,7 +1852,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 10000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>DEBUG</code> events.
+Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>DEBUG</code> events.
 
 <p>Equivalent to writing:
 <pre>
@@ -1870,7 +1870,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getDebug(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>DEBUG</code> events.
+Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>DEBUG</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1885,7 +1885,7 @@ Add a new logging event containing libfmt formatted \c ... to the appender(s) at
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 5000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>TRACE</code> events.
+Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>TRACE</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1896,7 +1896,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getTrace(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>TRACE</code> events.
+Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>TRACE</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1911,7 +1911,7 @@ Add a new logging event containing libfmt formatted \c ... to the appender(s) at
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 20000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>INFO</code> events.
+Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>INFO</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1922,7 +1922,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getInfo(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>INFO</code> events.
+Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>INFO</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1938,7 +1938,7 @@ Add a new logging event containing libfmt formatted \c ... to the appender(s) at
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 30000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>WARN</code> events.
+Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>WARN</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1949,7 +1949,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getWarn(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>WARN</code> events.
+Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>WARN</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1964,7 +1964,7 @@ Add a new logging event containing libfmt formatted \c ... to the appender(s) at
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 40000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>ERROR</code> events.
+Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1975,7 +1975,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>ERROR</code> events.
+Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1985,7 +1985,7 @@ Add a new logging event containing libfmt formatted \c ... to the appender(s) at
 			logger->forcedLog(::log4cxx::Level::getError(), fmt::format( __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 
 /**
-If \c condition is not true, add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>ERROR</code> events.
+If \c condition is not true, add a new logging event containing \c message to attached appender(s) if it is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param condition condition
@@ -1997,7 +1997,7 @@ If \c condition is not true, add a new logging event containing \c message to th
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-If \c condition is not true, add a new logging event containing libfmt formatted \c message to the appender(s) attached to \c logger if it is enabled for <code>ERROR</code> events.
+If \c condition is not true, add a new logging event containing libfmt formatted \c message to attached appender(s) if it is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param condition condition
@@ -2016,7 +2016,7 @@ If \c condition is not true, add a new logging event containing libfmt formatted
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 50000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>FATAL</code> events.
+Add a new logging event containing \c message to attached appender(s) if it is enabled for <code>FATAL</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -2027,7 +2027,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getFatal(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>FATAL</code> events.
+Add a new logging event containing libfmt formatted \c ... to attached appender(s) if it is enabled for <code>FATAL</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -2041,7 +2041,7 @@ Add a new logging event containing libfmt formatted \c ... to the appender(s) at
 #endif
 
 /**
-Add a new logging event containing the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
+Add a new logging event containing the localized message \c key to attached appender(s) if it is enabled for \c level events.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2052,7 +2052,7 @@ Add a new logging event containing the localized message \c key to the appender(
 			logger->l7dlog(level, key, LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events with one parameter.
+Add a new logging event containing the localized message \c key to attached appender(s) if it is enabled for \c level events with one parameter.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2064,7 +2064,7 @@ Add a new logging event containing the localized message \c key to the appender(
 			logger->l7dlog(level, key, LOG4CXX_LOCATION, p1); }} while (0)
 
 /**
-Add a new logging event containing the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events with two parameters.
+Add a new logging event containing the localized message \c key to attached appender(s) if it is enabled for \c level events with two parameters.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2077,7 +2077,7 @@ Add a new logging event containing the localized message \c key to the appender(
 			logger->l7dlog(level, key, LOG4CXX_LOCATION, p1, p2); }} while (0)
 
 /**
-Add a new logging event containing the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events with three parameters.
+Add a new logging event containing the localized message \c key to attached appender(s) if it is enabled for \c level events with three parameters.
 
 @param logger the logger to be used.
 @param level the level to log.

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -969,13 +969,14 @@ class LOG4CXX_EXPORT Logger :
 		bool isInfoEnabled() const;
 
 		/**
-		Is this logger is enabled for <code>INFO</code> level logging events?
+		Is \c logger is enabled for <code>INFO</code> level logging events?
 
 		See #isDebugEnabledFor.
 		See also #LOG4CXX_INFO.
 
-		@return bool - <code>true</code> if this logger is enabled
-		for level info, <code>false</code> otherwise.
+		@return bool - <code>false</code> if \c logger is <code>null</code>
+		or <code>INFO</code> logging events are disabled for \c logger,
+		<code>true</code> otherwise.
 		*/
 		inline static bool isInfoEnabledFor(const LoggerPtr& logger)
 		{
@@ -994,13 +995,14 @@ class LOG4CXX_EXPORT Logger :
 		bool isWarnEnabled() const;
 
 		/**
-		Is this logger is enabled for <code>INFO</code> level logging events?
+		Is \c logger is enabled for <code>INFO</code> level logging events?
 
 		See #isDebugEnabledFor.
 		See also #LOG4CXX_WARN.
 
-		@return bool - <code>true</code> if this logger is enabled
-		for level info, <code>false</code> otherwise.
+		@return bool - <code>false</code> if \c logger is <code>null</code>
+		or <code>WARN</code> logging events are disabled for \c logger,
+		<code>true</code> otherwise.
 		*/
 		inline static bool isWarnEnabledFor(const LoggerPtr& logger)
 		{
@@ -1019,13 +1021,14 @@ class LOG4CXX_EXPORT Logger :
 		bool isErrorEnabled() const;
 
 		/**
-		Is this logger is enabled for <code>INFO</code> level logging events?
+		Is \c logger is enabled for <code>INFO</code> level logging events?
 
 		See #isDebugEnabledFor.
 		See also #LOG4CXX_ERROR.
 
-		@return bool - <code>true</code> if this logger is enabled
-		for level info, <code>false</code> otherwise.
+		@return bool - <code>false</code> if \c logger is <code>null</code>
+		or <code>ERROR</code> logging events are disabled for \c logger,
+		<code>true</code> otherwise.
 		*/
 		inline static bool isErrorEnabledFor(const LoggerPtr& logger)
 		{
@@ -1041,6 +1044,17 @@ class LOG4CXX_EXPORT Logger :
 		for level fatal, <code>false</code> otherwise.
 		*/
 		bool isFatalEnabled() const;
+
+		/**
+		Is \c logger is enabled for <code>FATAL</code> level logging events?
+
+		See #isDebugEnabledFor.
+		See also #LOG4CXX_FATAL.
+
+		@return bool - <code>false</code> if \c logger is <code>null</code>
+		or <code>FATAL</code> logging events are disabled for \c logger,
+		<code>true</code> otherwise.
+		*/
 		inline static bool isFatalEnabledFor(const LoggerPtr& logger)
 		{
 			return logger && logger->m_threshold <= Level::FATAL_INT && logger->isFatalEnabled();
@@ -1055,6 +1069,17 @@ class LOG4CXX_EXPORT Logger :
 		for level trace, <code>false</code> otherwise.
 		*/
 		bool isTraceEnabled() const;
+
+		/**
+		Is \c logger is enabled for <code>TRACE</code> level logging events?
+
+		See #isDebugEnabledFor.
+		See also #LOG4CXX_TRACE.
+
+		@return bool - <code>false</code> if \c logger is <code>null</code>
+		or <code>TRACE</code> logging events are disabled for \c logger,
+		<code>true</code> otherwise.
+		*/
 		inline static bool isTraceEnabledFor(const LoggerPtr& logger)
 		{
 			return logger && logger->m_threshold <= Level::TRACE_INT && logger->isTraceEnabled();

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -783,6 +783,18 @@ class LOG4CXX_EXPORT Logger :
 		@param location location of source of logging request.
 		        */
 		void info(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
+		/**
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+
+		<p>This method first checks if this logger is <code>INFO</code>
+		enabled by comparing the level of this logger with the
+		INFO level. If this logger is
+		<code>INFO</code> enabled, it proceeds to call all the
+		registered appenders in this logger and also higher in the
+		hierarchy depending on the value of the additivity flag.
+
+		@param msg the message string to log.
+		*/
 		void info(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
@@ -1049,12 +1061,11 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1068,12 +1079,11 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::vector<LogString>& values) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1084,30 +1094,30 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::string& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with the \c val parameter.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
 		@param locationInfo The location info of the logging request.
-		@param val1 The first value for the placeholders within the pattern.
+		@param val The first value for the placeholders within the pattern.
 
 		@see #setResourceBundle
 		*/
 		void l7dlog(const LevelPtr& level, const std::string& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
-			const std::string& val1) const;
+			const std::string& val) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1 and \c val2.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1121,12 +1131,12 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val1, const std::string& val2) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1, \c val2 and val3.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1143,12 +1153,11 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method .
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1159,12 +1168,12 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameter \c val.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameter in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1175,14 +1184,14 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
-			const std::wstring& val1) const;
+			const std::wstring& val) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1 and \c val2.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1196,12 +1205,12 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val1, const std::wstring& val2) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1, \c val2 and val3.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1218,12 +1227,11 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1234,12 +1242,12 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::basic_string<UniChar>& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameter..
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1250,14 +1258,14 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void l7dlog(const LevelPtr& level, const std::basic_string<UniChar>& key,
 			const log4cxx::spi::LocationInfo& locationInfo,
-			const std::basic_string<UniChar>& val1) const;
+			const std::basic_string<UniChar>& val) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1 and \c val2.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1271,12 +1279,12 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val1, const std::basic_string<UniChar>& val2) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1, \c val2 and val3.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1294,12 +1302,11 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1310,12 +1317,12 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const CFStringRef& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameter \c val.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameter in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1328,12 +1335,12 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1 and \c val2.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1347,12 +1354,12 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1, const CFStringRef& val2) const;
 		/**
-		Log a localized and parameterized message.
+		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1, \c val2 and val3.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
-		pattern is formatted using helpers::StringHelper::format method with the user
-		supplied string array <code>params</code>.
+		pattern is formatted using helpers::StringHelper::format method with the
+		supplied parameters in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1370,6 +1377,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
+		Add a new logging event containing \c message and \c location to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 
@@ -1379,6 +1387,7 @@ class LOG4CXX_EXPORT Logger :
 		void log(const LevelPtr& level, const std::string& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
+		Add a new logging event containing \c message to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 
@@ -1388,6 +1397,7 @@ class LOG4CXX_EXPORT Logger :
 		void log(const LevelPtr& level, const std::string& message) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
+		Add a new logging event containing \c message and \c location to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 
@@ -1397,6 +1407,7 @@ class LOG4CXX_EXPORT Logger :
 		void log(const LevelPtr& level, const std::wstring& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
+		Add a new logging event containing \c message to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 
@@ -1407,6 +1418,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
+		Add a new logging event containing \c message and \c location to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 
@@ -1416,6 +1428,7 @@ class LOG4CXX_EXPORT Logger :
 		void log(const LevelPtr& level, const std::basic_string<UniChar>& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
+		Add a new logging event containing \c message to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 
@@ -1426,6 +1439,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
+		Add a new logging event containing \c message and \c location to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 
@@ -1435,6 +1449,7 @@ class LOG4CXX_EXPORT Logger :
 		void log(const LevelPtr& level, const CFStringRef& message,
 			const log4cxx::spi::LocationInfo& location) const;
 		/**
+		Add a new logging event containing \c message to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 
@@ -1444,6 +1459,7 @@ class LOG4CXX_EXPORT Logger :
 		void log(const LevelPtr& level, const CFStringRef& message) const;
 #endif
 		/**
+		Add a new logging event containing \c message and \c location to the appenders attached to this logger if this logger is enabled for \c level events.
 		This is the most generic printing method. It is intended to be
 		invoked by <b>wrapper</b> classes.
 

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -106,7 +106,7 @@ class LOG4CXX_EXPORT Logger :
 		void closeNestedAppenders();
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -120,7 +120,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -134,7 +134,7 @@ class LOG4CXX_EXPORT Logger :
 		void debug(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -148,7 +148,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -163,7 +163,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -177,7 +177,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -192,7 +192,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -206,7 +206,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>DEBUG</code> events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -221,7 +221,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -235,7 +235,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -249,7 +249,7 @@ class LOG4CXX_EXPORT Logger :
 		void error(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -262,7 +262,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::wstring& msg) const;
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -278,7 +278,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -292,7 +292,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -307,7 +307,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -321,7 +321,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -336,7 +336,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for FATAL events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>FATAL</code> events.
 
 		<p>This method first checks if this logger is <code>FATAL</code>
 		enabled by comparing the level of this logger with the
@@ -350,7 +350,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -364,7 +364,7 @@ class LOG4CXX_EXPORT Logger :
 		void fatal(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -378,7 +378,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -393,7 +393,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -407,7 +407,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -422,7 +422,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -436,7 +436,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>ERROR</code> events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -770,7 +770,7 @@ class LOG4CXX_EXPORT Logger :
 
 	public:
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -784,7 +784,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -798,7 +798,7 @@ class LOG4CXX_EXPORT Logger :
 		void info(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -812,7 +812,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -827,7 +827,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -841,7 +841,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -856,7 +856,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -870,7 +870,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>INFO</code> events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -1137,7 +1137,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1156,7 +1156,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val1, const std::string& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1193,7 +1193,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1211,7 +1211,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1230,7 +1230,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val1, const std::wstring& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1285,7 +1285,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1304,7 +1304,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val1, const std::basic_string<UniChar>& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1342,7 +1342,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const CFStringRef& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1360,7 +1360,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1379,7 +1379,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1, const CFStringRef& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and \c val3 to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1545,7 +1545,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1559,7 +1559,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1574,7 +1574,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1588,7 +1588,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1603,7 +1603,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1617,7 +1617,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1631,7 +1631,7 @@ class LOG4CXX_EXPORT Logger :
 		void warn(const CFStringRef& msg) const;
 #endif
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1645,7 +1645,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>WARN</code> events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1660,7 +1660,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1674,7 +1674,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1689,7 +1689,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1703,7 +1703,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1718,7 +1718,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1732,7 +1732,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1746,7 +1746,7 @@ class LOG4CXX_EXPORT Logger :
 		void trace(const CFStringRef& msg) const;
 #endif
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1760,7 +1760,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for <code>TRACE</code> events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1816,7 +1816,7 @@ LOG4CXX_LIST_DEF(LoggerList, LoggerPtr);
 
 
 /**
-Conditionally sends \c message to the appender attached to \c logger.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if this logger is enabled for \c events..
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1828,7 +1828,7 @@ Conditionally sends \c message to the appender attached to \c logger.
 			logger->forcedLog(level, oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Conditionally sends \c ... to the appender attached to \c logger, formatting utilizing libfmt
+Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if this logger is enabled for \c events.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1839,7 +1839,7 @@ Conditionally sends \c ... to the appender attached to \c logger, formatting uti
 			logger->forcedLog(level, fmt::format( __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Conditionally sends \c message to the appender attached to \c logger.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if this logger is enabled for \c events..
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -1852,7 +1852,7 @@ Conditionally sends \c message to the appender attached to \c logger.
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 10000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for DEBUG events.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>DEBUG</code> events.
 
 <p>Equivalent to writing:
 <pre>
@@ -1870,7 +1870,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getDebug(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for DEBUG events, formatting with libfmt
+Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>DEBUG</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1885,7 +1885,7 @@ Add a new logging event containing \c ... to the appender(s) attached to \c logg
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 5000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for TRACE events.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>TRACE</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1896,7 +1896,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getTrace(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for TRACE events, formatting with libfmt.
+Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>TRACE</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1911,7 +1911,7 @@ Add a new logging event containing \c ... to the appender(s) attached to \c logg
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 20000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for INFO events.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>INFO</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1922,7 +1922,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getInfo(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for INFO events, formatting with libfmt.
+Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>INFO</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1938,7 +1938,7 @@ Add a new logging event containing \c ... to the appender(s) attached to \c logg
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 30000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for WARN events.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>WARN</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1949,7 +1949,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getWarn(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for WARN events, formatting with libfmt
+Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>WARN</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1964,7 +1964,7 @@ Add a new logging event containing \c ... to the appender(s) attached to \c logg
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 40000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR events.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1975,7 +1975,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for ERROR events, formatting with libfmt
+Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1985,7 +1985,7 @@ Add a new logging event containing \c ... to the appender(s) attached to \c logg
 			logger->forcedLog(::log4cxx::Level::getError(), fmt::format( __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 
 /**
-If \c condition is not true, add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR events.
+If \c condition is not true, add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param condition condition
@@ -1997,7 +1997,7 @@ If \c condition is not true, add a new logging event containing \c message to th
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-If \c condition is not true, add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR events, formatting with libfmt
+If \c condition is not true, add a new logging event containing libfmt formatted \c message to the appender(s) attached to \c logger if it is enabled for <code>ERROR</code> events.
 
 @param logger the logger to be used.
 @param condition condition
@@ -2016,7 +2016,7 @@ If \c condition is not true, add a new logging event containing \c message to th
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 50000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for FATAL events.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for <code>FATAL</code> events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -2027,7 +2027,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getFatal(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for FATAL events, formatting with libfmt
+Add a new logging event containing libfmt formatted \c ... to the appender(s) attached to \c logger if it is enabled for <code>FATAL</code> events.
 
 @param logger the logger to be used.
 @param ... The format string and message to log

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -106,7 +106,7 @@ class LOG4CXX_EXPORT Logger :
 		void closeNestedAppenders();
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -120,7 +120,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -134,7 +134,7 @@ class LOG4CXX_EXPORT Logger :
 		void debug(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -148,7 +148,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -163,7 +163,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -177,7 +177,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -192,7 +192,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -206,7 +206,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void debug(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for DEBUG events.
 
 		<p>This method first checks if this logger is <code>DEBUG</code>
 		enabled by comparing the level of this logger with the
@@ -221,7 +221,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -235,7 +235,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -249,7 +249,7 @@ class LOG4CXX_EXPORT Logger :
 		void error(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -262,7 +262,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::wstring& msg) const;
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -278,7 +278,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -292,7 +292,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -307,7 +307,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -321,7 +321,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void error(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -336,7 +336,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for FATAL messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for FATAL events.
 
 		<p>This method first checks if this logger is <code>FATAL</code>
 		enabled by comparing the level of this logger with the
@@ -350,7 +350,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -364,7 +364,7 @@ class LOG4CXX_EXPORT Logger :
 		void fatal(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -378,7 +378,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -393,7 +393,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -407,7 +407,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -422,7 +422,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg and \c location to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -436,7 +436,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void fatal(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for ERROR events.
 
 		<p>This method first checks if this logger is <code>ERROR</code>
 		enabled by comparing the level of this logger with the
@@ -770,7 +770,7 @@ class LOG4CXX_EXPORT Logger :
 
 	public:
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -786,7 +786,7 @@ class LOG4CXX_EXPORT Logger :
 		void info(const std::string& msg) const;
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -800,7 +800,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -815,7 +815,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -829,7 +829,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -844,7 +844,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -858,7 +858,7 @@ class LOG4CXX_EXPORT Logger :
 		        */
 		void info(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for INFO events.
 
 		<p>This method first checks if this logger is <code>INFO</code>
 		enabled by comparing the level of this logger with the
@@ -878,7 +878,7 @@ class LOG4CXX_EXPORT Logger :
 		bool isAttached(const AppenderPtr appender) const override;
 
 		/**
-		 *  Is this logger is enabled for <code>DEBUG</code> level messages?
+		 *  Is this logger is enabled for <code>DEBUG</code> level logging events?
 		 *
 		 *  <p>By writing
 		 *  <pre>
@@ -897,11 +897,11 @@ class LOG4CXX_EXPORT Logger :
 		 *      logger->debug("Component: " + std::to_string(componentNumber));
 		 *  </pre>
 		 *
-		 *  <p>On the other hand, if the <code>logger</code> is debug enabled, you
-		 *  will incur the cost of evaluating whether the logger is debug
-		 *  enabled twice. Once in <code>isDebugEnabled</code> and once in
-		 *  the <code>debug</code>.  This is an insignificant overhead
-		 *  since evaluating a logger takes about 1%% of the time it
+		 *  <p>On the other hand, if the <code>logger</code> is enabled for <code>DEBUG</code> logging events,
+		 *  you will incur the cost of evaluating whether the logger is
+		 *  enabled twice, once in <code>isDebugEnabled</code> and once in
+		 *  the <code>DEBUG</code>.  This really is an insignificant overhead
+		 *  since evaluating a the enabled status takes about 1% of the time it
 		 *  takes to send the message to the appender.
 
 		 * See also #isDebugEnabledFor.
@@ -913,25 +913,24 @@ class LOG4CXX_EXPORT Logger :
 		bool isDebugEnabled() const;
 
 		/**
-		 *  Is \c logger is enabled for <code>DEBUG</code> level messages?
+		 *  Is \c logger is enabled for <code>DEBUG</code> level logging events?
 		 *
 		 *  <p>By writing
 		 *  <pre>
 		 *    if(log4cxx::Logger::isDebugEnabledFor(logger)) {
 		 *      logger->forcedLog(log4cxx::Level::getDebug(), "Component: " + std::to_string(componentNumber));
 		 *    }
-		 *  </pre>you will not incur the cost of a function call and parameter construction
-		 *  if debugging is disabled for <code>logger</code>.
-		 *  You avoid the cost constructing the message
-		 *  when the message is not logged.
-		 *
-		 *  <p>This function minimises the computational cost of
-		 *  disabled log debug statements.
+		 *  </pre>you minimise the computational cost
+		 *  when \c logger is not enabled for <code>DEBUG</code> logging events.
+		 *  This function may be inlined thereby avoiding a function call
+		 *  as well as the cost constructing the message
+		 *  when \c logger is not enabled for <code>DEBUG</code> events.
 		 *
 		 * See also #LOG4CXX_DEBUG.
 		 *
-		 *  @return bool - <code>true</code> if this logger is debug
-		 *  enabled, <code>false</code> otherwise.
+		 *  @return bool - <code>false</code> if \c logger is <code>null</code>
+		 *  or <code>DEBUG</code> logging events are disabled for \c logger,
+		 *  <code>true</code> otherwise.
 		 **/
 		inline static bool isDebugEnabledFor(const LoggerPtr& logger)
 		{
@@ -939,15 +938,15 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Is this logger is enabled for messages at \c level?
+		Is this logger is enabled for logging events at \c level?
 
-		@return bool True if this logger is enabled for <code>level</code> messages.
+		@return bool True if this logger is enabled for <code>level</code> logging events.
 		*/
 		bool isEnabledFor(const LevelPtr& level) const;
 
 
 		/**
-		Is this logger is enabled for <code>INFO</code> level messages?
+		Is this logger is enabled for <code>INFO</code> level logging events?
 
 		See #isDebugEnabled.
 		See also #LOG4CXX_INFO.
@@ -958,7 +957,7 @@ class LOG4CXX_EXPORT Logger :
 		bool isInfoEnabled() const;
 
 		/**
-		Is this logger is enabled for <code>INFO</code> level messages?
+		Is this logger is enabled for <code>INFO</code> level logging events?
 
 		See #isDebugEnabledFor.
 		See also #LOG4CXX_INFO.
@@ -972,7 +971,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Is this logger is enabled for <code>WARN</code> level messages?
+		Is this logger is enabled for <code>WARN</code> level logging events?
 
 		See also #isDebugEnabled.
 		See also #LOG4CXX_WARN.
@@ -983,7 +982,7 @@ class LOG4CXX_EXPORT Logger :
 		bool isWarnEnabled() const;
 
 		/**
-		Is this logger is enabled for <code>INFO</code> level messages?
+		Is this logger is enabled for <code>INFO</code> level logging events?
 
 		See #isDebugEnabledFor.
 		See also #LOG4CXX_WARN.
@@ -997,7 +996,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Is this logger is enabled for error level messages?
+		Is this logger is enabled for error level logging events?
 
 		See also #isDebugEnabled.
 		See also #LOG4CXX_ERROR.
@@ -1008,7 +1007,7 @@ class LOG4CXX_EXPORT Logger :
 		bool isErrorEnabled() const;
 
 		/**
-		Is this logger is enabled for <code>INFO</code> level messages?
+		Is this logger is enabled for <code>INFO</code> level logging events?
 
 		See #isDebugEnabledFor.
 		See also #LOG4CXX_ERROR.
@@ -1022,7 +1021,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Is this logger is enabled for fatal level messages?
+		Is this logger is enabled for fatal level logging events?
 		See also #isDebugEnabled.
 		See also #LOG4CXX_FATAL.
 
@@ -1036,7 +1035,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Is this logger is enabled for trace level messages?
+		Is this logger is enabled for trace level logging events?
 		See also #isDebugEnabled.
 		See also #LOG4CXX_FATAL.
 
@@ -1505,7 +1504,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1519,7 +1518,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1534,7 +1533,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1548,7 +1547,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1563,7 +1562,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1577,7 +1576,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1591,7 +1590,7 @@ class LOG4CXX_EXPORT Logger :
 		void warn(const CFStringRef& msg) const;
 #endif
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1605,7 +1604,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void warn(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for WARN events.
 
 		<p>This method first checks if this logger is <code>WARN</code>
 		enabled by comparing the level of this logger with the
@@ -1620,7 +1619,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1634,7 +1633,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::wstring& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1649,7 +1648,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1663,7 +1662,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::basic_string<UniChar>& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1678,7 +1677,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1692,7 +1691,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const CFStringRef& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1706,7 +1705,7 @@ class LOG4CXX_EXPORT Logger :
 		void trace(const CFStringRef& msg) const;
 #endif
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1720,7 +1719,7 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void trace(const std::string& msg, const log4cxx::spi::LocationInfo& location) const;
 		/**
-		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE messages.
+		Add a new logging event containing \c msg to the appender(s) attached to this logger if this logger is enabled for TRACE events.
 
 		<p>This method first checks if this logger is <code>TRACE</code>
 		enabled by comparing the level of this logger with the
@@ -1812,7 +1811,7 @@ Conditionally sends \c message to the appender attached to \c logger.
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 10000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for DEBUG messages.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for DEBUG events.
 
 <p>Equivalent to writing:
 <pre>
@@ -1830,7 +1829,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getDebug(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for DEBUG messages, formatting with libfmt
+Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for DEBUG events, formatting with libfmt
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1845,7 +1844,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 5000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for TRACE messages.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for TRACE events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1856,7 +1855,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getTrace(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for TRACE messages, formatting with libfmt.
+Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for TRACE events, formatting with libfmt.
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1871,7 +1870,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 20000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for INFO messages.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for INFO events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1882,7 +1881,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getInfo(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for INFO messages, formatting with libfmt.
+Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for INFO events, formatting with libfmt.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1898,7 +1897,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 30000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for WARN messages.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for WARN events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1909,7 +1908,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getWarn(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for WARN messages, formatting with libfmt
+Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for WARN events, formatting with libfmt
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1924,7 +1923,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 40000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR messages.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1935,7 +1934,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR messages, formatting with libfmt
+Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for ERROR events, formatting with libfmt
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -1945,7 +1944,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getError(), fmt::format( __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a error if the condition is not true.
+If \c condition is not true, add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR events.
 
 @param logger the logger to be used.
 @param condition condition
@@ -1957,7 +1956,7 @@ Logs a error if the condition is not true.
 			logger->forcedLog(::log4cxx::Level::getError(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a error if the condition is not true, formatting with libfmt
+If \c condition is not true, add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for ERROR events, formatting with libfmt
 
 @param logger the logger to be used.
 @param condition condition
@@ -1976,7 +1975,7 @@ Logs a error if the condition is not true, formatting with libfmt
 
 #if !defined(LOG4CXX_THRESHOLD) || LOG4CXX_THRESHOLD <= 50000
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for FATAL messages.
+Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for FATAL events.
 
 @param logger the logger to be used.
 @param message the message string to log.
@@ -1987,7 +1986,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 			logger->forcedLog(::log4cxx::Level::getFatal(), oss_.str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing \c message to the appender(s) attached to \c logger if it is enabled for FATAL messages, formatting with libfmt
+Add a new logging event containing \c ... to the appender(s) attached to \c logger if it is enabled for FATAL events, formatting with libfmt
 
 @param logger the logger to be used.
 @param ... The format string and message to log
@@ -2001,7 +2000,7 @@ Add a new logging event containing \c message to the appender(s) attached to \c 
 #endif
 
 /**
-Logs a localized message with no parameter.
+Add a new logging event containing the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2012,7 +2011,7 @@ Logs a localized message with no parameter.
 			logger->l7dlog(level, key, LOG4CXX_LOCATION); }} while (0)
 
 /**
-Logs a localized message with one parameter.
+Add a new logging event containing the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with one parameter.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2024,7 +2023,7 @@ Logs a localized message with one parameter.
 			logger->l7dlog(level, key, LOG4CXX_LOCATION, p1); }} while (0)
 
 /**
-Logs a localized message with two parameters.
+Add a new logging event containing the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with two parameters.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2037,7 +2036,7 @@ Logs a localized message with two parameters.
 			logger->l7dlog(level, key, LOG4CXX_LOCATION, p1, p2); }} while (0)
 
 /**
-Logs a localized message with three parameters.
+Add a new logging event containing the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with three parameters.
 
 @param logger the logger to be used.
 @param level the level to log.

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -1061,7 +1061,7 @@ class LOG4CXX_EXPORT Logger :
 		}
 
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
+		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1079,7 +1079,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::vector<LogString>& values) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events.
+		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1094,7 +1094,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::string& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with the \c val parameter.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1112,7 +1112,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1 and \c val2.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1131,7 +1131,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::string& val1, const std::string& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1, \c val2 and val3.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and val3 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1153,7 +1153,7 @@ class LOG4CXX_EXPORT Logger :
 
 #if LOG4CXX_WCHAR_T_API
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
+		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1168,7 +1168,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::wstring& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameter \c val.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1186,7 +1186,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1 and \c val2.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1205,7 +1205,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::wstring& val1, const std::wstring& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1, \c val2 and val3.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and val3 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1227,7 +1227,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_UNICHAR_API
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
+		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1242,12 +1242,12 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const std::basic_string<UniChar>& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameter..
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
 		pattern is formatted using helpers::StringHelper::format method with the
-		supplied parameters in a string array.
+		supplied parameter in a string array.
 
 		@param level The level of the logging request.
 		@param key The key to be searched in the ResourceBundle.
@@ -1260,7 +1260,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1 and \c val2.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1279,7 +1279,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const std::basic_string<UniChar>& val1, const std::basic_string<UniChar>& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1, \c val2 and val3.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and val3 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1302,7 +1302,7 @@ class LOG4CXX_EXPORT Logger :
 #endif
 #if LOG4CXX_CFSTRING_API
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
+		Add a new logging event containing \c locationInfo and the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1317,7 +1317,7 @@ class LOG4CXX_EXPORT Logger :
 		void l7dlog(const LevelPtr& level, const CFStringRef& key,
 			const log4cxx::spi::LocationInfo& locationInfo) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameter \c val.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameter \c val to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1335,7 +1335,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1 and \c val2.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1 and \c val2 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -1354,7 +1354,7 @@ class LOG4CXX_EXPORT Logger :
 			const log4cxx::spi::LocationInfo& locationInfo,
 			const CFStringRef& val1, const CFStringRef& val2) const;
 		/**
-		Add a new logging event containing \c locationInfo and the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with parameters \c val1, \c val2 and val3.
+		Add a new logging event containing \c locationInfo and the localized message \c key using parameters \c val1, \c val2 and val3 to the appender(s) attached to \c logger if it is enabled for \c level events
 
 		First, the user supplied
 		<code>key</code> is searched in the resource bundle. Next, the resulting
@@ -2016,7 +2016,7 @@ Add a new logging event containing \c ... to the appender(s) attached to \c logg
 #endif
 
 /**
-Add a new logging event containing the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with no parameter.
+Add a new logging event containing the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2027,7 +2027,7 @@ Add a new logging event containing the \c key localized message to the appender(
 			logger->l7dlog(level, key, LOG4CXX_LOCATION); }} while (0)
 
 /**
-Add a new logging event containing the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with one parameter.
+Add a new logging event containing the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events with one parameter.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2039,7 +2039,7 @@ Add a new logging event containing the \c key localized message to the appender(
 			logger->l7dlog(level, key, LOG4CXX_LOCATION, p1); }} while (0)
 
 /**
-Add a new logging event containing the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with two parameters.
+Add a new logging event containing the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events with two parameters.
 
 @param logger the logger to be used.
 @param level the level to log.
@@ -2052,7 +2052,7 @@ Add a new logging event containing the \c key localized message to the appender(
 			logger->l7dlog(level, key, LOG4CXX_LOCATION, p1, p2); }} while (0)
 
 /**
-Add a new logging event containing the \c key localized message to the appender(s) attached to \c logger if it is enabled for \c level events with three parameters.
+Add a new logging event containing the localized message \c key to the appender(s) attached to \c logger if it is enabled for \c level events with three parameters.
 
 @param logger the logger to be used.
 @param level the level to log.


### PR DESCRIPTION
Add macro links onto the Logger page and document the static inline methods used in the macros.