### PR TITLE
Remove unnecessary delays in unit tests

### DIFF
--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -258,6 +258,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 		void testLocationInfoTrue()
 		{
 			BlockableVectorAppenderPtr blockableAppender = BlockableVectorAppenderPtr(new BlockableVectorAppender());
+			blockableAppender->setMillisecondDelay(100);
 			blockableAppender->setName(LOG4CXX_STR("async-blockableVector"));
 			AsyncAppenderPtr async = AsyncAppenderPtr(new AsyncAppender());
 			async->setName(LOG4CXX_STR("async-testLocationInfoTrue"));

--- a/src/test/cpp/streamtestcase.cpp
+++ b/src/test/cpp/streamtestcase.cpp
@@ -188,8 +188,9 @@ public:
 	{
 		LoggerPtr root(Logger::getRootLogger());
 		LOG4CXX_INFO(root, std::scientific << 0.000001115);
-		spi::LoggingEventPtr event(vectorAppender->getVector()[0]);
-		LogString msg(event->getMessage());
+		auto events = vectorAppender->getVector();
+		LOGUNIT_ASSERT_EQUAL((size_t) 1, events.size());
+		LogString msg(events.front()->getMessage());
 		LOGUNIT_ASSERT(msg.find(LOG4CXX_STR("e-")) != LogString::npos ||
 			msg.find(LOG4CXX_STR("E-")) != LogString::npos);
 	}

--- a/src/test/cpp/vectorappender.cpp
+++ b/src/test/cpp/vectorappender.cpp
@@ -25,9 +25,9 @@ IMPLEMENT_LOG4CXX_OBJECT(VectorAppender)
 
 void VectorAppender::append(const spi::LoggingEventPtr& event, Pool& /*p*/)
 {
-	std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
-
-	vector.push_back(event);
+	if (0 < this->appendMillisecondDelay)
+		std::this_thread::sleep_for( std::chrono::milliseconds( this->appendMillisecondDelay ) );
+	this->vector.push_back(event);
 }
 
 void VectorAppender::close()

--- a/src/test/cpp/vectorappender.h
+++ b/src/test/cpp/vectorappender.h
@@ -37,7 +37,7 @@ class VectorAppender : public AppenderSkeleton
 		END_LOG4CXX_CAST_MAP()
 
 		std::vector<spi::LoggingEventPtr> vector;
-
+		int appendMillisecondDelay = 0;
 
 		/**
 		This method is called by the AppenderSkeleton#doAppend
@@ -47,7 +47,7 @@ class VectorAppender : public AppenderSkeleton
 
 		const std::vector<spi::LoggingEventPtr>& getVector() const
 		{
-			return vector;
+			return this->vector;
 		}
 
 		void close() override;
@@ -60,6 +60,11 @@ class VectorAppender : public AppenderSkeleton
 		bool requiresLayout() const override
 		{
 			return false;
+		}
+
+		void setMillisecondDelay(int milliseconds)
+		{
+			this->appendMillisecondDelay = milliseconds;
 		}
 };
 typedef std::shared_ptr<VectorAppender> VectorAppenderPtr;


### PR DESCRIPTION
The delay in VectorAppender does not seem to be currently required.