### PR TITLE
Allow use of log4cxx::cast with all log4cxx classes

### DIFF
--- a/src/main/include/log4cxx/helpers/onlyonceerrorhandler.h
+++ b/src/main/include/log4cxx/helpers/onlyonceerrorhandler.h
@@ -45,8 +45,13 @@ class LOG4CXX_EXPORT OnlyOnceErrorHandler :
 	public:
 		DECLARE_LOG4CXX_OBJECT(OnlyOnceErrorHandler)
 		BEGIN_LOG4CXX_CAST_MAP()
+#if 15 < LOG4CXX_ABI_VERSION
+		LOG4CXX_CAST_ENTRY(OnlyOnceErrorHandler)
+		LOG4CXX_CAST_ENTRY_CHAIN(spi::ErrorHandler)
+#else
 		LOG4CXX_CAST_ENTRY(spi::OptionHandler)
 		LOG4CXX_CAST_ENTRY(spi::ErrorHandler)
+#endif
 		END_LOG4CXX_CAST_MAP()
 
 		OnlyOnceErrorHandler();

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -60,7 +60,12 @@ class LOG4CXX_EXPORT Hierarchy : public spi::LoggerRepository
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(Hierarchy)
 		BEGIN_LOG4CXX_CAST_MAP()
+#if 15 < LOG4CXX_ABI_VERSION
+		LOG4CXX_CAST_ENTRY(Hierarchy)
+		LOG4CXX_CAST_ENTRY_CHAIN(spi::LoggerRepository)
+#else
 		LOG4CXX_CAST_ENTRY(spi::LoggerRepository)
+#endif
 		END_LOG4CXX_CAST_MAP()
 
 	private:

--- a/src/main/include/log4cxx/propertyconfigurator.h
+++ b/src/main/include/log4cxx/propertyconfigurator.h
@@ -101,7 +101,12 @@ class LOG4CXX_EXPORT PropertyConfigurator :
 	public:
 		DECLARE_LOG4CXX_OBJECT(PropertyConfigurator)
 		BEGIN_LOG4CXX_CAST_MAP()
+#if 15 < LOG4CXX_ABI_VERSION
+		LOG4CXX_CAST_ENTRY(PropertyConfigurator)
+		LOG4CXX_CAST_ENTRY_CHAIN(spi::Configurator)
+#else
 		LOG4CXX_CAST_ENTRY(spi::Configurator)
+#endif
 		END_LOG4CXX_CAST_MAP()
 
 		PropertyConfigurator();


### PR DESCRIPTION
OnlyOnceErrorHandler, Hierarchy and PropertyConfigurator cast entries do not support down-casting