### PR TITLE
Allow removal of an individual logger from the single global repository

### DIFF
--- a/src/main/cpp/logmanager.cpp
+++ b/src/main/cpp/logmanager.cpp
@@ -210,3 +210,11 @@ void LogManager::resetConfiguration()
 {
 	getLoggerRepository()->resetConfiguration();
 }
+
+bool LogManager::removeLogger(const LogString& name, bool ifNotUsed)
+{
+	bool result = false;
+	if (auto r = dynamic_cast<Hierarchy*>(getLoggerRepository().get()))
+		result = r->removeLogger(name, ifNotUsed);
+	return result;
+}

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -232,7 +232,7 @@ class LOG4CXX_EXPORT Hierarchy : public spi::LoggerRepository
 		Remove the \c name Logger from the hierarchy.
 
 		Note: The \c name Logger must be retrieved from the hierarchy
-		*after* any subsequent configuration file change
+		\b after any subsequent configuration file change
 		for the newly loaded settings to be used.
 
 		@param name The logger to remove.

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -228,6 +228,19 @@ class LOG4CXX_EXPORT Hierarchy : public spi::LoggerRepository
 
 		void addAppender(AppenderPtr appender);
 
+		/**
+		Remove the \c name Logger from the hierarchy.
+
+		Note: The \c name Logger must be retrieved from the hierarchy
+		*after* any subsequent configuration file change
+		for the newly loaded settings to be used.
+
+		@param name The logger to remove.
+		@param ifNotUsed If true and use_count() indicates there are other references, do not remove the Logger and return false.
+		@returns true if \c name Logger was removed from the hierarchy.
+		*/
+		bool removeLogger(const LogString& name, bool ifNotUsed = true);
+
 	private:
 
 		/**

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -26,6 +26,15 @@ namespace LOG4CXX_NS
 
 /**
  * Conditionally removes a Logger at the end of the instance variable's lifetime.
+
+ * Use a LoggerInstancePtr to prevent unbounded growth of the LoggerRepository
+ * when using runtime generated logger names.
+
+ * A runtime generated logger name is a technique for marking logging messages
+ * that allows control of the logger level at a class instance level (i.e. a per object logger).
+
+ * A per object logger is useful when the object instance has a identifiable name
+ * (e.g. when it is instantiated from configuration data).
  */
  class LoggerInstancePtr
 {

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -29,9 +29,10 @@ namespace LOG4CXX_NS
 
  * If the configuration process loaded settings for the logger,
  * or the logger is referenced elsewhere,
- * the LoggerInstancePtr destructor will not remove it from the LoggerRepository.
+ * the LoggerInstancePtr destructor will not remove it from the spi::LoggerRepository.
 
- * Use a LoggerInstancePtr to prevent unbounded growth of the LoggerRepository
+ * Use a LoggerInstancePtr to prevent unbounded growth
+ * of data in the spi::LoggerRepository
  * when using runtime generated logger names.
 
  * A runtime generated logger name is a technique for marking logging messages
@@ -42,7 +43,7 @@ namespace LOG4CXX_NS
  */
  class LoggerInstancePtr
 {
-	bool m_hadConfiguration; //!< Did the logger repository hold the m_logger before creation of this instance?
+	bool m_hadConfiguration; //!< Did the logger repository hold a \c m_logger before creation of this instance?
 	LoggerPtr m_logger;
 public: // ...structors
 	/// A null LoggerPtr

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -61,12 +61,7 @@ public: // ...structors
 	/// Conditionally remove the logger from the single global map
 	~LoggerInstancePtr()
 	{
-		if (m_logger && !m_hadConfiguration)
-		{
-			auto name = m_logger->getName();
-			m_logger.reset(); // Decrease reference count
-			LogManager::removeLogger(name);
-		}
+		reset();
 	}
 	const LoggerPtr& operator->() const noexcept
 	{
@@ -93,10 +88,27 @@ public: // ...structors
 		return m_logger;
 	}
 
+	/// Conditionally remove the Logger from the spi::LoggerRepository
+	void reset()
+	{
+		if (m_logger && !m_hadConfiguration)
+		{
+			auto name = m_logger->getName();
+			m_logger.reset(); // Decrease reference count
+			LogManager::removeLogger(name);
+		}
+		else
+		{
+			m_hadConfiguration = false;
+			m_logger.reset();
+		}
+	}
+
 	/// Change this to a logger named \c instanceName
 	template <class StringType>
 	void reset(const StringType& instanceName)
 	{
+		reset();
 		m_hadConfiguration = !!LogManager::exists(instanceName);
 		m_logger = LogManager::getLogger(instanceName);
 	}

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -27,8 +27,9 @@ namespace LOG4CXX_NS
 /**
  * Conditionally removes a Logger at the end of the instance variable's lifetime.
 
-  * If the configuration process loaded settings for the logger,
- *  the LoggerInstancePtr destructor will not remove it from the LoggerRepository.
+ * If the configuration process loaded settings for the logger,
+ * or the logger is referenced elsewhere,
+ * the LoggerInstancePtr destructor will not remove it from the LoggerRepository.
 
  * Use a LoggerInstancePtr to prevent unbounded growth of the LoggerRepository
  * when using runtime generated logger names.

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -27,6 +27,9 @@ namespace LOG4CXX_NS
 /**
  * Conditionally removes a Logger at the end of the instance variable's lifetime.
 
+  * If the configuration process loaded settings for the logger,
+ *  the LoggerInstancePtr destructor will not remove it from the LoggerRepository.
+
  * Use a LoggerInstancePtr to prevent unbounded growth of the LoggerRepository
  * when using runtime generated logger names.
 
@@ -51,7 +54,7 @@ public: // ...structors
 		, m_logger(LogManager::getLogger(instanceName))
 	{
 	}
-	/// Remove the logger from the single global map
+	/// Conditionally remove the logger from the single global map
 	~LoggerInstancePtr()
 	{
 		if (m_logger && !m_hadConfiguration)

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -63,10 +63,16 @@ public: // ...structors
 	{
 		reset();
 	}
+
 	const LoggerPtr& operator->() const noexcept
 	{
-        return m_logger;
-    }
+		return m_logger;
+	}
+
+	explicit operator bool() const noexcept
+	{
+		return !!m_logger;
+	}
 
 	operator LoggerPtr&() noexcept
 	{

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -58,7 +58,7 @@ public: // ...structors
 		, m_logger(LogManager::getLogger(instanceName))
 	{
 	}
-	/// Conditionally remove the logger from the single global map
+	/// Conditionally remove the logger from the the spi::LoggerRepository
 	~LoggerInstancePtr()
 	{
 		reset();

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -118,11 +118,6 @@ public: // ...structors
 		m_hadConfiguration = !!LogManager::exists(instanceName);
 		m_logger = LogManager::getLogger(instanceName);
 	}
-private: // Prevent copies and assignment
-	LoggerInstancePtr(const LoggerInstancePtr&) = delete;
-	LoggerInstancePtr(LoggerInstancePtr&&) = delete;
-	LoggerInstancePtr& operator=(const LoggerInstancePtr&) = delete;
-	LoggerInstancePtr& operator=(LoggerInstancePtr&&) = delete;
 };
 
 } // namespace LOG4CXX_NS

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -25,7 +25,9 @@ namespace LOG4CXX_NS
 {
 
 /**
- * Conditionally removes a Logger at the end of the instance variable's lifetime.
+ * A smart pointer (implicity convertable to LoggerPtr)
+ * that conditionally removes a Logger from the spi::LoggerRepository
+ * at the end of the instance variable's lifetime.
 
  * If the configuration process loaded settings for the logger,
  * or the logger is referenced elsewhere,
@@ -89,6 +91,14 @@ public: // ...structors
 	const LoggerPtr& value() const noexcept
 	{
 		return m_logger;
+	}
+
+	/// Change this to a logger named \c instanceName
+	template <class StringType>
+	void reset(const StringType& instanceName)
+	{
+		m_hadConfiguration = !!LogManager::exists(instanceName);
+		m_logger = LogManager::getLogger(instanceName);
 	}
 private: // Prevent copies and assignment
 	LoggerInstancePtr(const LoggerInstancePtr&) = delete;

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -84,14 +84,14 @@ public: // ...structors
 		return m_logger;
 	}
 
-	LoggerPtr& value() noexcept
+	Logger* get() noexcept
 	{
-		return m_logger;
+		return m_logger.get();
 	}
 
-	const LoggerPtr& value() const noexcept
+	const Logger* get() const noexcept
 	{
-		return m_logger;
+		return m_logger.get();
 	}
 
 	/// Conditionally remove the Logger from the spi::LoggerRepository

--- a/src/main/include/log4cxx/loggerinstance.h
+++ b/src/main/include/log4cxx/loggerinstance.h
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LOG4CXX_LOGGER_INSTANCE_HDR_
+#define LOG4CXX_LOGGER_INSTANCE_HDR_
+
+#include <log4cxx/logmanager.h>
+#include <log4cxx/logger.h>
+
+namespace LOG4CXX_NS
+{
+
+/**
+ * Conditionally removes a Logger at the end of the instance variable's lifetime.
+ */
+ class LoggerInstancePtr
+{
+	bool m_hadConfiguration; //!< Did the logger repository hold the m_logger before creation of this instance?
+	LoggerPtr m_logger;
+public: // ...structors
+	/// A null LoggerPtr
+	LoggerInstancePtr() : m_hadConfiguration(false)
+	{}
+	/// A separately configurable logger named \c instanceName
+	template <class StringType>
+	LoggerInstancePtr(const StringType& instanceName)
+		: m_hadConfiguration(LogManager::exists(instanceName))
+		, m_logger(LogManager::getLogger(instanceName))
+	{
+	}
+	/// Remove the logger from the single global map
+	~LoggerInstancePtr()
+	{
+		if (m_logger && !m_hadConfiguration)
+		{
+			auto name = m_logger->getName();
+			m_logger.reset(); // Decrease reference count
+			LogManager::removeLogger(name);
+		}
+	}
+	const LoggerPtr& operator->() const noexcept
+	{
+        return m_logger;
+    }
+
+	operator LoggerPtr&() noexcept
+	{
+		return m_logger;
+	}
+
+	operator const LoggerPtr&() const noexcept
+	{
+		return m_logger;
+	}
+
+	LoggerPtr& value() noexcept
+	{
+		return m_logger;
+	}
+
+	const LoggerPtr& value() const noexcept
+	{
+		return m_logger;
+	}
+private: // Prevent copies and assignment
+	LoggerInstancePtr(const LoggerInstancePtr&) = delete;
+	LoggerInstancePtr(LoggerInstancePtr&&) = delete;
+	LoggerInstancePtr& operator=(const LoggerInstancePtr&) = delete;
+	LoggerInstancePtr& operator=(LoggerInstancePtr&&) = delete;
+};
+
+} // namespace LOG4CXX_NS
+
+#endif // LOG4CXX_LOGGER_INSTANCE_HDR_

--- a/src/main/include/log4cxx/logmanager.h
+++ b/src/main/include/log4cxx/logmanager.h
@@ -223,6 +223,19 @@ class LOG4CXX_EXPORT LogManager
 		to their default.
 		*/
 		static void resetConfiguration();
+
+		/**
+		Remove the \c name Logger from the hierarchy.
+
+		Note: The \c name Logger must be retrieved from the hierarchy
+		*after* any subsequent configuration file change
+		for the newly loaded settings to be used.
+
+		@param name The logger to remove.
+		@param ifNotUsed If true and use_count() indicates there are other references, do not remove the Logger and return false.
+		@returns true if \c name Logger was removed from the hierarchy.
+		*/
+		static bool removeLogger(const LogString& name, bool ifNotUsed = true);
 }; // class LogManager
 }  // namespace log4cxx
 

