### PR TITLE
jsonlayout, register the class in class.cpp

### DIFF
--- a/src/main/cpp/class.cpp
+++ b/src/main/cpp/class.cpp
@@ -46,6 +46,7 @@
 #include <log4cxx/net/xmlsocketappender.h>
 #include <log4cxx/layout.h>
 #include <log4cxx/patternlayout.h>
+#include <log4cxx/jsonlayout.h>
 #include <log4cxx/htmllayout.h>
 #include <log4cxx/simplelayout.h>
 #include <log4cxx/xml/xmllayout.h>
@@ -172,6 +173,7 @@ void Class::registerClasses()
 	log4cxx::nt::OutputDebugStringAppender::registerClass();
 #endif
 	SMTPAppender::registerClass();
+	JSONLayout::registerClass();
 	HTMLLayout::registerClass();
 	PatternLayout::registerClass();
 	SimpleLayout::registerClass();


### PR DESCRIPTION
Hi,
When linking statically with log4cxx, I got the issue:
```
log4cxx: Count not instantiate class [org.apache.log4j.JSONLayout]
log4cxx: Class not found: org.apache.log4j.JSONLayout
```

Registering the class solves the issue. I could not pinpoint on why the class was not present in the executable.