### PR TITLE
Reduce logging overhead when the output is unchanged by encoding

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -48,6 +48,7 @@ if(LOG4CXX_NETWORKING_SUPPORT)
 endif()
 
 if(LOG4CXX_MULTIPROCESS_ROLLING_FILE_APPENDER)
+    target_compile_definitions(log4cxx PRIVATE LOG4CXX_MULTI_PROCESS)
     list(APPEND extra_classes
 	multiprocessrollingfileappender.cpp
 	)

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -646,7 +646,7 @@ void CharsetEncoder::encode(CharsetEncoderPtr& enc,
 	}
 }
 
-bool CharsetEncoder::isTriviallyCopyable(const LogString& src, CharsetEncoderPtr& enc)
+bool CharsetEncoder::isTriviallyCopyable(const LogString& src, const CharsetEncoderPtr& enc)
 {
 	bool result = false;
 	if (dynamic_cast<LocaleCharsetEncoder*>(enc.get()))

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -644,3 +644,18 @@ void CharsetEncoder::encode(CharsetEncoderPtr& enc,
 		dst.put(Transcoder::LOSSCHAR);
 	}
 }
+
+bool CharsetEncoder::isTriviallyCopyable(const LogString& src, CharsetEncoderPtr& enc)
+{
+	bool result = false;
+	if (dynamic_cast<LocaleCharsetEncoder*>(enc.get()))
+	{
+		result = src.end() == std::find_if(src.begin(), src.end()
+			, [](const logchar& ch) -> bool { return 0x80 <= (unsigned int)ch; });
+	}
+#if LOG4CXX_LOGCHAR_IS_UTF8
+	else
+		result = !!dynamic_cast<TrivialCharsetEncoder*>(enc.get());
+#endif
+	return result;
+}

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -648,15 +648,13 @@ void CharsetEncoder::encode(CharsetEncoderPtr& enc,
 
 bool CharsetEncoder::isTriviallyCopyable(const LogString& src, const CharsetEncoderPtr& enc)
 {
-	bool result = false;
+	bool result;
 	if (dynamic_cast<LocaleCharsetEncoder*>(enc.get()))
 	{
 		result = src.end() == std::find_if(src.begin(), src.end()
 			, [](const logchar& ch) -> bool { return 0x80 <= (unsigned int)ch; });
 	}
-#if LOG4CXX_LOGCHAR_IS_UTF8
 	else
 		result = !!dynamic_cast<TrivialCharsetEncoder*>(enc.get());
-#endif
 	return result;
 }

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -21,6 +21,7 @@
 #include <apr_xlate.h>
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/transcoder.h>
+#include <algorithm>
 
 #if !defined(LOG4CXX)
 	#define LOG4CXX 1

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -649,12 +649,14 @@ void CharsetEncoder::encode(CharsetEncoderPtr& enc,
 bool CharsetEncoder::isTriviallyCopyable(const LogString& src, const CharsetEncoderPtr& enc)
 {
 	bool result;
+#if !LOG4CXX_CHARSET_EBCDIC
 	if (dynamic_cast<LocaleCharsetEncoder*>(enc.get()))
 	{
 		result = src.end() == std::find_if(src.begin(), src.end()
 			, [](const logchar& ch) -> bool { return 0x80 <= (unsigned int)ch; });
 	}
 	else
+#endif
 		result = !!dynamic_cast<TrivialCharsetEncoder*>(enc.get());
 	return result;
 }

--- a/src/main/cpp/outputstreamwriter.cpp
+++ b/src/main/cpp/outputstreamwriter.cpp
@@ -96,7 +96,7 @@ void OutputStreamWriter::write(const LogString& str, Pool& p)
 		// Ensure the logging event is a single write system call to keep events from each process separate
 		if (bufSize < str.length() * 2)
 		{
-			heapData.resize(bufSize = str.length() * 2)
+			heapData.resize(bufSize = str.length() * 2);
 			rawbuf = heapData.data();
 		}
 #endif

--- a/src/main/cpp/outputstreamwriter.cpp
+++ b/src/main/cpp/outputstreamwriter.cpp
@@ -78,18 +78,29 @@ void OutputStreamWriter::flush(Pool& p)
 
 void OutputStreamWriter::write(const LogString& str, Pool& p)
 {
-	if (str.length() > 0)
+	if (str.empty())
+		return;
+	if (CharsetEncoder::isTriviallyCopyable(str, m_priv->enc))
 	{
-#ifdef LOG4CXX_MULTI_PROCESS
-		// Ensure the logging event is a single write system call to keep events from each process separate
-		size_t bufSize = str.length() * 2;
-		char* rawbuf = new char[bufSize];
-		ByteBuffer buf(rawbuf, (size_t) bufSize);
-#else
+		ByteBuffer buf((char*)str.data(), str.size() * sizeof (logchar));
+		m_priv->out->write(buf, p);
+	}
+	else
+	{
 		enum { BUFSIZE = 1024 };
-		char rawbuf[BUFSIZE];
-		ByteBuffer buf(rawbuf, (size_t) BUFSIZE);
+		char stackData[BUFSIZE];
+		char* rawbuf = stackData;
+		size_t bufSize = BUFSIZE;
+#ifdef LOG4CXX_MULTI_PROCESS
+		std::vector<char> heapData;
+		// Ensure the logging event is a single write system call to keep events from each process separate
+		if (bufSize < str.length() * 2)
+		{
+			heapData.resize(bufSize = str.length() * 2)
+			rawbuf = heapData.data();
+		}
 #endif
+		ByteBuffer buf(rawbuf, bufSize);
 		m_priv->enc->reset();
 		LogString::const_iterator iter = str.begin();
 
@@ -105,9 +116,6 @@ void OutputStreamWriter::write(const LogString& str, Pool& p)
 		m_priv->enc->flush(buf);
 		buf.flip();
 		m_priv->out->write(buf, p);
-#ifdef LOG4CXX_MULTI_PROCESS
-		delete []rawbuf;
-#endif
 	}
 }
 

--- a/src/main/include/log4cxx/helpers/charsetencoder.h
+++ b/src/main/include/log4cxx/helpers/charsetencoder.h
@@ -116,6 +116,12 @@ class LOG4CXX_EXPORT CharsetEncoder : public Object
 			return (stat != 0);
 		}
 
+		/**
+		* Is the data of \c src unchanged by \c enc.
+		*
+		*/
+		static bool isTriviallyCopyable(const LogString& src, CharsetEncoderPtr& enc);
+
 
 	private:
 		/**

--- a/src/main/include/log4cxx/helpers/charsetencoder.h
+++ b/src/main/include/log4cxx/helpers/charsetencoder.h
@@ -120,7 +120,7 @@ class LOG4CXX_EXPORT CharsetEncoder : public Object
 		* Is the data of \c src unchanged by \c enc.
 		*
 		*/
-		static bool isTriviallyCopyable(const LogString& src, CharsetEncoderPtr& enc);
+		static bool isTriviallyCopyable(const LogString& src, const CharsetEncoderPtr& enc);
 
 
 	private:


### PR DESCRIPTION
Also reduce logging overhead when LOG4CXX_MULTI_PROCESS is enabled.