### PR TITLE
Revert to console output when configuration file is missing in examples

### DIFF
--- a/src/examples/cpp/com/foo/config-qt.cpp
+++ b/src/examples/cpp/com/foo/config-qt.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "config-qt.h"
+#include <log4cxx/basicconfigurator.h>
 #include <log4cxx/logmanager.h>
 #include <log4cxx-qt/configuration.h>
 #include <log4cxx/helpers/loglog.h>
@@ -51,7 +52,8 @@ void ConfigureLogging() {
 #if defined(_DEBUG)
 	log4cxx::helpers::LogLog::setInternalDebugging(true);
 #endif
-	log4cxx::qt::Configuration::configureFromFileAndWatch(paths, names);
+	if (log4cxx::qt::Configuration::configureFromFileAndWatch(paths, names) == log4cxx::spi::ConfigurationStatus::NotConfigured)
+		log4cxx::BasicConfigurator::configure(); // Send events to the console
 }
 
 // Retrieve the \c name logger pointer.

--- a/src/examples/cpp/com/foo/config-qt.cpp
+++ b/src/examples/cpp/com/foo/config-qt.cpp
@@ -52,7 +52,10 @@ void ConfigureLogging() {
 #if defined(_DEBUG)
 	log4cxx::helpers::LogLog::setInternalDebugging(true);
 #endif
-	if (log4cxx::qt::Configuration::configureFromFileAndWatch(paths, names) == log4cxx::spi::ConfigurationStatus::NotConfigured)
+	log4cxx::spi::ConfigurationStatus status = {};
+	QString selectedPath;
+	std::tie(status, selectedPath) = log4cxx::qt::Configuration::configureFromFileAndWatch(paths, names);
+	if (status == log4cxx::spi::ConfigurationStatus::NotConfigured)
 		log4cxx::BasicConfigurator::configure(); // Send events to the console
 }
 

--- a/src/examples/cpp/com/foo/config-qt.cpp
+++ b/src/examples/cpp/com/foo/config-qt.cpp
@@ -52,8 +52,8 @@ void ConfigureLogging() {
 #if defined(_DEBUG)
 	log4cxx::helpers::LogLog::setInternalDebugging(true);
 #endif
-	log4cxx::spi::ConfigurationStatus status = {};
-	QString selectedPath;
+	auto status       = log4cxx::spi::ConfigurationStatus::NotConfigured;
+	auto selectedPath = QString();
 	std::tie(status, selectedPath) = log4cxx::qt::Configuration::configureFromFileAndWatch(paths, names);
 	if (status == log4cxx::spi::ConfigurationStatus::NotConfigured)
 		log4cxx::BasicConfigurator::configure(); // Send events to the console

--- a/src/examples/cpp/com/foo/config2.cpp
+++ b/src/examples/cpp/com/foo/config2.cpp
@@ -1,4 +1,5 @@
 #include "com/foo/config.h"
+#include <log4cxx/basicconfigurator.h>
 #include <log4cxx/propertyconfigurator.h>
 #include <log4cxx/logmanager.h>
 
@@ -7,7 +8,8 @@ namespace com { namespace foo {
 auto getLogger(const std::string& name) -> LoggerPtr {
 	static struct log4cxx_initializer {
 		log4cxx_initializer() {
-			log4cxx::PropertyConfigurator::configure("MyApp.properties");
+			if (log4cxx::PropertyConfigurator::configure("MyApp.properties") == log4cxx::spi::ConfigurationStatus::NotConfigured)
+				log4cxx::BasicConfigurator::configure(); // Send events to the console
 		}
 		~log4cxx_initializer() {
 			log4cxx::LogManager::shutdown();

--- a/src/examples/cpp/com/foo/config3.cpp
+++ b/src/examples/cpp/com/foo/config3.cpp
@@ -17,6 +17,7 @@
 #include "config.h"
 #include <log4cxx/logmanager.h>
 #include <log4cxx/logstring.h>
+#include <log4cxx/basicconfigurator.h>
 #include <log4cxx/defaultconfigurator.h>
 #include <log4cxx/helpers/pool.h>
 #include <log4cxx/file.h>
@@ -136,8 +137,10 @@ void SelectConfigurationFile() {
 			}
 		}
 		if (extension[i]) // Found a configuration file?
-			break;
+			return;
 	}
+	// Configuration file not found - send events to the console
+	BasicConfigurator::configure();
 }
 
 } // namespace

--- a/src/main/include/log4cxx/basicconfigurator.h
+++ b/src/main/include/log4cxx/basicconfigurator.h
@@ -29,10 +29,11 @@ class Appender;
 typedef std::shared_ptr<Appender> AppenderPtr;
 
 /**
-Use this class to quickly configure the package.
-<p>For file based configuration see
-PropertyConfigurator. For XML based configuration see
-DOMConfigurator.
+Use BasicConfigurator (static) methods to configure Log4cxx
+when not using a configuration file.
+
+For <code>key=value</code> format configuration see PropertyConfigurator.
+For XML format configuration see xml::DOMConfigurator.
 */
 class LOG4CXX_EXPORT BasicConfigurator
 {


### PR DESCRIPTION
Sending logging events to the console seems to be more useful than seeing the message

> Please initialize the log4cxx system properly.

on the console.
