### PR TITLE
Implement a functional 'locale' character encoding

### DIFF
--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -418,8 +418,7 @@ class USASCIICharsetDecoder : public CharsetDecoder
 };
 
 /**
- *    Charset decoder that uses an embedded CharsetDecoder consistent
- *     with current locale settings.
+ *    Charset decoder that uses current locale settings.
  */
 class LocaleCharsetDecoder : public CharsetDecoder
 {
@@ -427,11 +426,7 @@ class LocaleCharsetDecoder : public CharsetDecoder
 		LocaleCharsetDecoder() : state()
 		{
 		}
-		virtual ~LocaleCharsetDecoder()
-		{
-		}
-		virtual log4cxx_status_t decode(ByteBuffer& in,
-			LogString& out)
+		log4cxx_status_t decode(ByteBuffer& in, LogString& out) override
 		{
 			log4cxx_status_t result = APR_SUCCESS;
 			const char* p = in.current();
@@ -447,7 +442,6 @@ class LocaleCharsetDecoder : public CharsetDecoder
 				}
 			}
 #endif
-
 			// Decode characters that may be represented by multiple bytes
 			while (0 < remain)
 			{

--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -438,7 +438,7 @@ class LocaleCharsetDecoder : public CharsetDecoder
 			size_t i = in.position();
 			size_t remain = in.limit() - i;
 #if !LOG4CXX_CHARSET_EBCDIC
-			if (std::mbsinit(&this->state))
+			if (std::mbsinit(&this->state)) // ByteBuffer not partially decoded?
 			{
 				// Copy single byte characters
 				for (; 0 < remain && ((unsigned int) *p) < 0x80; --remain, ++i, p++)
@@ -448,7 +448,7 @@ class LocaleCharsetDecoder : public CharsetDecoder
 			}
 #endif
 
-			// Decode characters that may be represented by multiple byts
+			// Decode characters that may be represented by multiple bytes
 			while (0 < remain)
 			{
 				wchar_t ch;

--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -197,9 +197,7 @@ class MbstowcsCharsetDecoder : public CharsetDecoder
 
 					if (converted == (size_t) -1) // Illegal byte sequence?
 					{
-						LogString msg(LOG4CXX_STR("Illegal byte sequence (["));
-						Transcoder::decode(src, msg);
-						msg.append(LOG4CXX_STR("]) at "));
+						LogString msg(LOG4CXX_STR("Illegal byte sequence at "));
 						StringHelper::toString(src - in.current(), msg);
 						msg.append(LOG4CXX_STR(" of "));
 						StringHelper::toString(in.limit(), msg);

--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -198,7 +198,7 @@ class MbstowcsCharsetDecoder : public CharsetDecoder
 					if (wCharCount == (size_t) -1) // Illegal byte sequence?
 					{
 						LogString msg(LOG4CXX_STR("Illegal byte sequence at "));
-						msg.append(std::to_wstring(src - in.current()));
+						msg.append(std::to_wstring(in.position()));
 						msg.append(LOG4CXX_STR(" of "));
 						msg.append(std::to_wstring(in.limit()));
 						LogLog::warn(msg);

--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -197,10 +197,11 @@ class MbstowcsCharsetDecoder : public CharsetDecoder
 
 					if (converted == (size_t) -1) // Illegal byte sequence?
 					{
+						Pool p;
 						LogString msg(LOG4CXX_STR("Illegal byte sequence at "));
-						StringHelper::toString(src - in.current(), msg);
+						StringHelper::toString(src - in.current(), p, msg);
 						msg.append(LOG4CXX_STR(" of "));
-						StringHelper::toString(in.limit(), msg);
+						StringHelper::toString(in.limit(), p, msg);
 						LogLog::warn(msg);
 						stat = APR_BADCH;
 						in.position(src - in.data());

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -446,8 +446,7 @@ class UTF16LECharsetEncoder : public CharsetEncoder
 };
 
 /**
- *    Charset encoder that uses an embedded CharsetEncoder consistent
- *     with current locale settings.
+ *    Charset encoder that uses current locale settings.
  */
 class LocaleCharsetEncoder : public CharsetEncoder
 {
@@ -455,12 +454,11 @@ class LocaleCharsetEncoder : public CharsetEncoder
 		LocaleCharsetEncoder() : state()
 		{
 		}
-		virtual ~LocaleCharsetEncoder()
-		{
-		}
-		virtual log4cxx_status_t encode(const LogString& in,
-			LogString::const_iterator& iter,
-			ByteBuffer& out)
+		log4cxx_status_t encode
+			( const LogString&           in
+			, LogString::const_iterator& iter
+			, ByteBuffer&                out
+			) override
 		{
 			log4cxx_status_t result = APR_SUCCESS;
 #if !LOG4CXX_CHARSET_EBCDIC
@@ -495,8 +493,6 @@ class LocaleCharsetEncoder : public CharsetEncoder
 		}
 
 	private:
-		LocaleCharsetEncoder(const LocaleCharsetEncoder&);
-		LocaleCharsetEncoder& operator=(const LocaleCharsetEncoder&);
 		std::mbstate_t state;
 };
 

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -462,6 +462,7 @@ class LocaleCharsetEncoder : public CharsetEncoder
 			LogString::const_iterator& iter,
 			ByteBuffer& out)
 		{
+			log4cxx_status_t result = APR_SUCCESS;
 #if !LOG4CXX_CHARSET_EBCDIC
 			char* current = out.current();
 			size_t remain = out.remaining();
@@ -478,38 +479,23 @@ class LocaleCharsetEncoder : public CharsetEncoder
 
 			if (iter != in.end() && out.remaining() > 0)
 			{
-				Pool subpool;
-				const char* enc = apr_os_locale_encoding(subpool.getAPRPool());
+				std::mbstate_t state = {};
+				while (iter != in.end() && MB_CUR_MAX <= remain)
 				{
-					std::unique_lock<std::mutex> lock(mutex);
-
-					if (enc == 0)
+					auto ch = Transcoder::decode(in, iter);
+					auto n = std::wcrtomb(current, ch, &state);
+					if (static_cast<std::size_t>(-1) == n)
 					{
-						if (encoder == 0)
-						{
-							encoding = "C";
-							encoder.reset( new USASCIICharsetEncoder() );
-						}
+						result = APR_BADARG;
+						break;
 					}
-					else if (encoding != enc)
-					{
-						encoding = enc;
-						LOG4CXX_DECODE_CHAR(ename, encoding);
-
-						try
-						{
-							encoder = CharsetEncoder::getEncoder(ename);
-						}
-						catch (IllegalArgumentException&)
-						{
-							encoder.reset( new USASCIICharsetEncoder() );
-						}
-					}
+					remain -= n;
+					current += n;
 				}
-				return encoder->encode(in, iter, out);
+				out.position(current - out.data());
 			}
 
-			return APR_SUCCESS;
+			return result;
 		}
 
 	private:
@@ -578,7 +564,8 @@ CharsetEncoderPtr CharsetEncoder::getUTF8Encoder()
 
 CharsetEncoderPtr CharsetEncoder::getEncoder(const LogString& charset)
 {
-	if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-8"), LOG4CXX_STR("utf-8")))
+	if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-8"), LOG4CXX_STR("utf-8"))
+		|| StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("CP65001"), LOG4CXX_STR("cp65001")))
 	{
 		return std::make_shared<UTF8CharsetEncoder>();
 	}
@@ -586,23 +573,30 @@ CharsetEncoderPtr CharsetEncoder::getEncoder(const LogString& charset)
 		charset == LOG4CXX_STR("646") ||
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("US-ASCII"), LOG4CXX_STR("us-ascii")) ||
 		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO646-US"), LOG4CXX_STR("iso646-US")) ||
-		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ANSI_X3.4-1968"), LOG4CXX_STR("ansi_x3.4-1968")))
+		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ANSI_X3.4-1968"), LOG4CXX_STR("ansi_x3.4-1968")) ||
+		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("CP20127"), LOG4CXX_STR("cp20127")))
 	{
 		return std::make_shared<USASCIICharsetEncoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO-8859-1"), LOG4CXX_STR("iso-8859-1")) ||
-		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO-LATIN-1"), LOG4CXX_STR("iso-latin-1")))
+		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("ISO-LATIN-1"), LOG4CXX_STR("iso-latin-1")) ||
+		StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("CP1252"), LOG4CXX_STR("cp1252")))
 	{
 		return std::make_shared<ISOLatinCharsetEncoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-16BE"), LOG4CXX_STR("utf-16be"))
-		|| StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-16"), LOG4CXX_STR("utf-16")))
+		|| StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-16"), LOG4CXX_STR("utf-16"))
+		|| StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("CP1200"), LOG4CXX_STR("cp1200")))
 	{
 		return std::make_shared<UTF16BECharsetEncoder>();
 	}
 	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("UTF-16LE"), LOG4CXX_STR("utf-16le")))
 	{
 		return std::make_shared<UTF16LECharsetEncoder>();
+	}
+	else if (StringHelper::equalsIgnoreCase(charset, LOG4CXX_STR("LOCALE"), LOG4CXX_STR("locale")))
+	{
+		return std::make_shared<LocaleCharsetEncoder>();
 	}
 
 #if APR_HAS_XLATE

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -466,7 +466,7 @@ class LocaleCharsetEncoder : public CharsetEncoder
 #if !LOG4CXX_CHARSET_EBCDIC
 			char* current = out.current();
 			size_t remain = out.remaining();
