### PR TITLE
Reduce overhead of commonly used logging macros

### DIFF
--- a/src/main/cpp/level.cpp
+++ b/src/main/cpp/level.cpp
@@ -105,6 +105,22 @@ LevelPtr Level::toLevel(int val)
 	return toLevel(val, Level::getDebug());
 }
 
+const Level::Data& Level::getData()
+{
+	static Data data =
+		{ getOff()
+		, getFatal()
+		, getError()
+		, getWarn()
+		, getInfo()
+		, getDebug()
+		, getTrace()
+		, getAll()
+		};
+	return data;
+}
+
+
 LevelPtr Level::toLevel(int val, const LevelPtr& defaultLevel)
 {
 	switch (val)

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -44,7 +44,8 @@ struct Logger::LoggerPrivate
 		name(name1),
 		repositoryRaw(0),
 		aai(p),
-		additive(true) {}
+		additive(true),
+		levelData(Level::getData()) {}
 
 	/**
 	The name of this logger.
@@ -82,6 +83,8 @@ struct Logger::LoggerPrivate
 	        have their additivity flag set to <code>false</code> too. See
 	        the user manual for more details. */
 	bool additive;
+
+	const Level::Data& levelData;
 };
 
 IMPLEMENT_LOG4CXX_OBJECT(Logger)
@@ -166,6 +169,21 @@ void Logger::addEvent(const LevelPtr& level, std::string&& message, const Locati
 #endif
 	Pool p;
 	callAppenders(event, p);
+}
+
+void Logger::addInfoEvent(std::string&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Info, std::move(message), location);
+}
+
+void Logger::addDebugEvent(std::string&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Debug, std::move(message), location);
+}
+
+void Logger::addTraceEvent(std::string&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Trace, std::move(message), location);
 }
 
 void Logger::forcedLog(const LevelPtr& level, const std::string& message,
@@ -605,7 +623,7 @@ void Logger::trace(const std::string& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isTraceEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getTrace(), msg, location);
+		forcedLog(m_priv->levelData.Trace, msg, location);
 	}
 }
 
@@ -614,7 +632,7 @@ void Logger::trace(const std::string& msg) const
 {
 	if (isTraceEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getTrace(), msg);
+		forcedLog(m_priv->levelData.Trace, msg);
 	}
 }
 
@@ -622,7 +640,7 @@ void Logger::debug(const std::string& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isDebugEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getDebug(), msg, location);
+		forcedLog(m_priv->levelData.Debug, msg, location);
 	}
 }
 
@@ -630,7 +648,7 @@ void Logger::debug(const std::string& msg) const
 {
 	if (isDebugEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getDebug(), msg);
+		forcedLog(m_priv->levelData.Debug, msg);
 	}
 }
 
@@ -639,7 +657,7 @@ void Logger::error(const std::string& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isErrorEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getError(), msg, location);
+		forcedLog(m_priv->levelData.Error, msg, location);
 	}
 }
 
@@ -648,7 +666,7 @@ void Logger::error(const std::string& msg) const
 {
 	if (isErrorEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getError(), msg);
+		forcedLog(m_priv->levelData.Error, msg);
 	}
 }
 
@@ -656,7 +674,7 @@ void Logger::fatal(const std::string& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isFatalEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getFatal(), msg, location);
+		forcedLog(m_priv->levelData.Fatal, msg, location);
 	}
 }
 
@@ -664,7 +682,7 @@ void Logger::fatal(const std::string& msg) const
 {
 	if (isFatalEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getFatal(), msg);
+		forcedLog(m_priv->levelData.Fatal, msg);
 	}
 }
 
@@ -672,7 +690,7 @@ void Logger::info(const std::string& msg, const LOG4CXX_NS::spi::LocationInfo& l
 {
 	if (isInfoEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getInfo(), msg, location);
+		forcedLog(m_priv->levelData.Info, msg, location);
 	}
 }
 
@@ -680,7 +698,7 @@ void Logger::info(const std::string& msg) const
 {
 	if (isInfoEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getInfo(), msg);
+		forcedLog(m_priv->levelData.Info, msg);
 	}
 }
 
