### PR TITLE
Fix broken links on the 'Introduction to Log4cxx' page

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -52,15 +52,17 @@ The configuration also allows you to control the destination of log messages.
 They can be sent to a file, a remote socket server, event loggers as well as the console,
 with support for directing particular messages to one or more destinations.
 
-More information on how to use Log4cxx can be found on the [usage] page.  For
-a more general overview of what logging is, the logging services committee
-has a [logging overview] page that explains more of what logging is and
+The [example programs page] will let you to quickly start using Log4cxx.
+The components of Log4cxx are described on the [concepts page].
+For a more general overview, the logging services committee
+provides a [logging overview page] that explains more of what logging is and
 when to use it.
 
 [Apache log4j]:https://logging.apache.org/log4j/2.x/
 [Apache Portable Runtime]:https://apr.apache.org/
 [Apache License]:https://www.apache.org/licenses/
-[usage]:usage.html
+[example programs page]:quick-start.html
+[concepts page]:concepts.html
 [Open Source Initiative]:https://opensource.org/
 [Performance]:performance.html
-[logging overview]:https://logging.apache.org/what-is-logging.html
+[logging overview page]:https://logging.apache.org/what-is-logging.html


### PR DESCRIPTION
The [updated web site](https://logging.staged.apache.org/log4cxx/latest_stable/usage-overview.html) is available for review.