### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/src/cmake/projectVersionDetails.cmake
+++ b/src/cmake/projectVersionDetails.cmake
@@ -2,5 +2,5 @@
 # setting the project version. The variable name must not
 # clash with the log4cxx_VERSION* variables automatically
 # defined by the project() command.
-set(log4cxx_VER 1.1.0.0)
+set(log4cxx_VER 1.2.0.0)
 set(log4cxx_ABI_VER 15)


### PR DESCRIPTION
I suggest the next version will require a bump of the minor number (not the patch number).