@@ -714,7 +732,7 @@ void Logger::warn(const std::string& msg, const LOG4CXX_NS::spi::LocationInfo& l
 {
 	if (isWarnEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getWarn(), msg, location);
+		forcedLog(m_priv->levelData.Warn, msg, location);
 	}
 }
 
@@ -722,7 +740,7 @@ void Logger::warn(const std::string& msg) const
 {
 	if (isWarnEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getWarn(), msg);
+		forcedLog(m_priv->levelData.Warn, msg);
 	}
 }
 
@@ -747,6 +765,21 @@ void Logger::addEvent(const LevelPtr& level, std::wstring&& message, const Locat
 #endif
 	Pool p;
 	callAppenders(event, p);
+}
+
+void Logger::addInfoEvent(std::wstring&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Info, std::move(message), location);
+}
+
+void Logger::addDebugEvent(std::wstring&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Debug, std::move(message), location);
+}
+
+void Logger::addTraceEvent(std::wstring&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Trace, std::move(message), location);
 }
 
 void Logger::forcedLog(const LevelPtr& level, const std::wstring& message,
@@ -788,7 +821,7 @@ void Logger::trace(const std::wstring& msg, const LOG4CXX_NS::spi::LocationInfo&
 {
 	if (isTraceEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getTrace(), msg, location);
+		forcedLog(m_priv->levelData.Trace, msg, location);
 	}
 }
 
@@ -797,7 +830,7 @@ void Logger::trace(const std::wstring& msg) const
 {
 	if (isTraceEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getTrace(), msg);
+		forcedLog(m_priv->levelData.Trace, msg);
 	}
 }
 
@@ -805,7 +838,7 @@ void Logger::debug(const std::wstring& msg, const LOG4CXX_NS::spi::LocationInfo&
 {
 	if (isDebugEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getDebug(), msg, location);
+		forcedLog(m_priv->levelData.Debug, msg, location);
 	}
 }
 
@@ -813,7 +846,7 @@ void Logger::debug(const std::wstring& msg) const
 {
 	if (isDebugEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getDebug(), msg);
+		forcedLog(m_priv->levelData.Debug, msg);
 	}
 }
 
@@ -821,7 +854,7 @@ void Logger::error(const std::wstring& msg, const LOG4CXX_NS::spi::LocationInfo&
 {
 	if (isErrorEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getError(), msg, location);
+		forcedLog(m_priv->levelData.Error, msg, location);
 	}
 }
 
@@ -829,7 +862,7 @@ void Logger::error(const std::wstring& msg) const
 {
 	if (isErrorEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getError(), msg);
+		forcedLog(m_priv->levelData.Error, msg);
 	}
 }
 
@@ -837,7 +870,7 @@ void Logger::fatal(const std::wstring& msg, const LOG4CXX_NS::spi::LocationInfo&
 {
 	if (isFatalEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getFatal(), msg, location);
+		forcedLog(m_priv->levelData.Fatal, msg, location);
 	}
 }
 
@@ -845,7 +878,7 @@ void Logger::fatal(const std::wstring& msg) const
 {
 	if (isFatalEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getFatal(), msg);
+		forcedLog(m_priv->levelData.Fatal, msg);
 	}
 }
 
@@ -853,7 +886,7 @@ void Logger::info(const std::wstring& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isInfoEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getInfo(), msg, location);
+		forcedLog(m_priv->levelData.Info, msg, location);
 	}
 }
 
@@ -861,7 +894,7 @@ void Logger::info(const std::wstring& msg) const
 {
 	if (isInfoEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getInfo(), msg);
+		forcedLog(m_priv->levelData.Info, msg);
 	}
 }
 
@@ -886,7 +919,7 @@ void Logger::warn(const std::wstring& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isWarnEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getWarn(), msg, location);
+		forcedLog(m_priv->levelData.Warn, msg, location);
 	}
 }
 
@@ -894,7 +927,7 @@ void Logger::warn(const std::wstring& msg) const
 {
 	if (isWarnEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getWarn(), msg);
+		forcedLog(m_priv->levelData.Warn, msg);
 	}
 }
 
