### PR TITLE
Improve example code clarity

### DIFF
--- a/src/examples/cpp/com/foo/config-qt.cpp
+++ b/src/examples/cpp/com/foo/config-qt.cpp
@@ -29,9 +29,10 @@ namespace com { namespace foo {
 // Provide the name of the configuration file to Log4cxx.
 // Reload the configuration on a QFileSystemWatcher::fileChanged event.
 void ConfigureLogging() {
+	using namespace log4cxx;
 	static struct log4cxx_finalizer {
 		~log4cxx_finalizer() {
-			log4cxx::LogManager::shutdown();
+			LogManager::shutdown();
 		}
 	} finaliser;
 	QFileInfo app{QCoreApplication::applicationFilePath()};
@@ -50,27 +51,27 @@ void ConfigureLogging() {
 		, QString("log4j.properties")
 	};
 #if defined(_DEBUG)
-	log4cxx::helpers::LogLog::setInternalDebugging(true);
+	helpers::LogLog::setInternalDebugging(true);
 #endif
-	auto status       = log4cxx::spi::ConfigurationStatus::NotConfigured;
+	auto status       = spi::ConfigurationStatus::NotConfigured;
 	auto selectedPath = QString();
-	std::tie(status, selectedPath) = log4cxx::qt::Configuration::configureFromFileAndWatch(paths, names);
-	if (status == log4cxx::spi::ConfigurationStatus::NotConfigured)
-		log4cxx::BasicConfigurator::configure(); // Send events to the console
+	std::tie(status, selectedPath) = qt::Configuration::configureFromFileAndWatch(paths, names);
+	if (status == spi::ConfigurationStatus::NotConfigured)
+		BasicConfigurator::configure(); // Send events to the console
 }
 
 // Retrieve the \c name logger pointer.
 auto getLogger(const QString& name) -> LoggerPtr {
 	return name.isEmpty()
-		? log4cxx::LogManager::getRootLogger()
-		: log4cxx::LogManager::getLogger(name.toStdString());
+		? LogManager::getRootLogger()
+		: LogManager::getLogger(name.toStdString());
 }
 
 // Retrieve the \c name logger pointer.
 auto getLogger(const char* name) -> LoggerPtr {
 	return name
-		? log4cxx::LogManager::getLogger(name)
-		: log4cxx::LogManager::getRootLogger();
+		? LogManager::getLogger(name)
+		: LogManager::getRootLogger();
 }
 
 } } // namespace com::foo