--- a/src/main/include/log4cxx/logmanager.h
+++ b/src/main/include/log4cxx/logmanager.h
@@ -228,7 +228,7 @@ class LOG4CXX_EXPORT LogManager
 		Remove the \c name Logger from the hierarchy.
 
 		Note: The \c name Logger must be retrieved from the hierarchy
-		*after* any subsequent configuration file change
+		\b after any subsequent configuration file change
 		for the newly loaded settings to be used.
 
 		@param name The logger to remove.

--- a/src/site/markdown/concepts.md
+++ b/src/site/markdown/concepts.md
@@ -74,7 +74,7 @@ Sometimes a per object logger is useful.
 When each class instance has a identifiable name
 (e.g. when it is instantiated from configuration data)
 add a member variable to hold a log4cxx::LoggerInstancePtr
-and name it so it a *descendant* of the class.
+and initialize it with a name that makes it a *descendant* of the class.
 This allows activation of DEBUG logging for a single object
 or all objects of that class.
 

--- a/src/site/markdown/concepts.md
+++ b/src/site/markdown/concepts.md
@@ -44,6 +44,8 @@ but any category naming scheme may be used.
 Logging category names (or equivalently logger name)
 are case-sensitive.
 
+## Naming {#naming}
+
 Log4cxx makes it easy to name loggers by *software component*. This can
 be accomplished by statically instantiating a logger in each class, with
 the logger name equal to the fully qualified name of the class. This is
