### PR TITLE
Prevent potential deadlock on shutdown when using AsyncAppender

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -502,13 +502,19 @@ void AsyncAppender::dispatch()
 			}
 			catch (std::exception& ex)
 			{
-				priv->errorHandler->error(LOG4CXX_STR("async dispatcher"), ex, 0, *iter);
-				isActive = false;
+				if (isActive)
+				{
+					priv->errorHandler->error(LOG4CXX_STR("async dispatcher"), ex, 0, *iter);
+					isActive = false;
+				}
 			}
 			catch (...)
 			{
-				priv->errorHandler->error(LOG4CXX_STR("async dispatcher"));
-				isActive = false;
+				if (isActive)
+				{
+					priv->errorHandler->error(LOG4CXX_STR("async dispatcher"));
+					isActive = false;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR prevents a deadlock in the rare circumstance where a `FallbackErrorHandler `attached to the `AsyncAppender `is invoked in 
   the `AsyncAppender::dispatch` thread while `AsyncAppender::close` (called from `Hierarchy::shutdown`) is waiting in `dispatcher.join()`