### PR TITLE
Remove old/unused/unrequired code from AsyncAppender

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -180,6 +180,9 @@ struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkele
 
 #if LOG4CXX_HAS_CONCURRENT_QUEUE
 	moodycamel::ConcurrentQueue<spi::LoggingEventPtr> queue;
+	bool stop_waiting() const { return 0 < this->queue.size_approx() || this->closed; }
+#else
+	bool stop_waiting() const { return 0 < this->buffer.size() || this->closed; }
 #endif
 };
 
@@ -254,6 +257,7 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 	{
 		priv->dispatcher = ThreadUtility::instance()->createThread( LOG4CXX_STR("AsyncAppender"), &AsyncAppender::dispatch, this );
 	}
+	priv->bufferNotEmpty.notify_all();
 #else
 	std::unique_lock<std::mutex> lock(priv->bufferMutex);
 	if (!priv->dispatcher.joinable())
@@ -490,9 +494,7 @@ void AsyncAppender::dispatch()
 		LoggingEventList events;
 		{
 			std::unique_lock<std::mutex> lock(priv->bufferMutex);
-			priv->bufferNotEmpty.wait(lock, [this]() -> bool
-				{ return 0 < priv->buffer.size() || priv->closed; }
-			);
+			priv->bufferNotEmpty.wait(lock, std::bind(&AsyncAppenderPriv::stop_waiting, priv));
 			isActive = !priv->closed;
 
 #if LOG4CXX_HAS_CONCURRENT_QUEUE

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -96,15 +96,6 @@ typedef std::map<LogString, DiscardSummary> DiscardMap;
 }
 #endif
 
-#ifndef __has_include
-	#define LOG4CXX_HAS_CONCURRENT_QUEUE 0
-#elif __has_include(<concurrentqueue/concurrentqueue.h>)
-	#include <concurrentqueue/concurrentqueue.h>
-	#define LOG4CXX_HAS_CONCURRENT_QUEUE 1
-#else
-	#define LOG4CXX_HAS_CONCURRENT_QUEUE 0
-#endif
-
 struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkeletonPrivate
 {
 	AsyncAppenderPriv() :
@@ -177,10 +168,6 @@ struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkele
 #if LOG4CXX_EVENTS_AT_EXIT
 	helpers::AtExitRegistry::Raii atExitRegistryRaii;
 #endif
-
-#if LOG4CXX_HAS_CONCURRENT_QUEUE
-	moodycamel::ConcurrentQueue<spi::LoggingEventPtr> queue;
-#endif
 };
 
 
@@ -247,14 +234,6 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 	// Get a copy of this thread's MDC.
 	event->getMDCCopy();
 
-#if LOG4CXX_HAS_CONCURRENT_QUEUE
-	while (!priv->queue.enqueue(event))
-		;
-	if (!priv->dispatcher.joinable())
-	{
-		priv->dispatcher = ThreadUtility::instance()->createThread( LOG4CXX_STR("AsyncAppender"), &AsyncAppender::dispatch, this );
-	}
-#else
 	std::unique_lock<std::mutex> lock(priv->bufferMutex);
 	if (!priv->dispatcher.joinable())
 	{
@@ -318,7 +297,6 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 			break;
 		}
 	}
-#endif
 }
 
 void AsyncAppender::close()
@@ -495,19 +473,18 @@ void AsyncAppender::dispatch()
 			);
 			isActive = !priv->closed;
 
-#if LOG4CXX_HAS_CONCURRENT_QUEUE
-			LoggingEventPtr event;
-			while (priv->queue.try_dequeue(event))
-#else
-			for (auto event : priv->buffer)
-#endif
+			for (LoggingEventList::iterator eventIter = priv->buffer.begin();
+				eventIter != priv->buffer.end();
+				eventIter++)
 			{
-				events.push_back(event);
+				events.push_back(*eventIter);
 			}
 
-			for (auto discardItem : priv->discardMap)
+			for (DiscardMap::iterator discardIter = priv->discardMap.begin();
+				discardIter != priv->discardMap.end();
+				discardIter++)
 			{
-				events.push_back(discardItem.second.createEvent(p));
+				events.push_back(discardIter->second.createEvent(p));
 			}
 
 			priv->buffer.clear();
@@ -515,15 +492,17 @@ void AsyncAppender::dispatch()
 			priv->bufferNotFull.notify_all();
 		}
 
-		for (auto item : events)
+		for (LoggingEventList::iterator iter = events.begin();
+			iter != events.end();
+			iter++)
 		{
 			try
 			{
-				priv->appenders->appendLoopOnAppenders(item, p);
+				priv->appenders->appendLoopOnAppenders(*iter, p);
 			}
 			catch (std::exception& ex)
 			{
-				priv->errorHandler->error(LOG4CXX_STR("async dispatcher"), ex, 0, item);
+				priv->errorHandler->error(LOG4CXX_STR("async dispatcher"), ex, 0, *iter);
 				isActive = false;
 			}
 			catch (...)

--- a/src/main/include/log4cxx/asyncappender.h
+++ b/src/main/include/log4cxx/asyncappender.h
@@ -20,18 +20,11 @@
 
 #include <log4cxx/appenderskeleton.h>
 #include <log4cxx/helpers/appenderattachableimpl.h>
-#include <deque>
 #include <log4cxx/spi/loggingevent.h>
-#include <thread>
-#include <condition_variable>
-
-#if defined(NON_BLOCKING)
-	#include <boost/lockfree/queue.hpp>
-#endif
 
 namespace LOG4CXX_NS
 {
-LOG4CXX_LIST_DEF(LoggingEventList, LOG4CXX_NS::spi::LoggingEventPtr);
+LOG4CXX_LIST_DEF(LoggingEventList, spi::LoggingEventPtr);
 
 /**
 The AsyncAppender lets users log events asynchronously. It uses a

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -32,6 +32,7 @@
 #include <log4cxx/spi/location/locationinfo.h>
 #include <log4cxx/xml/domconfigurator.h>
 #include <log4cxx/file.h>
+#include <thread>
 
 using namespace log4cxx;
 using namespace log4cxx::helpers;


### PR DESCRIPTION
This PR moves some header files to the implementation and removes unused code.

Also, the only reason for the `AsyncAppender::doAppend` override is to *avoid* the lock in `AppenderSkeleton::doAppend` as `AsyncAppender::append` is synchronised using `bufferMutex`