@@ -67,6 +69,16 @@ For example, the logger named `com.foo` is a parent of the logger
 named `com.foo.Bar`. Similarly, `java` is a parent of `java.util`
 and an ancestor of `java.util.Vector`. This naming scheme should be
 familiar to most developers.
+
+Sometimes a per object logger is useful.
+When each class instance has a identifiable name
+(e.g. when it is instantiated from configuration data)
+add a member variable to hold a log4cxx::LoggerInstancePtr
+and name it so it a *descendant* of the class.
+This allows activation of DEBUG logging for a single object
+or all objects of that class.
+
+## Instantiation {#getLogger}
 
 The root logger resides at the top of the hierarchy. It is
 exceptional in two ways:

--- a/src/test/cpp/loggertestcase.cpp
+++ b/src/test/cpp/loggertestcase.cpp
@@ -453,6 +453,7 @@ public:
 
 	void testLoggerInstance()
 	{
+		LoggerInstancePtr initiallyNull;
 		auto ca = std::make_shared<CountingAppender>();
 		Logger::getRootLogger()->addAppender(ca);
 
@@ -485,6 +486,10 @@ public:
 		}
 		LOGUNIT_ASSERT(LogManager::exists(LOG4CXX_TEST_STR("xxx.aaaa")));
 		LOGUNIT_ASSERT_EQUAL(ca->counter, expectedCount);