-			if (std::mbsinit(&this->state))
+			if (std::mbsinit(&this->state)) // ByteBuffer not partially encoded?
 			{
 				// Copy single byte characters
 				for (;
@@ -477,7 +477,7 @@ class LocaleCharsetEncoder : public CharsetEncoder
 				}
 			}
 #endif
-			// Encode characters that may require multiple byts
+			// Encode characters that may require multiple bytes
 			while (iter != in.end() && MB_CUR_MAX <= remain)
 			{
 				auto ch = Transcoder::decode(in, iter);

--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -172,7 +172,7 @@ IOException& IOException::operator=(const IOException& src)
 
 LogString IOException::formatMessage(log4cxx_status_t stat)
 {
-	char err_buff[32];
+	char err_buff[1024];
 	LogString s(LOG4CXX_STR("IO Exception : status code = "));
 	Pool p;
 	StringHelper::toString(stat, p, s);

--- a/src/test/cpp/decodingtest.cpp
+++ b/src/test/cpp/decodingtest.cpp
@@ -139,7 +139,7 @@ public:
 
 		try
 		{
-			std::locale::global(std::locale("utf-16"));
+			std::locale::global(std::locale("en_US.UTF-16"));
 			testImpl(LOG4CXX_STR("UTF-16.txt"), witness);
 		}
 		catch (std::runtime_error& ex)
@@ -147,7 +147,7 @@ public:
 			LogString msg;
 			Transcoder::decode(ex.what(), msg);
 			msg.append(LOG4CXX_STR(": "));
-			msg.append(LOG4CXX_STR("utf-16"));
+			msg.append(LOG4CXX_STR("en_US.UTF-16"));
 			LogLog::warn(msg);
 		}
 	}
