### PR TITLE
Reduce logging overhead more

### DIFF
--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -44,8 +44,7 @@ struct Logger::LoggerPrivate
 		name(name1),
 		repositoryRaw(0),
 		aai(p),
-		additive(true),
-		pool(p) {}
+		additive(true) {}
 
 	/**
 	The name of this logger.
@@ -83,10 +82,6 @@ struct Logger::LoggerPrivate
 	        have their additivity flag set to <code>false</code> too. See
 	        the user manual for more details. */
 	bool additive;
-
-	/** A reference to the Pool held by the LoggerRepository
-	 */
-	Pool& pool;
 };
 
 IMPLEMENT_LOG4CXX_OBJECT(Logger)
@@ -169,7 +164,7 @@ void Logger::addEvent(const LevelPtr& level, std::string&& message, const Locati
 	LOG4CXX_DECODE_CHAR(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level, location, std::move(msg));
 #endif
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -184,7 +179,7 @@ void Logger::forcedLog(const LevelPtr& level, const std::string& message,
 	LOG4CXX_DECODE_CHAR(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level, location, std::move(msg));
 #endif
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -198,7 +193,7 @@ void Logger::addEventLS(const LevelPtr& level, LogString&& message, const Locati
 	if (!getHierarchy()) // Has removeHierarchy() been called?
 		return;
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level, location, std::move(message));
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -208,7 +203,7 @@ void Logger::forcedLogLS(const LevelPtr& level1, const LogString& message,
 	if (!getHierarchy()) // Has removeHierarchy() been called?
 		return;
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, message, location);
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -750,7 +745,7 @@ void Logger::addEvent(const LevelPtr& level, std::wstring&& message, const Locat
 	LOG4CXX_DECODE_WCHAR(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level, location, std::move(msg));
 #endif
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -765,7 +760,7 @@ void Logger::forcedLog(const LevelPtr& level, const std::wstring& message,
 	LOG4CXX_DECODE_WCHAR(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level, location, std::move(msg));
 #endif
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -913,7 +908,7 @@ void Logger::addEvent(const LevelPtr& level1, std::basic_string<UniChar>&& messa
 		return;
 	LOG4CXX_DECODE_UNICHAR(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, location, std::move(msg));
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -924,7 +919,7 @@ void Logger::forcedLog(const LevelPtr& level1, const std::basic_string<UniChar>&
 		return;
 	LOG4CXX_DECODE_UNICHAR(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, location, std::move(msg));
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -935,7 +930,7 @@ void Logger::forcedLog(const LevelPtr& level1, const std::basic_string<UniChar>&
 	LOG4CXX_DECODE_UNICHAR(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, msg,
 			LocationInfo::getLocationUnavailable());
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -1074,7 +1069,7 @@ void Logger::forcedLog(const LevelPtr& level, const CFStringRef& message,
 		return;
 	LOG4CXX_DECODE_CFSTRING(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level, location, std::move(msg));
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 
@@ -1085,7 +1080,7 @@ void Logger::forcedLog(const LevelPtr& level, const CFStringRef& message) const
 	LOG4CXX_DECODE_CFSTRING(msg, message);
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level, msg,
 			LocationInfo::getLocationUnavailable());
-	Pool p(m_priv->pool.create(), true);
+	Pool p;
 	callAppenders(event, p);
 }
 

--- a/src/main/cpp/pool.cpp
+++ b/src/main/cpp/pool.cpp
@@ -32,12 +32,6 @@ using namespace LOG4CXX_NS;
 
 Pool::Pool() : pool(0), release(true)
 {
-	apr_status_t stat = apr_pool_create(&pool, APRInitializer::getRootPool());
-
-	if (stat != APR_SUCCESS)
-	{
-		throw PoolException(stat);
-	}
 }
 
 Pool::Pool(apr_pool_t* p, bool release1) : pool(p), release(release1)
@@ -47,20 +41,33 @@ Pool::Pool(apr_pool_t* p, bool release1) : pool(p), release(release1)
 
 Pool::~Pool()
 {
-	if (release)
+	if (pool && release)
 	{
 		apr_pool_destroy(pool);
 	}
 }
 
+void Pool::setPool()
+{
+	apr_status_t stat = apr_pool_create(&pool, APRInitializer::getRootPool());
+
+	if (stat != APR_SUCCESS)
+	{
+		throw PoolException(stat);
+	}
+}
 
 apr_pool_t* Pool::getAPRPool()
 {
+	if (!pool)
+		setPool();
 	return pool;
 }
 
 apr_pool_t* Pool::create()
 {
+	if (!pool)
+		setPool();
 	apr_pool_t* child;
 	apr_status_t stat = apr_pool_create(&child, pool);
 
@@ -74,6 +81,8 @@ apr_pool_t* Pool::create()
 
 void* Pool::palloc(size_t size)
 {
+	if (!pool)
+		setPool();
 	return apr_palloc(pool, size);
 }
 
@@ -84,20 +93,28 @@ char* Pool::pstralloc(size_t size)
 
 char* Pool::itoa(int n)
 {
+	if (!pool)
+		setPool();
 	return apr_itoa(pool, n);
 }
 
 char* Pool::pstrndup(const char* s, size_t len)
 {
+	if (!pool)
+		setPool();
 	return apr_pstrndup(pool, s, len);
 }
 
 char* Pool::pstrdup(const char* s)
 {
+	if (!pool)
+		setPool();
 	return apr_pstrdup(pool, s);
 }
 
 char* Pool::pstrdup(const std::string& s)
 {
+	if (!pool)
+		setPool();
 	return apr_pstrndup(pool, s.data(), s.length());
 }

--- a/src/main/include/log4cxx/helpers/pool.h
+++ b/src/main/include/log4cxx/helpers/pool.h
@@ -52,6 +52,7 @@ class LOG4CXX_EXPORT Pool
 	private:
 		Pool(const LOG4CXX_NS::helpers::Pool&);
 		Pool& operator=(const Pool&);
+		void setPool();
 };
 } // namespace helpers
 } // namespace log4cxx


### PR DESCRIPTION
This PR improves benchmarks more than #333.

On Windows, the new results are:
 | Benchmark | Time | CPU | Iterations | 
 | -------- | ------ | --- | -------- | 
 | Testing disabled logging request | 3.18 ns | 1.19 ns | 497777778 | 
 | Testing disabled logging request/threads:4 | 1.35 ns | 3.85 ns | 199111112 | 
 | Logging 5 char string using MessageBuffer, pattern: %m%n | 614 ns | 327 ns | 3200000 | 
 | Logging 5 char string using MessageBuffer, pattern: %m%n/threads:4 | 359 ns | 837 ns | 1120000 | 
 | Logging 49 char string using MessageBuffer, pattern: %m%n | 707 ns | 488 ns | 1120000 | 
 | Logging 49 char string using MessageBuffer, pattern: %m%n/threads:4 | 442 ns | 949 ns | 1054116 | 
 | Logging int value using MessageBuffer, pattern: %m%n | 1564 ns | 889 ns | 896000 | 
 | Logging int value using MessageBuffer, pattern: %m%n/threads:4 | 608 ns | 1289 ns | 400000 | 
 | Logging int+float using MessageBuffer, pattern: %m%n | 2941 ns | 1880 ns | 407273 | 
 | Logging int+float using MessageBuffer, pattern: %m%n/threads:4 | 1163 ns | 3047 ns | 400000 | 
 | Logging int value using MessageBuffer, pattern: [%d] %m%n | 1804 ns | 1130 ns | 746667 | 
 | Logging int value using MessageBuffer, pattern: [%d] [%c] [%p] %m%n | 1572 ns | 907 ns | 1120000 | 
 | Logging 49 char string using FMT, pattern: %m%n | 703 ns | 391 ns | 1600000 | 
 | Logging 49 char string using FMT, pattern: %m%n/threads:4 | 414 ns | 767 ns | 1120000 | 
 | Logging int value using FMT, pattern: %m%n | 643 ns | 348 ns | 1659259 | 
 | Logging int value using FMT, pattern: %m%n/threads:4 | 384 ns | 907 ns | 896000 | 
 | Logging int+float using FMT, pattern: %m%n | 1088 ns | 641 ns | 1000000 | 
 | Logging int+float using FMT, pattern: %m%n/threads:4 | 532 ns | 1270 ns | 689232 | 
 | Async, int value using MessageBuffer, pattern: %m%n | 1876 ns | 1367 ns | 560000 | 
 | Async, int value using MessageBuffer, pattern: %m%n/threads:4 | 675 ns | 1694 ns | 617932 | 
