### PR TITLE
fix reuse of a per thread cached stream

### DIFF
--- a/src/main/cpp/messagebuffer.cpp
+++ b/src/main/cpp/messagebuffer.cpp
@@ -57,19 +57,12 @@ struct StringOrStream
 			thread_local static struct
 			{
 				std::basic_ostringstream<T> sStream;
-				std::locale locale = sStream.getloc();
-				std::streamsize precision = sStream.precision();
-				std::ios_base::fmtflags flags = sStream.flags();
-				T fill = sStream.fill();
-			} streamWithInitialState;
+				const std::basic_ostringstream<T> sPrototype;
+			} streamWithPrototype;
 
-			this->stream = &streamWithInitialState.sStream;
+			this->stream = &streamWithPrototype.sStream;
 			this->stream->clear();
-			if(streamWithInitialState.locale != this->stream->getloc())
-				this->stream->imbue(streamWithInitialState.locale);
-			this->stream->precision(streamWithInitialState.precision);
-			this->stream->setf(streamWithInitialState.flags, ~streamWithInitialState.flags);
-			this->stream->fill(streamWithInitialState.fill);
+			this->stream->copyfmt(streamWithPrototype.sPrototype);
 #else
 			this->stream = new std::basic_ostringstream<T>();
 #endif

--- a/src/main/cpp/messagebuffer.cpp
+++ b/src/main/cpp/messagebuffer.cpp
@@ -65,7 +65,8 @@ struct StringOrStream
 
 			this->stream = &streamWithInitialState.sStream;
 			this->stream->clear();
-			this->stream->imbue(streamWithInitialState.locale);
+			if(streamWithInitialState.locale != this->stream->getloc())
+				this->stream->imbue(streamWithInitialState.locale);
 			this->stream->precision(streamWithInitialState.precision);
 			this->stream->setf(streamWithInitialState.flags, ~streamWithInitialState.flags);
 			this->stream->fill(streamWithInitialState.fill);

--- a/src/main/cpp/messagebuffer.cpp
+++ b/src/main/cpp/messagebuffer.cpp
@@ -54,15 +54,14 @@ struct StringOrStream
 		if (!this->stream)
 		{
 #if LOG4CXX_HAS_THREAD_LOCAL
-			thread_local static struct
-			{
-				std::basic_ostringstream<T> sStream;
-				const std::basic_ostringstream<T> sPrototype;
-			} streamWithPrototype;
-
-			this->stream = &streamWithPrototype.sStream;
+			const static std::basic_ostringstream<T> initialState;
+			thread_local static std::basic_ostringstream<T> sStream;
+			this->stream = &sStream;
 			this->stream->clear();
-			this->stream->copyfmt(streamWithPrototype.sPrototype);
+			this->stream->precision(initialState.precision());
+			this->stream->width(initialState.width());
+			this->stream->setf(initialState.flags(), ~initialState.flags());
+			this->stream->fill(initialState.fill());
 #else
 			this->stream = new std::basic_ostringstream<T>();
 #endif

--- a/src/test/cpp/helpers/messagebuffertest.cpp
+++ b/src/test/cpp/helpers/messagebuffertest.cpp
@@ -21,6 +21,9 @@
 #include "../logunit.h"
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/loglog.h>
+#include <log4cxx/logger.h>
+#include <log4cxx/propertyconfigurator.h>
+#include "util/compare.h"
 
 #if LOG4CXX_CFSTRING_API
 	#include <CoreFoundation/CFString.h>
@@ -42,6 +45,7 @@ LOGUNIT_CLASS(MessageBufferTest)
 	LOGUNIT_TEST(testInsertNull);
 	LOGUNIT_TEST(testInsertInt);
 	LOGUNIT_TEST(testInsertManipulator);
+	LOGUNIT_TEST(testBaseChange);
 #if LOG4CXX_WCHAR_T_API
 	LOGUNIT_TEST(testInsertConstWStr);
 	LOGUNIT_TEST(testInsertWString);
@@ -134,6 +138,30 @@ public:
 		std::ostream& retval = buf << "pi=" << std::setprecision(4) << 3.1415926;
 		LOGUNIT_ASSERT_EQUAL(greeting, buf.str(retval));
 		LOGUNIT_ASSERT_EQUAL(true, buf.hasStream());
+	}
+
+	void testBaseChange()
+	{
+		LoggerPtr root;
+		LoggerPtr logger;
+
+		root = Logger::getRootLogger();
+		logger = Logger::getLogger(LOG4CXX_STR("java.org.apache.log4j.PatternLayoutTest"));
+
+		PropertyConfigurator::configure(LOG4CXX_FILE("input/messagebuffer1.properties"));
+
+		int num = 220;
+		LOG4CXX_INFO(logger, "number in hex: " << std::hex << num);
+		LOG4CXX_INFO(logger, "number in dec: " << num);
+
+		LOGUNIT_ASSERT(Compare::compare(LOG4CXX_STR("output/messagebuffer"), LOG4CXX_FILE("witness/messagebuffer.1")));
+
+		auto rep = root->getLoggerRepository();
+
+		if (rep)
+		{
+			rep->resetConfiguration();
+		}
 	}
 
 #if LOG4CXX_WCHAR_T_API

--- a/src/test/resources/input/messagebuffer1.properties
+++ b/src/test/resources/input/messagebuffer1.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+log4j.rootCategory=DEBUG, testAppender
+log4j.appender.testAppender=org.apache.log4j.FileAppender
+log4j.appender.testAppender.file=output/messagebuffer
+log4j.appender.testAppender.Append=false
+log4j.appender.testAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.testAppender.layout.ConversionPattern=%-5p - %m%n

--- a/src/test/resources/witness/messagebuffer.1
+++ b/src/test/resources/witness/messagebuffer.1
@@ -1,0 +1,2 @@
+INFO  - number in hex: dc
+INFO  - number in dec: 220


### PR DESCRIPTION
This fix repetitive usage of per thread cached ostringstream in StringOrStream-CharMessageBuffer-MessageBuffer. 
The problem occurs when using output manipulators ([standart](https://en.cppreference.com/w/cpp/io/manip) or custom) that change the state of the stream in aspect of formatting output values. Example:
```
int num = 220;
LOG4CXX_INFO(logger, "some number in hex: " << std::hex << num);
LOG4CXX_INFO(logger, "wrongly hex number base here: " << num);
```

I am not sure that the proposed solution is optimal, perhaps it is worth simply abandoning caching of the ostringstream value.