@@ -160,7 +160,7 @@ public:
 		const wchar_t witness[] = { L'A', 0x0605, 0x0530, 0x986, 0x4E03, 0x0400, 0x0020, 0x00B9, 0 };
 		try
 		{
-			std::locale::global(std::locale("UTF-16BE"));
+			std::locale::global(std::locale("en_US.UTF-16BE"));
 			testImpl(LOG4CXX_STR("UTF-16BE.txt"), witness);
 		}
 		catch (std::runtime_error& ex)
@@ -168,7 +168,7 @@ public:
 			LogString msg;
 			Transcoder::decode(ex.what(), msg);
 			msg.append(LOG4CXX_STR(": "));
-			msg.append(LOG4CXX_STR("UTF-16BE"));
+			msg.append(LOG4CXX_STR("en_US.UTF-16BE"));
 			LogLog::warn(msg);
 		}
 	}
@@ -181,7 +181,7 @@ public:
 		const wchar_t witness[] = { L'A', 0x0605, 0x0530, 0x986, 0x4E03, 0x0400, 0x0020, 0x00B9, 0 };
 		try
 		{
-			std::locale::global(std::locale("UTF-16LE"));
+			std::locale::global(std::locale("en_US.UTF-16LE"));
 			testImpl(LOG4CXX_STR("UTF-16LE.txt"), witness);
 		}
 		catch (std::exception& ex)
@@ -189,7 +189,7 @@ public:
 			LogString msg;
 			Transcoder::decode(ex.what(), msg);
 			msg.append(LOG4CXX_STR(": "));
-			msg.append(LOG4CXX_STR("UTF-16LE"));
+			msg.append(LOG4CXX_STR("en_US.UTF-16LE"));
 			LogLog::warn(msg);
 		}
 	}

--- a/src/test/cpp/decodingtest.cpp
+++ b/src/test/cpp/decodingtest.cpp
@@ -27,6 +27,10 @@
 #include <log4cxx/logstring.h>
 
 #include "logunit.h"
+
+#define LOG4CXX_TEST 1
+#include <log4cxx/private/log4cxx_private.h>
+
 //
 // If there is no support for wchar_t logging then
 // there is not a consistent way to get the test characters compared.

