### PR TITLE
Set the level of a logger only if it changes

### DIFF
--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -538,10 +538,13 @@ void Logger::setParent(LoggerPtr parentLogger)
 
 void Logger::setLevel(const LevelPtr level1)
 {
-	m_priv->level = level1;
-	updateThreshold();
-	if (auto rep = dynamic_cast<Hierarchy*>(getHierarchy()))
-		rep->updateChildren(this);
+	if (m_priv->level != level1)
+	{
+		m_priv->level = level1;
+		updateThreshold();
+		if (auto rep = dynamic_cast<Hierarchy*>(getHierarchy()))
+			rep->updateChildren(this);
+	}
 }
 
 void Logger::updateThreshold()


### PR DESCRIPTION
Hierarchy::resetConfiguration() loops over each logger and calls setLogger(0), which in turn will call Hierarchy::updateChildren() where again over each logger is looped. This leads to quadratic behavior.