### PR TITLE
Document how to send events to a fluent-bit server

### DIFF
--- a/src/main/cpp/socketappenderskeleton.cpp
+++ b/src/main/cpp/socketappenderskeleton.cpp
@@ -107,12 +107,16 @@ void SocketAppenderSkeleton::connect(Pool& p)
 		}
 		catch (SocketException& e)
 		{
-			LogString msg = LOG4CXX_STR("Could not connect to remote log4cxx server at [")
-				+ _priv->address->getHostName() + LOG4CXX_STR("].");
+			LogString msg = LOG4CXX_STR("Could not connect to [")
+				+ _priv->address->getHostName() + LOG4CXX_STR(":");
+			StringHelper::toString(_priv->port, p, msg);
+			msg += LOG4CXX_STR("].");
 
 			if (_priv->reconnectionDelay > 0)
 			{
-				msg += LOG4CXX_STR(" We will try again later. ");
+				msg += LOG4CXX_STR(" We will try again in ");
+				StringHelper::toString(_priv->reconnectionDelay, p, msg);
+				msg += LOG4CXX_STR(" ms");
 			}
 
 			fireConnector(); // fire the connector thread

--- a/src/main/include/log4cxx/appenderskeleton.h
+++ b/src/main/include/log4cxx/appenderskeleton.h
@@ -146,8 +146,6 @@ class LOG4CXX_EXPORT AppenderSkeleton :
 		/**
 		Set the layout for this appender. Note that some appenders have
 		their own (fixed) layouts or do not use one. For example, the
-		{@link net::XMLSocketAppender XMLSocketAppender} ignores the layout set
-		here.
 		*/
 		void setLayout(const LayoutPtr layout1) override;
 

--- a/src/main/include/log4cxx/appenderskeleton.h
+++ b/src/main/include/log4cxx/appenderskeleton.h
@@ -145,7 +145,7 @@ class LOG4CXX_EXPORT AppenderSkeleton :
 
 		/**
 		Set the layout for this appender. Note that some appenders have
-		their own (fixed) layouts or do not use one. For example, the
+		their own (fixed) layouts or do not use one.
 		*/
 		void setLayout(const LayoutPtr layout1) override;
 

--- a/src/main/include/log4cxx/net/xmlsocketappender.h
+++ b/src/main/include/log4cxx/net/xmlsocketappender.h
@@ -30,9 +30,9 @@ namespace net
 Sends spi::LoggingEvent elements
 to a remote a log server, usually in XML format.
 
-A configuration that writes JSON to the TCP input plugin
-of a <a href="https://docs.fluentbit.io/manual/pipeline/inputs/tcp">fluent-bit</a>
-process running on the same system as the application:
+Here is an example configuration that writes JSON to the
+<a href="https://docs.fluentbit.io/manual/pipeline/inputs/tcp">TCP input plugin of a fluent-bit log server</a>
+running on the same system as the application:
 ~~~{.xml}
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
 <appender name="A1" class="XMLSocketAppender">

--- a/src/main/include/log4cxx/net/xmlsocketappender.h
+++ b/src/main/include/log4cxx/net/xmlsocketappender.h
@@ -27,20 +27,31 @@ namespace net
 {
 
 /**
-Sends LoggingEvent objects in XML format
-to a remote a log server, usually a XMLSocketNode.
+Sends spi::LoggingEvent elements
+to a remote a log server, usually in XML format.
 
-<p>The XMLSocketAppender has the following properties:
+A configuration that writes JSON to the TCP input plugin
+of a <a href="https://docs.fluentbit.io/manual/pipeline/inputs/tcp">fluent-bit</a>
+process running on the same system as the application:
+~~~{.xml}
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<appender name="A1" class="XMLSocketAppender">
+  <param name="RemoteHost" value="localhost" />
+  <param name="Port"       value="5170" />
+  <layout class="JSONLayout"/>
+</appender>
+<root>
+  <priority value ="INFO" />
+  <appender-ref ref="A1" />
+</root>
+</log4j:configuration>
+~~~
 
-- If sent to a XMLSocketNode, remote logging
-is non-intrusive as far as the log event is concerned. In other
-words, the event will be logged with the same time stamp,
+<p>XMLSocketAppender has the following properties:
+
+- The event will be logged with the same time stamp,
 NDC, location info as if it were logged locally by
 the client.
-
-- XMLSocketAppenders use exclusively an XMLLayout. They ship an
-XML stream representing a LoggingEvent object
-to the server side.
 
 - Remote logging uses the TCP protocol. Consequently, if
 the server is reachable, then log events will eventually arrive
@@ -76,7 +87,7 @@ destruction problem. Most other applications can safely
 ignore it.
 
 - If the application hosting the <code>XMLSocketAppender</code>
-        exits before the <code>XMLSocketAppender</code> is closed either
+exits before the <code>XMLSocketAppender</code> is closed either
 explicitly or subsequent to destruction, then there might
 be untransmitted data in the pipe which might be lost.
 @n @n To avoid lost data, it is usually sufficient to
@@ -99,7 +110,7 @@ class LOG4CXX_EXPORT XMLSocketAppender : public SocketAppenderSkeleton
 		static int DEFAULT_RECONNECTION_DELAY;
 
 		/**
-		An event XML stream cannot exceed 1024 bytes.
+		Unused
 		*/
 		static const int MAX_EVENT_LEN;
 

--- a/src/test/cpp/net/xmlsocketappendertestcase.cpp
+++ b/src/test/cpp/net/xmlsocketappendertestcase.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <log4cxx/net/xmlsocketappender.h>
+#include <log4cxx/xml/domconfigurator.h>
 #include "../appenderskeletontestcase.h"
 #include "apr.h"
 
@@ -34,6 +35,7 @@ class XMLSocketAppenderTestCase : public AppenderSkeletonTestCase
 		//
 		LOGUNIT_TEST(testDefaultThreshold);
 		LOGUNIT_TEST(testSetOptionThreshold);
+		//LOGUNIT_TEST(test_fluent_bit);
 
 		LOGUNIT_TEST_SUITE_END();
 
@@ -43,6 +45,18 @@ class XMLSocketAppenderTestCase : public AppenderSkeletonTestCase
 		AppenderSkeleton* createAppenderSkeleton() const
 		{
 			return new log4cxx::net::XMLSocketAppender();
+		}
+
+		void test_fluent_bit()
+		{
+			xml::DOMConfigurator::configure("input/xml/fluent-bit.xml");
+			auto odbc = Logger::getRootLogger();
+			for (int i = 0; i < 100; ++i)
+			{
+				LOG4CXX_INFO(odbc, "Message '" << i << "'");
+				//apr_sleep(30000);
+			}
+			LOG4CXX_INFO(odbc, "Last message");
 		}
 };
 

--- a/src/test/cpp/net/xmlsocketappendertestcase.cpp
+++ b/src/test/cpp/net/xmlsocketappendertestcase.cpp
@@ -50,13 +50,12 @@ class XMLSocketAppenderTestCase : public AppenderSkeletonTestCase
 		void test_fluent_bit()
 		{
 			xml::DOMConfigurator::configure("input/xml/fluent-bit.xml");
-			auto odbc = Logger::getRootLogger();
+			auto log = Logger::getRootLogger();
 			for (int i = 0; i < 100; ++i)
 			{
-				LOG4CXX_INFO(odbc, "Message '" << i << "'");
-				//apr_sleep(30000);
+				LOG4CXX_INFO(log, "Message '" << i << "'");
 			}
-			LOG4CXX_INFO(odbc, "Last message");
+			LOG4CXX_INFO(log, "Last message");
 		}
 };
 

--- a/src/test/resources/input/xml/fluent-bit.xml
+++ b/src/test/resources/input/xml/fluent-bit.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<appender name="A1" class="XMLSocketAppender">
+  <param name="RemoteHost" value="localhost" />
+  <param name="Port"       value="5170" />
+  <layout class="JSONLayout"/>
+</appender>
+<root>
+  <priority value ="INFO" />
+  <appender-ref ref="A1" />
+</root>
+</log4j:configuration>


### PR DESCRIPTION
A fluent-bit server provides a [large list of log targets](https://docs.fluentbit.io/manual/pipeline/outputs).