### PR TITLE
Add a date generated to documentation web pages

### DIFF
--- a/src/site/doxy/footer.html
+++ b/src/site/doxy/footer.html
@@ -6,7 +6,7 @@
     $navpath
     <li class="footer">$generatedby
     <a href="http://www.doxygen.org/index.html">
-    <img class="footer" src="$relpath^doxygen.png" alt="doxygen"/></a> $doxygenversion </li>
+    <img class="footer" src="https://www.doxygen.nl/images/doxygen.png" alt="Doxygen"/></a> $doxygenversion on $date </li>
     <li class="center">
 Copyright &copy; 2003-2023 <a href="https://www.apache.org/">Apache Software Foundation</a>. All Rights Reserved.  <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a><br/>
 Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, and the Apache Logging project logo are trademarks of The Apache Software Foundation.<br/>
@@ -14,12 +14,5 @@ Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, and the Ap
   </ul>
 </div>
 <!--END GENERATE_TREEVIEW-->
-<!--BEGIN !GENERATE_TREEVIEW-->
-<hr class="footer"/><address class="footer"><small>
-$generatedby &#160;<a href="http://www.doxygen.org/index.html">
-<img class="footer" src="$relpath^doxygen.png" alt="doxygen"/>
-</a> $doxygenversion
-</small></address>
-<!--END !GENERATE_TREEVIEW-->
 </body>
 </html>


### PR DESCRIPTION
The footer will now look like:
![footer](https://github.com/apache/logging-log4cxx/assets/13777035/c3a0e113-01b9-4769-847a-65b23050fdad)
