### PR TITLE
Prevent spurious configuration warnings

### DIFF
--- a/src/main/cpp/propertyconfigurator.cpp
+++ b/src/main/cpp/propertyconfigurator.cpp
@@ -523,15 +523,6 @@ AppenderPtr PropertyConfigurator::parseAppender(
 		}
 
 		PropertySetter::setProperties(appender, props, prefix + LOG4CXX_STR("."), p);
-		if (!rolling)
-			;
-		else if (!rolling->hasRollingPolicy())
-			LogLog::warn((LogString) LOG4CXX_STR("Missing rolling policy for \"")
-				+ appenderName + LOG4CXX_STR("\"."));
-		else if (!rolling->hasTriggeringPolicy())
-			LogLog::warn((LogString) LOG4CXX_STR("Missing triggering policy for \"")
-				+ appenderName + LOG4CXX_STR("\"."));
-
 		LogLog::debug((LogString) LOG4CXX_STR("Parsed \"")
 			+ appenderName + LOG4CXX_STR("\" options."));
 	}

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -482,8 +482,15 @@ void RollingFileAppender::subAppend(const LoggingEventPtr& event, Pool& p)
 }
 
 /**
- * Get rolling policy.
- * @return rolling policy.
+ Does this have a scheme for rolling over log files?
+*/
+bool RollingFileAppender::hasRollingPolicy() const
+{
+	return !!_priv->rollingPolicy;
+}
+
+/**
+ * TThe policy that implements the scheme for rolling over a log file.
  */
 RollingPolicyPtr RollingFileAppender::getRollingPolicy() const
 {
@@ -491,8 +498,15 @@ RollingPolicyPtr RollingFileAppender::getRollingPolicy() const
 }
 
 /**
- * Get triggering policy.
- * @return triggering policy.
+ Does this have a basis for triggering log file rollover?
+*/
+bool RollingFileAppender::hasTriggeringPolicy() const
+{
+	return !!_priv->triggeringPolicy;
+}
+
+/**
+ * The policy that determine when to trigger a log file rollover.
  */
 TriggeringPolicyPtr RollingFileAppender::getTriggeringPolicy() const
 {
@@ -500,8 +514,7 @@ TriggeringPolicyPtr RollingFileAppender::getTriggeringPolicy() const
 }
 
 /**
- * Sets the rolling policy.
- * @param policy rolling policy.
+ * Set the scheme for rolling over log files.
  */
 void RollingFileAppender::setRollingPolicy(const RollingPolicyPtr& policy)
 {
@@ -509,8 +522,7 @@ void RollingFileAppender::setRollingPolicy(const RollingPolicyPtr& policy)
 }
 
 /**
- * Set triggering policy.
- * @param policy triggering policy.
+ * Set policy that determine when to trigger a log file rollover.
  */
 void RollingFileAppender::setTriggeringPolicy(const TriggeringPolicyPtr& policy)
 {

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -201,6 +201,8 @@ void RollingFileAppender::activateOptions(Pool& p)
 {
 	if (!_priv->rollingPolicy)
 	{
+		LogLog::warn(LOG4CXX_STR("No rolling policy configured for the appender named [")
+			+ _priv->name + LOG4CXX_STR("]."));
 		auto fwrp = std::make_shared<FixedWindowRollingPolicy>();
 		fwrp->setFileNamePattern(getFile() + LOG4CXX_STR(".%i"));
 		_priv->rollingPolicy = fwrp;
@@ -221,6 +223,8 @@ void RollingFileAppender::activateOptions(Pool& p)
 
 	if (!_priv->triggeringPolicy)
 	{
+		LogLog::warn(LOG4CXX_STR("No triggering policy configured for the appender named [")
+			+ _priv->name + LOG4CXX_STR("]."));
 		_priv->triggeringPolicy = std::make_shared<SizeBasedTriggeringPolicy>();
 	}
 
@@ -482,27 +486,11 @@ void RollingFileAppender::subAppend(const LoggingEventPtr& event, Pool& p)
 }
 
 /**
- Does this have a scheme for rolling over log files?
-*/
-bool RollingFileAppender::hasRollingPolicy() const
-{
-	return !!_priv->rollingPolicy;
-}
-
-/**
  * TThe policy that implements the scheme for rolling over a log file.
  */
 RollingPolicyPtr RollingFileAppender::getRollingPolicy() const
 {
 	return _priv->rollingPolicy;
-}
-
-/**
- Does this have a basis for triggering log file rollover?
-*/
-bool RollingFileAppender::hasTriggeringPolicy() const
-{
-	return !!_priv->triggeringPolicy;
 }
 
 /**

--- a/src/main/include/log4cxx/rolling/rollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/rollingfileappender.h
@@ -158,19 +158,38 @@ class LOG4CXX_EXPORT RollingFileAppender : public FileAppender
 		bool rolloverInternal(log4cxx::helpers::Pool& p);
 
 	public:
+		/**
+		 Does this have a scheme for rolling over log files?
+		*/
+		bool hasRollingPolicy() const;
 
+		/**
+		 Does this have a basis for triggering log file rollover?
+		*/
+		bool hasTriggeringPolicy() const;
+
+		/**
+		 * The policy that implements the scheme for rolling over a log file.
+		 */
 		RollingPolicyPtr getRollingPolicy() const;
 
+		/**
+		 * The policy that determine when to trigger a log file rollover.
+		 */
 		TriggeringPolicyPtr getTriggeringPolicy() const;
 
 		/**
-		 * Sets the rolling policy. In case the 'policy' argument also implements
-		 * {@link TriggeringPolicy}, then the triggering policy for this appender
-		 * is automatically set to be the policy argument.
-		 * @param policy
+		 * Use \c policy as the scheme for rolling over log files.
+		 *
+		 * Where the \c policy also implements
+		 * {@link TriggeringPolicy}, then \c policy
+		 * will be used to determine when to trigger a log file rollover.
 		 */
 		void setRollingPolicy(const RollingPolicyPtr& policy);
 
+		/**
+		 * Use \c policy to determine when to trigger a log file rollover.
+		 */
 		void setTriggeringPolicy(const TriggeringPolicyPtr& policy);
 
 	public:

--- a/src/main/include/log4cxx/rolling/rollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/rollingfileappender.h
@@ -159,16 +159,6 @@ class LOG4CXX_EXPORT RollingFileAppender : public FileAppender
 
 	public:
 		/**
-		 Does this have a scheme for rolling over log files?
-		*/
-		bool hasRollingPolicy() const;
-
-		/**
-		 Does this have a basis for triggering log file rollover?
-		*/
-		bool hasTriggeringPolicy() const;
-
-		/**
 		 * The policy that implements the scheme for rolling over a log file.
 		 */
 		RollingPolicyPtr getRollingPolicy() const;


### PR DESCRIPTION
When configuring RollingFileAppender using a property file containing MaxBackupIndex and MaxFileSize options (as in the index.md documentation).

Occurs when running the MyApp2 example - it displays warnings that '.triggeringPolicy' and '.rollingPolicy' were not found.

Related to "22be6885 - Restore documented RollingFileAppender configuration properties (#146)"