### PR TITLE
Fix MSVC-2017 build for hexdump.cpp

### DIFF
--- a/src/main/cpp/hexdump.cpp
+++ b/src/main/cpp/hexdump.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <ios>
 #include <iomanip>
+#include <cctype>
 
 using namespace log4cxx;
 


### PR DESCRIPTION
MSVC 2017 produces an error
> hexdump.cpp(100): error C2039: isprint: is not a member of "std"