### PR TITLE
LOGCXX-564

### DIFF
--- a/src/main/cpp/class.cpp
+++ b/src/main/cpp/class.cpp
@@ -74,7 +74,7 @@ using namespace log4cxx::filter;
 using namespace log4cxx::xml;
 using namespace log4cxx::rolling;
 
-log4cxx_uint32_t libraryVersion(){
+uint32_t libraryVersion(){
 	// This function defined in log4cxx.h
 	return LOG4CXX_VERSION;
 }

--- a/src/main/cpp/relativetimedateformat.cpp
+++ b/src/main/cpp/relativetimedateformat.cpp
@@ -34,6 +34,6 @@ void log4cxx::helpers::RelativeTimeDateFormat::format(
 	log4cxx_time_t date,
 	Pool& p) const
 {
-	log4cxx_int64_t interval = (date - startTime) / APR_INT64_C(1000);
+	int64_t interval = (date - startTime) / APR_INT64_C(1000);
 	StringHelper::toString(interval, p, s);
 }

--- a/src/main/cpp/stringhelper.cpp
+++ b/src/main/cpp/stringhelper.cpp
@@ -124,7 +124,7 @@ int StringHelper::toInt(const LogString& s)
 	return atoi(as.c_str());
 }
 
-log4cxx_int64_t StringHelper::toInt64(const LogString& s)
+int64_t StringHelper::toInt64(const LogString& s)
 {
 	std::string as;
 	Transcoder::encode(s, as);
@@ -150,7 +150,7 @@ void StringHelper::toString(bool val, LogString& dst)
 }
 
 
-void StringHelper::toString(log4cxx_int64_t n, Pool& pool, LogString& dst)
+void StringHelper::toString(int64_t n, Pool& pool, LogString& dst)
 {
 	if (n >= INT_MIN && n <= INT_MAX)
 	{
@@ -158,7 +158,7 @@ void StringHelper::toString(log4cxx_int64_t n, Pool& pool, LogString& dst)
 	}
 	else
 	{
-		const log4cxx_int64_t BILLION = APR_INT64_C(1000000000);
+		const int64_t BILLION = APR_INT64_C(1000000000);
 		int billions = (int) (n / BILLION);
 		char* upper = pool.itoa(billions);
 		int remain = (int) (n - billions * BILLION);
@@ -178,7 +178,7 @@ void StringHelper::toString(log4cxx_int64_t n, Pool& pool, LogString& dst)
 
 void StringHelper::toString(size_t n, Pool& pool, LogString& s)
 {
-	toString((log4cxx_int64_t) n, pool, s);
+	toString((int64_t) n, pool, s);
 }
 
 LogString StringHelper::format(const LogString& pattern, const std::vector<LogString>& params)

--- a/src/main/include/log4cxx/helpers/stringhelper.h
+++ b/src/main/include/log4cxx/helpers/stringhelper.h
@@ -43,10 +43,10 @@ class LOG4CXX_EXPORT StringHelper
 
 
 		static int toInt(const LogString& s);
-		static log4cxx_int64_t toInt64(const LogString& s);
+		static int64_t toInt64(const LogString& s);
 
 		static void toString(int i, log4cxx::helpers::Pool& pool, LogString& dst);
-		static void toString(log4cxx_int64_t i, log4cxx::helpers::Pool& pool, LogString& dst);
+		static void toString(int64_t i, log4cxx::helpers::Pool& pool, LogString& dst);
 		static void toString(size_t i, log4cxx::helpers::Pool& pool, LogString& dst);
 
 		static void toString(bool val, LogString& dst);

--- a/src/main/include/log4cxx/log4cxx.h.in
+++ b/src/main/include/log4cxx/log4cxx.h.in
@@ -51,15 +51,12 @@
 #define LOG4CXX_HAS_NETWORKING @NETWORKING_SUPPORT@
 #define LOG4CXX_HAS_MULTIPROCESS_ROLLING_FILE_APPENDER @MULTIPROCESS_RFA@
 
-typedef long long log4cxx_int64_t;
 #define LOG4CXX_USE_GLOBAL_SCOPE_TEMPLATE 0
 #define LOG4CXX_LOGSTREAM_ADD_NOP 0
-typedef log4cxx_int64_t log4cxx_time_t;
-typedef int log4cxx_status_t;
-typedef unsigned int log4cxx_uint32_t;
 
 #include "boost-std-configuration.h"
 #include <memory>
+#include <cstdint>
 
 #define LOG4CXX_PTR_DEF(T) typedef std::shared_ptr<T> T##Ptr;\
 	typedef std::weak_ptr<T> T##WeakPtr
@@ -101,13 +98,20 @@ __pragma( warning( pop ) )
 namespace log4cxx {
 
 /**
+ * log4cxx_time_t - holds the number of microseconds since 1970-01-01
+ */
+typedef int64_t log4cxx_time_t;
+
+typedef int log4cxx_status_t;
+
+/**
  * Query the compiled version of the library.  Ideally, this should
  * be the same as the LOG4CXX_VERSION macro defined above.
  *
  * The LOG4CXX_VERSION_GET_ series of macros let you extract the
  * specific bytes of the version if required.
  */
-LOG4CXX_EXPORT log4cxx_uint32_t libraryVersion();
+LOG4CXX_EXPORT uint32_t libraryVersion();
 
 }
 


### PR DESCRIPTION
Move the relevant typdefs to the log4cxx namespace.

The log4cxx_status_t is still a weird typedef, but that seems to be mostly used to interface with APR.  That probably should go away at some point, but given that we still depend on APR a lot we will keep it for now.