@@ -910,6 +943,21 @@ void Logger::addEvent(const LevelPtr& level1, std::basic_string<UniChar>&& messa
 	auto event = std::make_shared<LoggingEvent>(m_priv->name, level1, location, std::move(msg));
 	Pool p;
 	callAppenders(event, p);
+}
+
+void Logger::addInfoEvent(std::basic_string<UniChar>&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Info, std::move(message), location);
+}
+
+void Logger::addDebugEvent(std::basic_string<UniChar>&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Debug, std::move(message), location);
+}
+
+void Logger::addTraceEvent(std::basic_string<UniChar>&& message, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData.Trace, std::move(message), location);
 }
 
 void Logger::forcedLog(const LevelPtr& level1, const std::basic_string<UniChar>& message,
@@ -948,7 +996,7 @@ void Logger::trace(const std::basic_string<UniChar>& msg, const LOG4CXX_NS::spi:
 {
 	if (isTraceEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getTrace(), msg, location);
+		forcedLog(m_priv->levelData.Trace, msg, location);
 	}
 }
 
@@ -957,7 +1005,7 @@ void Logger::trace(const std::basic_string<UniChar>& msg) const
 {
 	if (isTraceEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getTrace(), msg);
+		forcedLog(m_priv->levelData.Trace, msg);
 	}
 }
 
@@ -965,7 +1013,7 @@ void Logger::debug(const std::basic_string<UniChar>& msg, const LOG4CXX_NS::spi:
 {
 	if (isDebugEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getDebug(), msg, location);
+		forcedLog(m_priv->levelData.Debug, msg, location);
 	}
 }
 
@@ -973,7 +1021,7 @@ void Logger::debug(const std::basic_string<UniChar>& msg) const
 {
 	if (isDebugEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getDebug(), msg);
+		forcedLog(m_priv->levelData.Debug, msg);
 	}
 }
 
@@ -981,7 +1029,7 @@ void Logger::error(const std::basic_string<UniChar>& msg, const LOG4CXX_NS::spi:
 {
 	if (isErrorEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getError(), msg, location);
+		forcedLog(m_priv->levelData.Error, msg, location);
 	}
 }
 
@@ -989,7 +1037,7 @@ void Logger::error(const std::basic_string<UniChar>& msg) const
 {
 	if (isErrorEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getError(), msg);
+		forcedLog(m_priv->levelData.Error, msg);
 	}
 }
 
@@ -997,7 +1045,7 @@ void Logger::fatal(const std::basic_string<UniChar>& msg, const LOG4CXX_NS::spi:
 {
 	if (isFatalEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getFatal(), msg, location);
+		forcedLog(m_priv->levelData.Fatal, msg, location);
 	}
 }
 
@@ -1005,7 +1053,7 @@ void Logger::fatal(const std::basic_string<UniChar>& msg) const
 {
 	if (isFatalEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getFatal(), msg);
+		forcedLog(m_priv->levelData.Fatal, msg);
 	}
 }
 
@@ -1013,7 +1061,7 @@ void Logger::info(const std::basic_string<UniChar>& msg, const LOG4CXX_NS::spi::
 {
 	if (isInfoEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getInfo(), msg, location);
+		forcedLog(m_priv->levelData.Info, msg, location);
 	}
 }
 
@@ -1021,7 +1069,7 @@ void Logger::info(const std::basic_string<UniChar>& msg) const
 {
 	if (isInfoEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getInfo(), msg);
+		forcedLog(m_priv->levelData.Info, msg);
 	}
 }
 
@@ -1046,7 +1094,7 @@ void Logger::warn(const std::basic_string<UniChar>& msg, const LOG4CXX_NS::spi::
 {
 	if (isWarnEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getWarn(), msg, location);
+		forcedLog(m_priv->levelData.Warn, msg, location);
 	}
 }
 
@@ -1054,7 +1102,7 @@ void Logger::warn(const std::basic_string<UniChar>& msg) const
 {
 	if (isWarnEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getWarn(), msg);
+		forcedLog(m_priv->levelData.Warn, msg);
 	}
 }
 
@@ -1098,7 +1146,7 @@ void Logger::trace(const CFStringRef& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isTraceEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getTrace(), msg, location);
+		forcedLog(m_priv->levelData.Trace, msg, location);
 	}
 }
 
@@ -1107,7 +1155,7 @@ void Logger::trace(const CFStringRef& msg) const
 {
 	if (isTraceEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getTrace(), msg);
+		forcedLog(m_priv->levelData.Trace, msg);
 	}
 }
 
