### PR TITLE
Prevent a segfault during process exit

### DIFF
--- a/src/main/cpp/loglog.cpp
+++ b/src/main/cpp/loglog.cpp
@@ -70,43 +70,51 @@ void LogLog::setInternalDebugging(bool debugEnabled1)
 
 void LogLog::debug(const LogString& msg)
 {
-	if (!getInstance().m_priv->debugEnabled)
+	if (auto p = getInstance().m_priv.get())
 	{
-		return;
+		if (!p->debugEnabled)
+		{
+			return;
+		}
+
+		std::unique_lock<std::mutex> lock(p->mutex);
+
+		emit(msg);
 	}
-
-	std::unique_lock<std::mutex> lock(getInstance().m_priv->mutex);
-
-	emit(msg);
 }
 
 void LogLog::debug(const LogString& msg, const std::exception& e)
 {
-	if (!getInstance().m_priv->debugEnabled)
+	if (auto p = getInstance().m_priv.get())
 	{
-		return;
+		if (!p->debugEnabled)
+			return;
+
+		std::unique_lock<std::mutex> lock(p->mutex);
+		emit(msg);
+		emit(e);
 	}
-
-	std::unique_lock<std::mutex> lock(getInstance().m_priv->mutex);
-
-	emit(msg);
-	emit(e);
 }
 
 
 void LogLog::error(const LogString& msg)
 {
-	std::unique_lock<std::mutex> lock(getInstance().m_priv->mutex);
+	if (auto p = getInstance().m_priv.get())
+	{
+		std::unique_lock<std::mutex> lock(p->mutex);
 
-	emit(msg);
+		emit(msg);
+	}
 }
 
 void LogLog::error(const LogString& msg, const std::exception& e)
 {
-	std::unique_lock<std::mutex> lock(getInstance().m_priv->mutex);
-
-	emit(msg);
-	emit(e);
+	if (auto p = getInstance().m_priv.get())
+	{
+		std::unique_lock<std::mutex> lock(p->mutex);
+		emit(msg);
+		emit(e);
+	}
 }
 
 void LogLog::setQuietMode(bool quietMode1)
@@ -118,17 +126,21 @@ void LogLog::setQuietMode(bool quietMode1)
 
 void LogLog::warn(const LogString& msg)
 {
-	std::unique_lock<std::mutex> lock(getInstance().m_priv->mutex);
-
-	emit(msg);
+	if (auto p = getInstance().m_priv.get())
+	{
+		std::unique_lock<std::mutex> lock(p->mutex);
+		emit(msg);
+	}
 }
 
 void LogLog::warn(const LogString& msg, const std::exception& e)
 {
-	std::unique_lock<std::mutex> lock(getInstance().m_priv->mutex);
-
-	emit(msg);
-	emit(e);
+	if (auto p = getInstance().m_priv.get())
+	{
+		std::unique_lock<std::mutex> lock(p->mutex);
+		emit(msg);
+		emit(e);
+	}
 }
 
 void LogLog::emit(const LogString& msg)

--- a/src/main/cpp/loglog.cpp
+++ b/src/main/cpp/loglog.cpp
@@ -70,7 +70,7 @@ void LogLog::setInternalDebugging(bool debugEnabled1)
 
 void LogLog::debug(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get())
+	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
 	{
 		if (!p->debugEnabled)
 		{
@@ -85,7 +85,7 @@ void LogLog::debug(const LogString& msg)
 
 void LogLog::debug(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get())
+	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
 	{
 		if (!p->debugEnabled)
 			return;
@@ -99,7 +99,7 @@ void LogLog::debug(const LogString& msg, const std::exception& e)
 
 void LogLog::error(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get())
+	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 
@@ -109,7 +109,7 @@ void LogLog::error(const LogString& msg)
 
 void LogLog::error(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get())
+	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);
@@ -126,7 +126,7 @@ void LogLog::setQuietMode(bool quietMode1)
 
 void LogLog::warn(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get())
+	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);
@@ -135,7 +135,7 @@ void LogLog::warn(const LogString& msg)
 
 void LogLog::warn(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get())
+	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);

--- a/src/main/cpp/loglog.cpp
+++ b/src/main/cpp/loglog.cpp
@@ -70,7 +70,7 @@ void LogLog::setInternalDebugging(bool debugEnabled1)
 
 void LogLog::debug(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
+	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
 	{
 		if (!p->debugEnabled)
 		{
@@ -85,7 +85,7 @@ void LogLog::debug(const LogString& msg)
 
 void LogLog::debug(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
+	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
 	{
 		if (!p->debugEnabled)
 			return;
@@ -99,7 +99,7 @@ void LogLog::debug(const LogString& msg, const std::exception& e)
 
 void LogLog::error(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
+	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 
@@ -109,7 +109,7 @@ void LogLog::error(const LogString& msg)
 
 void LogLog::error(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
+	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);
@@ -126,7 +126,7 @@ void LogLog::setQuietMode(bool quietMode1)
 
 void LogLog::warn(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
+	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);
@@ -135,7 +135,7 @@ void LogLog::warn(const LogString& msg)
 
 void LogLog::warn(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in some other thread?
+	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);

--- a/src/main/cpp/loglog.cpp
+++ b/src/main/cpp/loglog.cpp
@@ -70,7 +70,7 @@ void LogLog::setInternalDebugging(bool debugEnabled1)
 
 void LogLog::debug(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
+	if (auto p = getInstance().m_priv.get()) // Not deleted by onexit processing?
 	{
 		if (!p->debugEnabled)
 		{
@@ -85,7 +85,7 @@ void LogLog::debug(const LogString& msg)
 
 void LogLog::debug(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
+	if (auto p = getInstance().m_priv.get()) // Not deleted by onexit processing?
 	{
 		if (!p->debugEnabled)
 			return;
@@ -99,7 +99,7 @@ void LogLog::debug(const LogString& msg, const std::exception& e)
 
 void LogLog::error(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
+	if (auto p = getInstance().m_priv.get()) // Not deleted by onexit processing?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 
@@ -109,7 +109,7 @@ void LogLog::error(const LogString& msg)
 
 void LogLog::error(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
+	if (auto p = getInstance().m_priv.get()) // Not deleted by onexit processing?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);
@@ -126,7 +126,7 @@ void LogLog::setQuietMode(bool quietMode1)
 
 void LogLog::warn(const LogString& msg)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
+	if (auto p = getInstance().m_priv.get()) // Not deleted by onexit processing?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);
@@ -135,7 +135,7 @@ void LogLog::warn(const LogString& msg)
 
 void LogLog::warn(const LogString& msg, const std::exception& e)
 {
-	if (auto p = getInstance().m_priv.get()) // Not deleted in the onexit procesing?
+	if (auto p = getInstance().m_priv.get()) // Not deleted by onexit processing?
 	{
 		std::unique_lock<std::mutex> lock(p->mutex);
 		emit(msg);


### PR DESCRIPTION
Some background threads call LogLog::debug on exit which can be after the static LogLogPrivate pointer is zeroed by the onexit processing chain.