### PR TITLE
Fix deallocation bug in rolling policy base private.

### DIFF
--- a/src/main/include/log4cxx/private/rollingpolicybase_priv.h
+++ b/src/main/include/log4cxx/private/rollingpolicybase_priv.h
@@ -28,6 +28,8 @@ namespace log4cxx
 namespace rolling{
 
 struct RollingPolicyBase::RollingPolicyBasePrivate {
+    virtual ~RollingPolicyBasePrivate() = default;
+
     /**
      * File name pattern converters.
      */


### PR DESCRIPTION
This fixes a deallocation bug from the parent pointer.

Rolling policy base private needs a virtual destructor because the base pointer to this class is being used to destruct things.

An example of this is in fixedwindowrollingpolicy.cpp:16 where the FixedWindowRollingPolictyPrivate is being passed to RollingPolicyBase() which stores in m_priv which is RollingPolicyBasePrivate.

When this pointer deallocates it will have the wrong size.

To reproduce:
1) Compile log4cxx in debug. (cmake ../ -DCMAKE_BUILD_TYPE=DEBUG)
2) Compile bug.cpp with addresssantizer (g++ -g -fsanitize=address  bug.cpp)
3) Run bug.cpp with audit.properties

These files are in the test.zip.

You should see something similar to result.

[test.zip](https://github.com/apache/logging-log4cxx/files/11776735/test.zip)

--------------------

As an aside to this bug, if you remove line 24 of bug.cpp it will cause a segfault because it is using a file watcher which uses a static variable that gets deallocated on main exit and other threads are using it.

Specifically: loglog.cpp:59 will become deallocated.
And the filewatchdog.cpp:126 will call getInstance().

