### PR TITLE
Prevent a deadlock when LOG4CXX_CHAR=utf-8 and LOG4CXX_CHARSET=EBCDIC

### DIFF
--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -466,8 +466,7 @@ class LocaleCharsetDecoder : public CharsetDecoder
 
 						try
 						{
-							LogString e;
-							Transcoder::decode(encoding, e);
+							LOG4CXX_DECODE_CHAR(e, encoding);
 							decoder = getDecoder(e);
 						}
 						catch (IllegalArgumentException&)

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -494,8 +494,7 @@ class LocaleCharsetEncoder : public CharsetEncoder
 					else if (encoding != enc)
 					{
 						encoding = enc;
-						LogString ename;
-						Transcoder::decode(encoding, ename);
+						LOG4CXX_DECODE_CHAR(ename, encoding);
 
 						try
 						{

--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -29,8 +29,7 @@ using namespace log4cxx::helpers;
 
 Exception::Exception(const LogString& msg1)
 {
-	std::string m;
-	Transcoder::encode(msg1, m);
+	LOG4CXX_ENCODE_CHAR(m, msg1);
 	size_t len = m.size();
 
 	if (len > MSG_SIZE)


### PR DESCRIPTION
LOG4CXX_ENCODE_CHAR is a string  assignment when LOG4CXX_CHAR=utf-8 (avoiding the recursive call when getDecoder() throws)