### PR TITLE
Improve AsyncAppender throughput

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -551,7 +551,7 @@ void AsyncAppender::dispatch()
 			priv->bufferNotEmpty.wait(lock, [this, &eventList]() -> bool
 				{
 					eventList = priv->eventList.pop_all_reverse();
-					return !eventList || priv->closed;
+					return eventList || priv->closed;
 				}
 			);
 			isActive = !priv->closed;

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -555,7 +555,6 @@ void AsyncAppender::dispatch()
 					return eventList || priv->closed;
 				}
 			);
-			isActive = !priv->closed;
 		}
 		priv->approxListSize = 0;
 		priv->bufferNotFull.notify_all();

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -390,7 +390,10 @@ void AsyncAppender::close()
 	// Queue a special event that will terminate the dispatch thread
 	priv->eventList.push(LoggingEventPtr());
 #endif
-	priv->closed = true;
+	{
+		std::unique_lock<std::mutex> lock(priv->bufferMutex);
+		priv->closed = true;
+	}
 	priv->bufferNotEmpty.notify_all();
 	priv->bufferNotFull.notify_all();
 

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -400,10 +400,6 @@ void AsyncAppender::close()
 		priv->eventList.push(LoggingEventPtr());
 #endif
 		priv->dispatcher.join();
-#if USE_ATOMIC_QUEUE
-		// Ensure a new dispatch thread is not immediately terminated
-		priv->eventList.pop_all();
-#endif
 	}
 
 	for (auto item : priv->appenders->getAllAppenders())

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -155,7 +155,7 @@ struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkele
 		AppenderSkeletonPrivate(),
 		buffer(),
 		bufferSize(DEFAULT_BUFFER_SIZE),
-		appenders(std::make_shared<AppenderAttachableImpl>(pool)),
+		appenders(pool),
 		dispatcher(),
 		locationInfo(false),
 		blocking(true)
@@ -203,7 +203,7 @@ struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkele
 	/**
 	 * Nested appenders.
 	*/
-	helpers::AppenderAttachableImplPtr appenders;
+	helpers::AppenderAttachableImpl appenders;
 
 	/**
 	 *  Dispatcher.
@@ -254,7 +254,7 @@ AsyncAppender::~AsyncAppender()
 
 void AsyncAppender::addAppender(const AppenderPtr newAppender)
 {
-	priv->appenders->addAppender(newAppender);
+	priv->appenders.addAppender(newAppender);
 }
 
 
@@ -291,7 +291,7 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 {
 	if (priv->bufferSize <= 0)
 	{
-		priv->appenders->appendLoopOnAppenders(event, p);
+		priv->appenders.appendLoopOnAppenders(event, p);
 	}
 
 	// Set the NDC and MDC for the calling thread as these
@@ -402,7 +402,7 @@ void AsyncAppender::close()
 		priv->dispatcher.join();
 	}
 
-	for (auto item : priv->appenders->getAllAppenders())
+	for (auto item : priv->appenders.getAllAppenders())
 	{
 		item->close();
 	}
@@ -410,17 +410,17 @@ void AsyncAppender::close()
 
 AppenderList AsyncAppender::getAllAppenders() const
 {
-	return priv->appenders->getAllAppenders();
+	return priv->appenders.getAllAppenders();
 }
 
 AppenderPtr AsyncAppender::getAppender(const LogString& n) const
 {
-	return priv->appenders->getAppender(n);
+	return priv->appenders.getAppender(n);
 }
 
 bool AsyncAppender::isAttached(const AppenderPtr appender) const
 {
-	return priv->appenders->isAttached(appender);
+	return priv->appenders.isAttached(appender);
 }
 
 bool AsyncAppender::requiresLayout() const
@@ -430,17 +430,17 @@ bool AsyncAppender::requiresLayout() const
 
 void AsyncAppender::removeAllAppenders()
 {
-	priv->appenders->removeAllAppenders();
+	priv->appenders.removeAllAppenders();
 }
 
 void AsyncAppender::removeAppender(const AppenderPtr appender)
 {
-	priv->appenders->removeAppender(appender);
+	priv->appenders.removeAppender(appender);
 }
 
 void AsyncAppender::removeAppender(const LogString& n)
 {
-	priv->appenders->removeAppender(n);
+	priv->appenders.removeAppender(n);
 }
 
 bool AsyncAppender::getLocationInfo() const
@@ -607,7 +607,7 @@ void AsyncAppender::dispatch()
 		{
 			try
 			{
-				priv->appenders->appendLoopOnAppenders(item, p);
+				priv->appenders.appendLoopOnAppenders(item, p);
 			}
 			catch (std::exception& ex)
 			{

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -386,15 +386,13 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 
 void AsyncAppender::close()
 {
-	{
-		std::lock_guard<std::mutex> lock(priv->bufferMutex);
-		priv->closed = true;
 #if USE_ATOMIC_QUEUE
-		priv->eventList.push(LoggingEventPtr());
+	// Queue a special event that will terminate the dispatch thread
+	priv->eventList.push(LoggingEventPtr());
 #endif
-		priv->bufferNotEmpty.notify_all();
-		priv->bufferNotFull.notify_all();
-	}
+	priv->closed = true;
+	priv->bufferNotEmpty.notify_all();
+	priv->bufferNotFull.notify_all();
 
 	if ( priv->dispatcher.joinable() )
 	{

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -391,11 +391,11 @@ void AsyncAppender::close()
 	priv->eventList.push(LoggingEventPtr());
 #endif
 	{
-		std::unique_lock<std::mutex> lock(priv->bufferMutex);
+		std::lock_guard<std::mutex> lock(priv->bufferMutex);
 		priv->closed = true;
+		priv->bufferNotEmpty.notify_all();
+		priv->bufferNotFull.notify_all();
 	}
-	priv->bufferNotEmpty.notify_all();
-	priv->bufferNotFull.notify_all();
 
 	if ( priv->dispatcher.joinable() )
 	{

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -270,6 +270,8 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			async->activateOptions(p);
 			LoggerPtr rootLogger = Logger::getRootLogger();
 			rootLogger->addAppender(async);
+			LOG4CXX_INFO(rootLogger, "Hello, World"); // This causes the dispatch thread creation
+			std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) ); // Wait for the dispatch thread  to be ready
 			{
 				std::unique_lock<std::mutex> sync(blockableAppender->getBlocker());
 


### PR DESCRIPTION
This PR aims to reduce synchronization contention when logging through AsyncAppender.

Relevant Windows benchmarks improve from:

 | Benchmark | Time | CPU | Iterations | 
 | --------- | ----- | ----- | --------- |
 | Async, int value using MessageBuffer, pattern: %m%n | 1594 ns | 928 ns | 640000 | 
 | Async, int value using MessageBuffer, pattern: %m%n/threads:4 | 687 ns | 1445 ns | 400000 | 

to:

 | Benchmark | Time | CPU | Iterations | 
 | -------- | ---- | ----- | ------------------- | 
 | Async, int value using MessageBuffer, pattern: %m%n | 1654 ns | 879 ns | 1120000 | 
 | Async, int value using MessageBuffer, pattern: %m%n/threads:4 | 671 ns | 1484 ns | 400000 | 