### PR TITLE
Use threadId for an unnamed thread when the layout requires a thread name

### DIFF
--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -399,7 +399,7 @@ const LogString& LoggingEvent::getCurrentThreadUserName()
 	char result[16];
 	pthread_t current_thread = pthread_self();
 	if (pthread_getname_np(current_thread, result, sizeof(result)) < 0 || 0 == result[0])
-		thread_name = LOG4CXX_STR("(noname)");
+		thread_name = getCurrentThreadName();
 	else
 		thread_name = Transcoder::decode(result);
 #elif WIN32
@@ -429,9 +429,9 @@ const LogString& LoggingEvent::getCurrentThreadUserName()
 		}
 	}
 	if (thread_name.empty())
-		thread_name = LOG4CXX_STR("(noname)");
+		thread_name = getCurrentThreadName();
 #else
-	thread_name = LOG4CXX_STR("(noname)");
+	thread_name = getCurrentThreadName();
 #endif
 	return thread_name;
 }

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -420,7 +420,7 @@ const LogString& LoggingEvent::getCurrentThreadUserName()
 	{
 		PWSTR result = 0;
 		HRESULT hr = win32func.GetThreadDescription(GetCurrentThread(), &result);
-		if (SUCCEEDED(hr) && result && *result)
+		if (SUCCEEDED(hr) && result)
 		{
 			std::wstring wresult = result;
 			LOG4CXX_DECODE_WCHAR(decoded, wresult);

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -354,8 +354,8 @@ const LogString& LoggingEvent::getCurrentThreadName()
 	thread_local LogString thread_id_string;
 #else
 	using ListItem = std::pair<ThreadIdType, LogString>;
-	static WideLife<std::list<ListItem>> thread_id_map;
-	static WideLife<std::mutex> mutex;
+	static std::list<ListItem> thread_id_map;
+	static std::mutex mutex;
 	std::lock_guard<std::mutex> lock(mutex);
 	auto pThreadId = std::find_if(thread_id_map.begin(), thread_id_map.end()
 		, [threadId](const ListItem& item) { return threadId == item.first; });


### PR DESCRIPTION
This PR prevents repeated calls to GetThreadDescription (Windows only) when the layout requires a thread name and SetThreadDescription was not called.