--- a/src/examples/cpp/com/foo/config-qt.cpp
+++ b/src/examples/cpp/com/foo/config-qt.cpp
@@ -62,6 +62,7 @@ void ConfigureLogging() {
 
 // Retrieve the \c name logger pointer.
 auto getLogger(const QString& name) -> LoggerPtr {
+	using namespace log4cxx;
 	return name.isEmpty()
 		? LogManager::getRootLogger()
 		: LogManager::getLogger(name.toStdString());
@@ -69,6 +70,7 @@ auto getLogger(const QString& name) -> LoggerPtr {
 
 // Retrieve the \c name logger pointer.
 auto getLogger(const char* name) -> LoggerPtr {
+	using namespace log4cxx;
 	return name
 		? LogManager::getLogger(name)
 		: LogManager::getRootLogger();

--- a/src/examples/cpp/com/foo/config1.cpp
+++ b/src/examples/cpp/com/foo/config1.cpp
@@ -5,18 +5,19 @@
 namespace com { namespace foo {
 
 auto getLogger(const std::string& name) -> LoggerPtr {
+	using namespace log4cxx;
 	static struct log4cxx_initializer {
 		log4cxx_initializer() {
 			// Set up a simple configuration that logs on the console.
-			log4cxx::BasicConfigurator::configure();
+			BasicConfigurator::configure();
 		}
 		~log4cxx_initializer() {
-			log4cxx::LogManager::shutdown();
+			LogManager::shutdown();
 		}
 	} initAndShutdown;
 	return name.empty()
-		? log4cxx::LogManager::getRootLogger()
-		: log4cxx::LogManager::getLogger(name);
+		? LogManager::getRootLogger()
+		: LogManager::getLogger(name);
 }
 
 } } // namespace com::foo

--- a/src/examples/cpp/com/foo/config2.cpp
+++ b/src/examples/cpp/com/foo/config2.cpp
@@ -6,18 +6,19 @@
 namespace com { namespace foo {
 
 auto getLogger(const std::string& name) -> LoggerPtr {
+	using namespace log4cxx;
 	static struct log4cxx_initializer {
 		log4cxx_initializer() {
-			if (log4cxx::PropertyConfigurator::configure("MyApp.properties") == log4cxx::spi::ConfigurationStatus::NotConfigured)
-				log4cxx::BasicConfigurator::configure(); // Send events to the console
+			if (PropertyConfigurator::configure("MyApp.properties") == spi::ConfigurationStatus::NotConfigured)
+				BasicConfigurator::configure(); // Send events to the console
 		}
 		~log4cxx_initializer() {
-			log4cxx::LogManager::shutdown();
+			LogManager::shutdown();
 		}
 	} initAndShutdown;
 	return name.empty()
-		? log4cxx::LogManager::getRootLogger()
-		: log4cxx::LogManager::getLogger(name);
+		? LogManager::getRootLogger()
+		: LogManager::getLogger(name);
 }
 
 } } // namespace com::foo

--- a/src/examples/cpp/com/foo/config3.cpp
+++ b/src/examples/cpp/com/foo/config3.cpp
@@ -154,17 +154,18 @@ namespace com { namespace foo {
 // Retrieve the \c name logger pointer.
 // Configure Log4cxx on the first call.
 auto getLogger(const std::string& name) -> LoggerPtr {
+	using namespace log4cxx;
 	static struct log4cxx_initializer {
 		log4cxx_initializer() {
 			SelectConfigurationFile();
 		}
 		~log4cxx_initializer() {
-			log4cxx::LogManager::shutdown();
+			LogManager::shutdown();
 		}
 	} initialiser;
 	return name.empty()
-		? log4cxx::LogManager::getRootLogger()
-		: log4cxx::LogManager::getLogger(name);
+		? LogManager::getRootLogger()
+		: LogManager::getLogger(name);
 }
 
 } } // namespace com::foo

--- a/src/examples/cpp/console.cpp
+++ b/src/examples/cpp/console.cpp
@@ -38,18 +38,16 @@ static void configure(bool err)
 {
     using namespace log4cxx;
     auto r = LogManager::getLoggerRepository();
-    r->ensureIsConfigured([r]() {
-        auto appender = std::make_shared<ConsoleAppender>(std::make_shared<SimpleLayout>());
+    r->ensureIsConfigured([r,err]() {
+        auto appender = std::make_shared<ConsoleAppender>
+            ( std::make_shared<SimpleLayout>()
+            , err ? ConsoleAppender::getSystemErr() : ConsoleAppender::getSystemOut()
+            );
         appender->setName(LOG4CXX_STR("console"));
         helpers::Pool pool;
         appender->activateOptions(pool);
         r->getRootLogger()->addAppender(appender);
     });
-    if (err)
-    {
-        if (auto appender = log4cxx::cast<ConsoleAppender>(r->getRootLogger()->getAppender(LOG4CXX_STR("console"))))
-            appender->setTarget(LOG4CXX_STR("System.err"));
-    }
 }
 
 /**

--- a/src/examples/cpp/console.cpp
+++ b/src/examples/cpp/console.cpp
@@ -31,22 +31,21 @@
 #endif
 
 using namespace log4cxx;
-using namespace log4cxx::helpers;
 
 /**
  *   Configures console appender.
  *   @param err if true, use stderr, otherwise stdout.
  */
 static void configure(bool err) {
-    log4cxx::ConsoleAppenderPtr appender(new log4cxx::ConsoleAppender());
+    ConsoleAppenderPtr appender(new ConsoleAppender());
     if (err) {
         appender->setTarget(LOG4CXX_STR("System.err"));
     }
-    log4cxx::LayoutPtr layout(new log4cxx::SimpleLayout());
+    LayoutPtr layout(new SimpleLayout());
     appender->setLayout(layout);
-    log4cxx::helpers::Pool pool;
+    helpers::Pool pool;
     appender->activateOptions(pool);
-    log4cxx::Logger::getRootLogger()->addAppender(appender);
+    Logger::getRootLogger()->addAppender(appender);
     LogManager::getLoggerRepository()->setConfigured(true);
 }
 
@@ -103,7 +102,7 @@ int main(int argc, char** argv)
                 configure(err);
                 configured = true;
             }
-            log4cxx::Logger::getRootLogger()->info("Hello, log4cxx");
+            Logger::getRootLogger()->info("Hello, log4cxx");
 #if LOG4CXX_WCHAR_T_API
         } else if (strcmp("wide", argv[i]) == 0) {
             fwide(err ? stderr : stdout, 1);

--- a/src/examples/cpp/custom-appender.cpp
+++ b/src/examples/cpp/custom-appender.cpp
@@ -22,7 +22,7 @@
 
 namespace LOG4CXX_NS {
 
-class NullWriterAppender : public log4cxx::AppenderSkeleton {
+class NullWriterAppender : public AppenderSkeleton {
 public:
 	DECLARE_LOG4CXX_OBJECT(NullWriterAppender)
 	BEGIN_LOG4CXX_CAST_MAP()
@@ -38,11 +38,11 @@ public:
 		return false;
 	}
 
-	void append(const spi::LoggingEventPtr& event, log4cxx::helpers::Pool& p) override {
+	void append(const spi::LoggingEventPtr& event, helpers::Pool& p) override {
 		// This gets called whenever there is a valid event for our appender.
 	}
 
-	void activateOptions(log4cxx::helpers::Pool& /* pool */) override {
+	void activateOptions(helpers::Pool& /* pool */) override {
 		// Given all of our options, do something useful(e.g. open a file)
 	}
 

--- a/src/examples/cpp/format-string.cpp
+++ b/src/examples/cpp/format-string.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <log4cxx/logger.h>
 #include <log4cxx/basicconfigurator.h>
 #include <locale.h>
 #if LOG4CXX_USING_STD_FORMAT
@@ -26,9 +27,6 @@
 #include <fmt/ostream.h>
 #endif
 #include <iomanip>
-
-using namespace log4cxx;
-using namespace log4cxx::helpers;
 
 struct MyStruct {
 		int x;
@@ -61,8 +59,9 @@ int main()
 {
 	setlocale(LC_ALL, "");
 
+	using namespace log4cxx;
 	BasicConfigurator::configure();
-	LoggerPtr rootLogger = Logger::getRootLogger();
+	auto rootLogger = Logger::getRootLogger();
 
 	LOG4CXX_INFO_FMT( rootLogger, "This is a {} mesage", "test" );
 #if !LOG4CXX_USING_STD_FORMAT


### PR DESCRIPTION
I believe the log4cxx namespace on every function is making code unecessarily hard to read.