@@ -1115,7 +1163,7 @@ void Logger::debug(const CFStringRef& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isDebugEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getDebug(), msg, location);
+		forcedLog(m_priv->levelData.Debug, msg, location);
 	}
 }
 
@@ -1123,7 +1171,7 @@ void Logger::debug(const CFStringRef& msg) const
 {
 	if (isDebugEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getDebug(), msg);
+		forcedLog(m_priv->levelData.Debug, msg);
 	}
 }
 
@@ -1131,7 +1179,7 @@ void Logger::error(const CFStringRef& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isErrorEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getError(), msg, location);
+		forcedLog(m_priv->levelData.Error, msg, location);
 	}
 }
 
@@ -1139,7 +1187,7 @@ void Logger::error(const CFStringRef& msg) const
 {
 	if (isErrorEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getError(), msg);
+		forcedLog(m_priv->levelData.Error, msg);
 	}
 }
 
@@ -1147,7 +1195,7 @@ void Logger::fatal(const CFStringRef& msg, const LOG4CXX_NS::spi::LocationInfo& 
 {
 	if (isFatalEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getFatal(), msg, location);
+		forcedLog(m_priv->levelData.Fatal, msg, location);
 	}
 }
 
@@ -1155,7 +1203,7 @@ void Logger::fatal(const CFStringRef& msg) const
 {
 	if (isFatalEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getFatal(), msg);
+		forcedLog(m_priv->levelData.Fatal, msg);
 	}
 }
 
@@ -1163,7 +1211,7 @@ void Logger::info(const CFStringRef& msg, const LOG4CXX_NS::spi::LocationInfo& l
 {
 	if (isInfoEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getInfo(), msg, location);
+		forcedLog(m_priv->levelData.Info, msg, location);
 	}
 }
 
@@ -1171,7 +1219,7 @@ void Logger::info(const CFStringRef& msg) const
 {
 	if (isInfoEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getInfo(), msg);
+		forcedLog(m_priv->levelData.Info, msg);
 	}
 }
 
@@ -1196,7 +1244,7 @@ void Logger::warn(const CFStringRef& msg, const LOG4CXX_NS::spi::LocationInfo& l
 {
 	if (isWarnEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getWarn(), msg, location);
+		forcedLog(m_priv->levelData.Warn, msg, location);
 	}
 }
 
@@ -1204,7 +1252,7 @@ void Logger::warn(const CFStringRef& msg) const
 {
 	if (isWarnEnabled())
 	{
-		forcedLog(LOG4CXX_NS::Level::getWarn(), msg);
+		forcedLog(m_priv->levelData.Warn, msg);
 	}
 }
 

--- a/src/main/include/log4cxx/level.h
+++ b/src/main/include/log4cxx/level.h
@@ -218,7 +218,19 @@ class LOG4CXX_EXPORT Level : public helpers::Object
 			ALL_INT = INT_MIN
 		};
 
+		struct Data
+		{
+			LevelPtr Off;
+			LevelPtr Fatal;
+			LevelPtr Error;
+			LevelPtr Warn;
+			LevelPtr Info;
+			LevelPtr Debug;
+			LevelPtr Trace;
+			LevelPtr All;
+		};
 