+
+		// Check reset
+		initiallyNull.reset("InitiallyNullLoggerPtr");
+		LOG4CXX_INFO(initiallyNull, "Hello, World.");
 	}
 
 	void compileTestForLOGCXX202() const

--- a/src/test/cpp/loggertestcase.cpp
+++ b/src/test/cpp/loggertestcase.cpp
@@ -454,11 +454,11 @@ public:
 	void testLoggerInstance()
 	{
 		std::vector<LogString> instanceNames =
-		{ LOG4CXX_TEST_STR("xxx.zzz")
-		, LOG4CXX_TEST_STR("xxx.aaaa")
-		, LOG4CXX_TEST_STR("xxx.bbb")
-		, LOG4CXX_TEST_STR("xxx.ccc")
-		, LOG4CXX_TEST_STR("xxx.ddd")
+		{ LOG4CXX_STR("xxx.zzz")
+		, LOG4CXX_STR("xxx.aaaa")
+		, LOG4CXX_STR("xxx.bbb")
+		, LOG4CXX_STR("xxx.ccc")
+		, LOG4CXX_STR("xxx.ddd")
 		};
 		auto initialCount = LogManager::getCurrentLoggers().size();
 		for (auto loggerName : instanceNames)

--- a/src/test/cpp/loggertestcase.cpp
+++ b/src/test/cpp/loggertestcase.cpp
@@ -489,6 +489,7 @@ public:
 
 		// Check reset
 		initiallyNull.reset("InitiallyNullLoggerPtr");
+		LOGUNIT_ASSERT(initiallyNull);
 		LOG4CXX_INFO(initiallyNull, "Hello, World.");
 	}
 

--- a/src/test/cpp/loggertestcase.cpp
+++ b/src/test/cpp/loggertestcase.cpp
@@ -23,6 +23,7 @@
 #include <log4cxx/logmanager.h>
 #include <log4cxx/level.h>
 #include <log4cxx/hierarchy.h>
+#include <log4cxx/loggerinstance.h>
 #include <log4cxx/spi/rootlogger.h>
 #include <log4cxx/helpers/propertyresourcebundle.h>
 #include "insertwide.h"
@@ -99,6 +100,7 @@ LOGUNIT_CLASS(LoggerTestCase)
 	//    LOGUNIT_TEST(testRB3);
 	LOGUNIT_TEST(testExists);
 	LOGUNIT_TEST(testHierarchy1);
+	LOGUNIT_TEST(testLoggerInstance);
 	LOGUNIT_TEST(testTrace);
 	LOGUNIT_TEST(testIsTraceEnabled);
 	LOGUNIT_TEST(testAddingListeners);
@@ -447,6 +449,25 @@ public:
 		LOGUNIT_ASSERT_EQUAL(true, Logger::isTraceEnabledFor(a0));
 		LOGUNIT_ASSERT_EQUAL(true, abc->isTraceEnabled());
 		LOGUNIT_ASSERT_EQUAL(true, Logger::isTraceEnabledFor(abc));
+	}
+
+	void testLoggerInstance()
+	{
+		std::vector<LogString> instanceNames =
+		{ LOG4CXX_TEST_STR("xxx.zzz")
+		, LOG4CXX_TEST_STR("xxx.aaaa")
+		, LOG4CXX_TEST_STR("xxx.bbb")
+		, LOG4CXX_TEST_STR("xxx.ccc")
+		, LOG4CXX_TEST_STR("xxx.ddd")
+		};
+		auto initialCount = LogManager::getCurrentLoggers().size();
+		for (auto loggerName : instanceNames)
+		{
+			LoggerInstancePtr instanceLogger(loggerName);
+			instanceLogger->info("Hello, World.");
+		}
+		auto finalCount = LogManager::getCurrentLoggers().size();
+		LOGUNIT_ASSERT_EQUAL(initialCount, finalCount);
 	}
 
 	void compileTestForLOGCXX202() const


### PR DESCRIPTION
This PR provides a method to prevent unbounded growth of the LoggerRepository when using runtime generated logger names.

A runtime generated logger name is a technique for marking logging messages that allows control of the logger level at in class instance level (i.e. a per object logger).

A per object logger is useful when the object instance has a identifiable name (e.g. when it is instantiated from configuration data).