### PR TITLE
LOGCXX-568 Cleanup if GZip fails

### DIFF
--- a/src/main/include/log4cxx/file.h
+++ b/src/main/include/log4cxx/file.h
@@ -176,8 +176,22 @@ class LOG4CXX_EXPORT File
 		 */
 		bool mkdirs(log4cxx::helpers::Pool& p) const;
 
+		/**
+		 * Set the file to be deleted when this object is destroyed.
+		 * @param autoDelete If true, delete file upon destruction.  If true, do not delete file.
+		 */
+		void setAutoDelete(bool autoDelete);
+
+		/**
+		 * Return the value of the autodelete setting.  If true, this file will be deleted when the
+		 * destructor is called.
+		 *
+		 * @return True if the file is deleted upon destruction.
+		 */
+		bool getAutoDelete() const;
+
 	private:
-		LOG4CXX_DECLARE_PRIVATE_MEMBER(LogString, path)
+		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(FilePrivate, m_priv)
 		static char* convertBackSlashes(char*);
 		char* getPath(log4cxx::helpers::Pool& p) const;
 };

--- a/src/main/include/log4cxx/rolling/gzcompressaction.h
+++ b/src/main/include/log4cxx/rolling/gzcompressaction.h
@@ -52,6 +52,17 @@ class GZCompressAction : public Action
 		 */
 		bool execute(log4cxx::helpers::Pool& pool) const override;
 
+		/**
+		 * Set to true to throw an IOException on a fork failure.  By default, this
+		 * is true.  When an IOException is thrown, this will automatically cause the
+		 * error handler to be called(which is the recommended way of handling this
+		 * problem).  By setting this to true, the GZCompressAction effectively
+		 * turns into a FileRenameAction if any errors are encountered.
+		 *
+		 * @param throwIO
+		 */
+		void setThrowIOExceptionOnForkFailure(bool throwIO);
+
 	private:
 		GZCompressAction(const GZCompressAction&);
 		GZCompressAction& operator=(const GZCompressAction&);

--- a/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
+++ b/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
@@ -190,7 +190,8 @@ class LOG4CXX_EXPORT TimeBasedRollingPolicy : public virtual RollingPolicyBase,
 			const LogString& filename,
 			size_t fileLength) override;
 
-		using RollingPolicyBase::setOption;
+		void setOption(const LogString& option, const LogString& value) override;
+
 	protected:
 		log4cxx::pattern::PatternMap getFormatSpecifiers() const override;
 

--- a/src/main/include/log4cxx/rolling/zipcompressaction.h
+++ b/src/main/include/log4cxx/rolling/zipcompressaction.h
@@ -51,6 +51,17 @@ class ZipCompressAction : public Action
 		 */
 		bool execute(log4cxx::helpers::Pool& pool) const override;
 
+		/**
+		 * Set to true to throw an IOException on a fork failure.  By default, this
+		 * is true.  When an IOException is thrown, this will automatically cause the
+		 * error handler to be called(which is the recommended way of handling this
+		 * problem).  By setting this to true, the ZipCompressAction effectively
+		 * turns into a FileRenameAction if any errors are encountered.
+		 *
+		 * @param throwIO
+		 */
+		void setThrowIOExceptionOnForkFailure(bool throwIO);
+
 	private:
 		ZipCompressAction(const ZipCompressAction&);
 		ZipCompressAction& operator=(const ZipCompressAction&);


### PR DESCRIPTION
Cleanup 0-sized gzip files if rollover fails.  Added a new option to determine what to do if there is a failure, to make the rollover dumb.

This also implements the long-standing PR #62, adding that fix in as an option.  The best way to fix this is to use the `FallbackErrorHandler`, however this fix is easier to configure.