### PR TITLE
Prevent a compilation errors when using older compilers

### DIFF
--- a/src/main/cpp-qt/configuration.cpp
+++ b/src/main/cpp-qt/configuration.cpp
@@ -25,11 +25,11 @@
 #include <memory>
 #include <QDebug>
 
-using log4cxx::qt::Configuration;
 namespace log4cxx
 {
-namespace helpers
+namespace qt
 {
+using log4cxx::helpers::LogLog;
 
 static std::unique_ptr<QFileSystemWatcher> watcher;
 static QString configFilename;

--- a/src/main/cpp-qt/configuration.cpp
+++ b/src/main/cpp-qt/configuration.cpp
@@ -26,7 +26,10 @@
 #include <QDebug>
 
 using log4cxx::qt::Configuration;
-using log4cxx::helpers::LogLog;
+namespace log4cxx
+{
+namespace helpers
+{
 
 static std::unique_ptr<QFileSystemWatcher> watcher;
 static QString configFilename;
@@ -120,3 +123,6 @@ Configuration::configureFromFileAndWatch(const QVector<QString>& directories,
 
 	return {log4cxx::spi::ConfigurationStatus::NotConfigured, QString()};
 }
+
+} //namespace helpers
+} //namespace log4cxx

--- a/src/main/cpp/aprdatagramsocket.cpp
+++ b/src/main/cpp/aprdatagramsocket.cpp
@@ -20,7 +20,10 @@
 #include <log4cxx/helpers/transcoder.h>
 #include <apr_network_io.h>
 
-using log4cxx::helpers::APRDatagramSocket;
+namespace log4cxx
+{
+namespace helpers
+{
 
 #define _priv static_cast<APRDatagramSocketPriv*>(m_priv.get())
 
@@ -207,3 +210,6 @@ bool APRDatagramSocket::isClosed() const
 {
 	return _priv->socket != nullptr;
 }
+
+} //namespace helpers
+} //namespace log4cxx

--- a/src/main/cpp/aprserversocket.cpp
+++ b/src/main/cpp/aprserversocket.cpp
@@ -22,7 +22,10 @@
 #include "apr_pools.h"
 #include "apr_poll.h"
 
-using log4cxx::helpers::APRServerSocket;
+namespace log4cxx
+{
+namespace helpers
+{
 
 #define _priv static_cast<APRServerSocketPriv*>(m_priv.get())
 
@@ -98,7 +101,7 @@ void APRServerSocket::close(){
 /** Listens for a connection to be made to this socket and
 accepts it
 */
-log4cxx::helpers::SocketPtr APRServerSocket::accept()
+SocketPtr APRServerSocket::accept()
 {
 	std::unique_lock<std::mutex> lock(_priv->mutex);
 
@@ -155,3 +158,6 @@ log4cxx::helpers::SocketPtr APRServerSocket::accept()
 
 	return std::make_shared<APRSocket>(newSocket, newPool);
 }
+
+} //namespace helpers
+} //namespace log4cxx

--- a/src/main/cpp/aprsocket.cpp
+++ b/src/main/cpp/aprsocket.cpp
@@ -23,9 +23,12 @@
 #include "apr_network_io.h"
 #include "apr_signal.h"
 
-using log4cxx::helpers::APRSocket;
+namespace log4cxx
+{
+namespace helpers
+{
 
-struct APRSocket::APRSocketPriv : public log4cxx::helpers::Socket::SocketPrivate {
+struct APRSocket::APRSocketPriv : public Socket::SocketPrivate {
 	APRSocketPriv() :
 		socket(nullptr)
 	{}
@@ -154,3 +157,6 @@ void APRSocket::close()
 		_priv->socket = 0;
 	}
 }
+
+} //namespace helpers
+} //namespace log4cxx

--- a/src/main/cpp/defaultconfigurator.cpp
+++ b/src/main/cpp/defaultconfigurator.cpp
@@ -169,6 +169,7 @@ log4cxx::spi::ConfigurationStatus DefaultConfigurator::tryLoadFile(const LogStri
 
 std::tuple<log4cxx::spi::ConfigurationStatus,LogString>
 DefaultConfigurator::configureFromFile(const std::vector<LogString>& directories, const std::vector<LogString>& filenames){
+	using ResultType = std::tuple<log4cxx::spi::ConfigurationStatus, LogString>;
 	log4cxx::helpers::Pool pool;
 
 	for( LogString dir : directories ){
@@ -183,14 +184,14 @@ DefaultConfigurator::configureFromFile(const std::vector<LogString>& directories
 			{
 				log4cxx::spi::ConfigurationStatus configStatus = tryLoadFile(canidate_str);
 				if( configStatus == log4cxx::spi::ConfigurationStatus::Configured ){
-					return {configStatus, canidate_str};
+					return ResultType{configStatus, canidate_str};
 				}
 				LogLog::debug(LOG4CXX_STR("Unable to load file: trying next"));
 			}
 		}
 	}
 
-	return {log4cxx::spi::ConfigurationStatus::NotConfigured, LogString()};
+	return ResultType{log4cxx::spi::ConfigurationStatus::NotConfigured, LogString()};
 }
 
 

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -32,6 +32,7 @@
 #endif
 
 using log4cxx::helpers::ThreadUtility;
+using log4cxx::helpers::ThreadConfigurationType;
 
 struct ThreadUtility::priv_data
 {

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -31,8 +31,10 @@
 	#include <processthreadsapi.h>
 #endif
 
-using log4cxx::helpers::ThreadUtility;
-using log4cxx::helpers::ThreadConfigurationType;
+namespace log4cxx
+{
+namespace helpers
+{
 
 struct ThreadUtility::priv_data
 {
@@ -43,9 +45,9 @@ struct ThreadUtility::priv_data
 		start_post = nullptr;
 	}
 
-	log4cxx::helpers::ThreadStartPre start_pre;
-	log4cxx::helpers::ThreadStarted started;
-	log4cxx::helpers::ThreadStartPost start_post;
+	ThreadStartPre start_pre;
+	ThreadStarted started;
+	ThreadStartPost start_post;
 };
 
 #if LOG4CXX_HAS_PTHREAD_SIGMASK
@@ -181,17 +183,20 @@ void ThreadUtility::postThreadUnblockSignals()
 }
 
 
-log4cxx::helpers::ThreadStartPre ThreadUtility::preStartFunction()
+ThreadStartPre ThreadUtility::preStartFunction()
 {
 	return m_priv->start_pre;
 }
 
-log4cxx::helpers::ThreadStarted ThreadUtility::threadStartedFunction()
+ThreadStarted ThreadUtility::threadStartedFunction()
 {
 	return m_priv->started;
 }
 
-log4cxx::helpers::ThreadStartPost ThreadUtility::postStartFunction()
+ThreadStartPost ThreadUtility::postStartFunction()
 {
 	return m_priv->start_post;
 }
+
+} //namespace helpers
+} //namespace log4cxx


### PR DESCRIPTION
These arose as the conan package manager include gcc5 and VS 2017 in their CI matrix.

See the [PR I am working on](https://github.com/conan-io/conan-center-index/pull/16679)