### PR TITLE
ODBCAppender should not use the message as an SQL statement

### DIFF
--- a/src/main/cpp/odbcappender.cpp
+++ b/src/main/cpp/odbcappender.cpp
@@ -192,7 +192,7 @@ void ODBCAppender::setOption(const LogString& option, const LogString& value)
 
 bool ODBCAppender::requiresLayout() const
 {
-    return false;
+	return _priv->parameterValue.empty();
 }
 
 void ODBCAppender::activateOptions(log4cxx::helpers::Pool&)
@@ -248,7 +248,9 @@ void ODBCAppender::append(const spi::LoggingEventPtr& event, log4cxx::helpers::P
 
 LogString ODBCAppender::getLogStatement(const spi::LoggingEventPtr& event, log4cxx::helpers::Pool& p) const
 {
-    return event->getMessage();
+	LogString sbuf;
+	getLayout()->format(sbuf, event, p);
+	return sbuf;
 }
 
 void ODBCAppender::execute(const LogString& sql, log4cxx::helpers::Pool& p)
@@ -643,7 +645,23 @@ void ODBCAppender::flushBuffer(Pool& p)
 
 void ODBCAppender::setSql(const LogString& s)
 {
-    _priv->sqlStatement = s;
+	_priv->sqlStatement = s;
+
+	if (getLayout() == 0)
+	{
+		this->setLayout(std::make_shared<PatternLayout>(s));
+	}
+	else
+	{
+		PatternLayoutPtr patternLayout;
+		LayoutPtr asLayout = this->getLayout();
+		patternLayout = log4cxx::cast<PatternLayout>(asLayout);
+
+		if (patternLayout != 0)
+		{
+			patternLayout->setConversionPattern(s);
+		}
+	}
 }
 
 #if LOG4CXX_WCHAR_T_API || LOG4CXX_LOGCHAR_IS_WCHAR_T || defined(WIN32) || defined(_WIN32)

--- a/src/main/cpp/odbcappender.cpp
+++ b/src/main/cpp/odbcappender.cpp
@@ -249,7 +249,10 @@ void ODBCAppender::append(const spi::LoggingEventPtr& event, log4cxx::helpers::P
 LogString ODBCAppender::getLogStatement(const spi::LoggingEventPtr& event, log4cxx::helpers::Pool& p) const
 {
 	LogString sbuf;
-	getLayout()->format(sbuf, event, p);
+	if (auto l = getLayout())
+		l->format(sbuf, event, p);
+	else
+		LogLog::error(LOG4CXX_STR("A SQL statement must be provided to ODBCAppender"));
 	return sbuf;
 }
 


### PR DESCRIPTION
This PR restores the 1.0 functionality (restores compatability).

Commit 0be583c caused the ODBC appender to use the message as the SQL statement.