### PR TITLE
Fix compilation errors in the next ABI version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,10 @@ set(LOG4CXX_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 # Note that the lib version is different from the SOVERSION
 # The lib version is the version of log4cxx, the SOVERSION is the ABI version
 # See also: https://cmake.org/pipermail/cmake/2012-September/051904.html
-set(log4cxx_ABI_VER 15)
+set(current_log4cxx_ABI_VER 15)
 set(next_log4cxx_ABI_VER 16)
-set(log4cxx_ABI_VER "${log4cxx_ABI_VER}" CACHE STRING "The DSO library version")
-set_property(CACHE log4cxx_ABI_VER PROPERTY STRINGS "${log4cxx_ABI_VER}" "${next_log4cxx_ABI_VER}")
+set(log4cxx_ABI_VER "${current_log4cxx_ABI_VER}" CACHE STRING "The DSO library version")
+set_property(CACHE log4cxx_ABI_VER PROPERTY STRINGS "${current_log4cxx_ABI_VER}" "${next_log4cxx_ABI_VER}")
 set(LIBLOG4CXX_LIB_VERSION ${log4cxx_ABI_VER}.${log4cxx_VERSION_MINOR}.${log4cxx_VERSION_PATCH})
 set(LIBLOG4CXX_LIB_SOVERSION ${log4cxx_ABI_VER})
 # Set the 'release' version.  This is the human-readable version

--- a/src/main/include/log4cxx/spi/configurator.h
+++ b/src/main/include/log4cxx/spi/configurator.h
@@ -39,6 +39,11 @@ class LOG4CXX_EXPORT Configurator : virtual public helpers::Object
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(Configurator)
+#if 15 < LOG4CXX_ABI_VERSION
+		BEGIN_LOG4CXX_CAST_MAP()
+		LOG4CXX_CAST_ENTRY(Configurator)
+		END_LOG4CXX_CAST_MAP()
+#endif
 
 		/**
 		Interpret a resource pointed by a URL and set up log4j accordingly.

--- a/src/main/include/log4cxx/spi/loggerrepository.h
+++ b/src/main/include/log4cxx/spi/loggerrepository.h
@@ -43,6 +43,11 @@ class LOG4CXX_EXPORT LoggerRepository : public virtual helpers::Object
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(LoggerRepository)
+#if 15 < LOG4CXX_ABI_VERSION
+		BEGIN_LOG4CXX_CAST_MAP()
+		LOG4CXX_CAST_ENTRY(LoggerRepository)
+		END_LOG4CXX_CAST_MAP()
+#endif
 		virtual ~LoggerRepository() {}
 
 		/**


### PR DESCRIPTION
This PR also corrects a cmake issue caused by using the same name for a non-cache variable and a cache variable.