+		static const Data& getData();
 		static LevelPtr getAll();
 		static LevelPtr getFatal();
 		static LevelPtr getError();

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -507,6 +507,30 @@ class LOG4CXX_EXPORT Logger :
 			, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
 
 		/**
+		Add a new info level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addInfoEvent(std::string&& message, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+
+		/**
+		Add a new debug level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addDebugEvent(std::string&& message, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+
+		/**
+		Add a new trace level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addTraceEvent(std::string&& message, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+
+		/**
 		Add a new logging event containing \c message and \c location to attached appender(s).
 		without further checks.
 		@param level The logging event level.
@@ -535,6 +559,30 @@ class LOG4CXX_EXPORT Logger :
 			, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
 
 		/**
+		Add a new info level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addInfoEvent(std::wstring&& message, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+
+		/**
+		Add a new debug level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addDebugEvent(std::wstring&& message, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+
+		/**
+		Add a new trace level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addTraceEvent(std::wstring&& message, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+
+		/**
 		Add a new logging event containing \c message and \c location to attached appender(s).
 		without further checks.
 		@param level The logging event level.
@@ -561,6 +609,28 @@ class LOG4CXX_EXPORT Logger :
 		*/
 		void addEvent(const LevelPtr& level, std::basic_string<UniChar>&& message,
 			const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+		/**
+		Add a new info level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addInfoEvent(std::basic_string<UniChar>&& message,const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+		/**
+		Add a new debug level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addDebugEvent(std::basic_string<UniChar>&& message,const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+		/**
+		Add a new trace level logging event containing \c message and \c location to attached appender(s).
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addTraceEvent(std::basic_string<UniChar>&& message,const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+
 		/**
 		Add a new logging event containing \c message and \c location to attached appender(s).
 		without further checks.
@@ -1030,7 +1100,7 @@ class LOG4CXX_EXPORT Logger :
 		 *  <p>By writing
 		 *  ~~~{.cpp}
 		 *    if(log4cxx::Logger::isDebugEnabledFor(logger)) {
-		 *      logger->addEvent(log4cxx::Level::getDebug(), "Component: " + std::to_string(componentNumber));
+		 *      logger->addDebugEvent("Component: " + std::to_string(componentNumber));
 		 *    }
 		 *  ~~~
 		 *  you minimise the computational cost
@@ -2075,7 +2145,7 @@ LOG4CXX_DEBUG(m_log, "AddMesh:"
 #define LOG4CXX_DEBUG(logger, message) do { \
 		if (LOG4CXX_UNLIKELY(::LOG4CXX_NS::Logger::isDebugEnabledFor(logger))) {\
 			::LOG4CXX_NS::helpers::MessageBuffer oss_; \
-			logger->addEvent(::LOG4CXX_NS::Level::getDebug(), oss_.extract_str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
+			logger->addDebugEvent(oss_.extract_str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
 Add a new logging event containing a message defined by \c fmt and <code>...</code> to attached appender(s) if \c logger is enabled for <code>DEBUG</code> events.
@@ -2098,7 +2168,7 @@ LOG4CXX_DEBUG_FMT(m_log, "AddMesh: name {} type 0x{x} materialName {} visible? {
 */
 #define LOG4CXX_DEBUG_FMT(logger, fmt, ...) do { \
 		if (LOG4CXX_UNLIKELY(::LOG4CXX_NS::Logger::isDebugEnabledFor(logger))) {\
-			logger->addEvent(::LOG4CXX_NS::Level::getDebug(), ::LOG4CXX_FORMAT_NS::format(fmt, __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
+			logger->addDebugEvent(::LOG4CXX_FORMAT_NS::format(fmt, __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 #else
 #define LOG4CXX_DEBUG(logger, message)
 #define LOG4CXX_DEBUG_FMT(logger, fmt, ...)
@@ -2119,7 +2189,7 @@ Add a new logging event containing \c message to attached appender(s) if \c logg
 #define LOG4CXX_TRACE(logger, message) do { \
 		if (LOG4CXX_UNLIKELY(::LOG4CXX_NS::Logger::isTraceEnabledFor(logger))) {\
 			::LOG4CXX_NS::helpers::MessageBuffer oss_; \
-			logger->addEvent(::LOG4CXX_NS::Level::getTrace(), oss_.extract_str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
+			logger->addTraceEvent(oss_.extract_str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
 Add a new logging event containing a message defined by \c fmt and <code>...</code> to attached appender(s) if \c logger is enabled for <code>TRACE</code> events.
@@ -2135,7 +2205,7 @@ Add a new logging event containing a message defined by \c fmt and <code>...</co
 */
 #define LOG4CXX_TRACE_FMT(logger, fmt, ...) do { \
 		if (LOG4CXX_UNLIKELY(::LOG4CXX_NS::Logger::isTraceEnabledFor(logger))) {\
-			logger->addEvent(::LOG4CXX_NS::Level::getTrace(), ::LOG4CXX_FORMAT_NS::format(fmt, __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
+			logger->addTraceEvent(::LOG4CXX_FORMAT_NS::format(fmt, __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 #else
 #define LOG4CXX_TRACE(logger, message)
 #define LOG4CXX_TRACE_FMT(logger, fmt, ...)
@@ -2161,7 +2231,7 @@ LOG4CXX_INFO(m_log, surface->GetName()
 #define LOG4CXX_INFO(logger, message) do { \
 		if (::LOG4CXX_NS::Logger::isInfoEnabledFor(logger)) {\
 			::LOG4CXX_NS::helpers::MessageBuffer oss_; \
-			logger->addEvent(::LOG4CXX_NS::Level::getInfo(), oss_.extract_str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
+			logger->addInfoEvent(oss_.extract_str(oss_ << message), LOG4CXX_LOCATION); }} while (0)
 
 /**
 Add a new logging event containing a message defined by \c fmt and <code>...</code> to attached appender(s) if \c logger is enabled for <code>INFO</code> events.
@@ -2181,7 +2251,7 @@ LOG4CXX_INFO_FMT(m_log, "{} successfully planned {:.1f}% planned area {:.4f}m^2 
 */
 #define LOG4CXX_INFO_FMT(logger, fmt, ...) do { \
 		if (::LOG4CXX_NS::Logger::isInfoEnabledFor(logger)) {\
-			logger->addEvent(::LOG4CXX_NS::Level::getInfo(), ::LOG4CXX_FORMAT_NS::format(fmt, __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
+			logger->addInfoEvent(::LOG4CXX_FORMAT_NS::format(fmt, __VA_ARGS__ ), LOG4CXX_LOCATION); }} while (0)
 #else
 #define LOG4CXX_INFO(logger, message)
 #define LOG4CXX_INFO_FMT(logger, fmt, ...)


### PR DESCRIPTION
The function scope static variable access in `Level::getInfo() `etc has unnecessary overhead (10% of logging a message on Windows). 

The new benchmarks for Ubuntu gcc 11 are:

| Benchmark | Time | CPU | Iterations | 
 | -------- | ------ | ------ | ------- | 
 | Testing disabled logging request | 0.472 ns | 0.472 ns | 1000000000 | 
 | Testing disabled logging request/threads:16 | 0.094 ns | 1.01 ns | 676137360 | 
 | Logging 5 char string using MessageBuffer, pattern: %m%n | 300 ns | 300 ns | 2327642 | 
 | Logging 5 char string using MessageBuffer, pattern: %m%n/threads:16 | 511 ns | 4127 ns | 173408 | 
 | Logging 49 char string using MessageBuffer, pattern: %m%n | 321 ns | 321 ns | 2163479 | 
 | Logging 49 char string using MessageBuffer, pattern: %m%n/threads:16 | 500 ns | 4030 ns | 166160 | 
 | Logging int value using MessageBuffer, pattern: %m%n | 512 ns | 512 ns | 1474939 | 
 | Logging int value using MessageBuffer, pattern: %m%n/threads:16 | 449 ns | 3666 ns | 165344 | 
 | Logging int+float using MessageBuffer, pattern: %m%n | 975 ns | 975 ns | 718422 | 
 | Logging int+float using MessageBuffer, pattern: %m%n/threads:16 | 534 ns | 4401 ns | 176896 | 
 | Logging int value using MessageBuffer, pattern: [%d] %m%n | 518 ns | 518 ns | 1348124 | 
 | Logging int value using MessageBuffer, pattern: [%d] [%c] [%p] %m%n | 520 ns | 520 ns | 1333224 | 
 | Logging 49 char string using FMT, pattern: %m%n | 314 ns | 314 ns | 2237700 | 
 | Logging 49 char string using FMT, pattern: %m%n/threads:16 | 448 ns | 3624 ns | 206080 | 
 | Logging int value using FMT, pattern: %m%n | 313 ns | 313 ns | 2235338 | 
 | Logging int value using FMT, pattern: %m%n/threads:16 | 380 ns | 3039 ns | 239872 | 
 | Logging int+float using FMT, pattern: %m%n | 463 ns | 463 ns | 1509341 | 
 | Logging int+float using FMT, pattern: %m%n/threads:16 | 487 ns | 3924 ns | 208816 | 
 | Async, int value using MessageBuffer, pattern: %m%n | 510 ns | 510 ns | 1484667 | 
 | Async, int value using MessageBuffer, pattern: %m%n/threads:16 | 440 ns | 3579 ns | 193056 | 