--- a/src/test/cpp/decodingtest.cpp
+++ b/src/test/cpp/decodingtest.cpp
@@ -66,6 +66,7 @@ LOGUNIT_CLASS(DecodingTest)
 #elif LOG4CXX_CHARSET_UTF8
 	LOGUNIT_TEST(testUtf8);
 #elif LOG4CXX_LOGCHAR_IS_WCHAR && LOG4CXX_HAS_MBSRTOWCS
+	LOGUNIT_TEST(testUtf8_to_wchar);
 	LOGUNIT_TEST(testUtf16);
 	LOGUNIT_TEST(testUtf16LE);
 	LOGUNIT_TEST(testUtf16BE);
@@ -105,6 +106,28 @@ public:
 		const wchar_t witness[] = { L'A', 0x0605, 0x0530, 0x986, 0x4E03, 0x0400, 0x0020, 0x00B9, 0 };
 
 		testImpl(LOG4CXX_STR("UTF-8.txt"), witness);
+	}
+
+	/**
+	 * Test utf-8 decoding.
+	 */
+	void testUtf8_to_wchar()
+	{
+		const wchar_t witness[] = { L'A', 0x0605, 0x0530, 0x986, 0x4E03, 0x0400, 0x0020, 0x00B9, 0 };
+
+		try
+		{
+			std::locale::global(std::locale("en_US.UTF-8"));
+			testImpl(LOG4CXX_STR("UTF-8.txt"), witness);
+		}
+		catch (std::runtime_error& ex)
+		{
+			LogString msg;
+			Transcoder::decode(ex.what(), msg);
+			msg.append(LOG4CXX_STR(": "));
+			msg.append(LOG4CXX_STR("en_US.UTF-8"));
+			LogLog::warn(msg);
+		}
 	}
 
 	/**

--- a/src/test/cpp/decodingtest.cpp
+++ b/src/test/cpp/decodingtest.cpp
@@ -121,7 +121,8 @@ public:
 		}
 		catch (std::runtime_error& ex)
 		{
-			LOG4CXX_DECODE_CHAR(msg, ex.what());
+			LogString msg;
+			Transcoder::decode(ex.what(), msg);
 			msg.append(LOG4CXX_STR(": "));
 			msg.append(LOG4CXX_STR("utf-16"));
 			LogLog::warn(msg);
@@ -141,7 +142,8 @@ public:
 		}
 		catch (std::runtime_error& ex)
 		{
-			LOG4CXX_DECODE_CHAR(msg, ex.what());
+			LogString msg;
+			Transcoder::decode(ex.what(), msg);
 			msg.append(LOG4CXX_STR(": "));
 			msg.append(LOG4CXX_STR("UTF-16BE"));
 			LogLog::warn(msg);
@@ -161,7 +163,8 @@ public:
 		}
 		catch (std::exception& ex)
 		{
-			LOG4CXX_DECODE_CHAR(msg, ex.what());
+			LogString msg;
+			Transcoder::decode(ex.what(), msg);
 			msg.append(LOG4CXX_STR(": "));
 			msg.append(LOG4CXX_STR("UTF-16LE"));
 			LogLog::warn(msg);

--- a/src/test/cpp/decodingtest.cpp
+++ b/src/test/cpp/decodingtest.cpp
@@ -24,6 +24,7 @@
 #include <log4cxx/helpers/inputstreamreader.h>
 #include <log4cxx/helpers/pool.h>
 #include <log4cxx/helpers/transcoder.h>
+#include <log4cxx/helpers/loglog.h>
 #include <log4cxx/logstring.h>
 
 #include "logunit.h"
@@ -113,7 +114,18 @@ public:
 	{
 		const wchar_t witness[] = { L'A', 0x0605, 0x0530, 0x986, 0x4E03, 0x0400, 0x0020, 0x00B9, 0 };
 
-		testImpl(LOG4CXX_STR("UTF-16.txt"), witness);
+		try
+		{
+			std::locale::global(std::locale("utf-16"));
+			testImpl(LOG4CXX_STR("UTF-16.txt"), witness);
+		}
+		catch (std::runtime_error& ex)
+		{
+			LOG4CXX_DECODE_CHAR(msg, ex.what());
+			msg.append(LOG4CXX_STR(": "));
+			msg.append(LOG4CXX_STR("utf-16"));
+			LogLog::warn(msg);
+		}
 	}
 
 	/**
@@ -122,8 +134,18 @@ public:
 	void testUtf16BE()
 	{
 		const wchar_t witness[] = { L'A', 0x0605, 0x0530, 0x986, 0x4E03, 0x0400, 0x0020, 0x00B9, 0 };
-
-		testImpl(LOG4CXX_STR("UTF-16BE.txt"), witness);
+		try
+		{
+			std::locale::global(std::locale("UTF-16BE"));
+			testImpl(LOG4CXX_STR("UTF-16BE.txt"), witness);
+		}
+		catch (std::runtime_error& ex)
+		{
+			LOG4CXX_DECODE_CHAR(msg, ex.what());
+			msg.append(LOG4CXX_STR(": "));
+			msg.append(LOG4CXX_STR("UTF-16BE"));
+			LogLog::warn(msg);
+		}
 	}
 
 	/**
@@ -132,8 +154,18 @@ public:
 	void testUtf16LE()
 	{
 		const wchar_t witness[] = { L'A', 0x0605, 0x0530, 0x986, 0x4E03, 0x0400, 0x0020, 0x00B9, 0 };
-
-		testImpl(LOG4CXX_STR("UTF-16LE.txt"), witness);
+		try
+		{
+			std::locale::global(std::locale("UTF-16LE"));
+			testImpl(LOG4CXX_STR("UTF-16LE.txt"), witness);
+		}
+		catch (std::exception& ex)
+		{
+			LOG4CXX_DECODE_CHAR(msg, ex.what());
+			msg.append(LOG4CXX_STR(": "));
+			msg.append(LOG4CXX_STR("UTF-16LE"));
+			LogLog::warn(msg);
+		}
 	}
 
 private:

--- a/src/test/cpp/helpers/charsetdecodertestcase.cpp
+++ b/src/test/cpp/helpers/charsetdecodertestcase.cpp
@@ -34,7 +34,8 @@ LOGUNIT_CLASS(CharsetDecoderTestCase)
 	LOGUNIT_TEST_SUITE(CharsetDecoderTestCase);
 	LOGUNIT_TEST(decode1);
 	LOGUNIT_TEST(decode2);
-	LOGUNIT_TEST(decode8);
+	LOGUNIT_TEST(decode3);
+	LOGUNIT_TEST(decode4);
 	LOGUNIT_TEST_SUITE_END();
 
 	enum { BUFSIZE = 256 };
@@ -83,9 +84,7 @@ public:
 		LOGUNIT_ASSERT_EQUAL(LogString(LOG4CXX_STR("Hello")), greeting.substr(BUFSIZE - 3));
 	}
 
-
-
-	void decode8()
+	void decode3()
 	{
 		char buf[] = { 'H', 'e', 'l', 'l', 'o', ',', 0, 'W', 'o', 'r', 'l', 'd'};
 		ByteBuffer src(buf, 12);
@@ -103,6 +102,37 @@ public:
 		LOGUNIT_ASSERT_EQUAL(LogString(expected, 12), greeting);
 	}
 
+	void decode4()
+	{
+		char utf8_greet[] = { 'A',
+				(char) 0xD8, (char) 0x85,
+				(char) 0xD4, (char) 0xB0,
+				(char) 0xE0, (char) 0xA6, (char) 0x86,
+				(char) 0xE4, (char) 0xB8, (char) 0x83,
+				(char) 0xD0, (char) 0x80,
+				0
+			};
+#if LOG4CXX_LOGCHAR_IS_WCHAR || LOG4CXX_LOGCHAR_IS_UNICHAR
+		//   arbitrary, hopefully meaningless, characters from
+		//     Latin, Arabic, Armenian, Bengali, CJK and Cyrillic
+		const logchar greet[] = { L'A', 0x0605, 0x0530, 0x986, 0x4E03, 0x400, 0 };
+#endif
+
+#if LOG4CXX_LOGCHAR_IS_UTF8
+		const logchar* greet = utf8_greet;
+#endif
+
+		std::locale::global(std::locale("en_US.UTF-8"));
+		auto dec = CharsetDecoder::getDecoder(LOG4CXX_STR("locale"));
+
+		ByteBuffer in(utf8_greet, sizeof (utf8_greet));
+		LogString out;
+		log4cxx_status_t stat = dec->decode(in, out);
+		LOGUNIT_ASSERT_EQUAL(false, CharsetDecoder::isError(stat));
+		stat = dec->decode(in, out);
+		LOGUNIT_ASSERT_EQUAL(false, CharsetDecoder::isError(stat));
+		LOGUNIT_ASSERT(out == greet);
+	}
 
 
 };


### PR DESCRIPTION
This PR allows the external (file) encoding to be controlled using `std::locale::global(std::locale("XXXXXXXXX"))`