### PR TITLE
Use GCC recommended symbol visibility in the next ABI version

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -20,6 +20,9 @@ option(LOG4CXX_ABI_CHECK "Check for ABI changes" OFF)
 
 # Build the log4cxx library
 add_library(log4cxx)
+if(${log4cxx_ABI_VER} GREATER 15)
+  set_target_properties(log4cxx PROPERTIES CXX_VISIBILITY_PRESET hidden)
+endif()
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(log4cxx PRIVATE LOG4CXX)
 else()

--- a/src/main/include/log4cxx/log4cxx.h.in
+++ b/src/main/include/log4cxx/log4cxx.h.in
@@ -95,9 +95,11 @@ __pragma( warning( pop ) )
 #else                          // Linking against a DLL?
 #define LOG4CXX_EXPORT __declspec(dllimport)
 #endif // !LOG4CXX_STATIC
-#else // !defined(_WIN32) || !defined(_MSC_VER)
-#define LOG4CXX_EXPORT
-#endif // !defined(_WIN32) || !defined(_MSC_VER)
+#elif defined(__GNUC__) && 4 <= __GNUC__ && 15 < LOG4CXX_ABI_VERSION
+  #define LOG4CXX_EXPORT __attribute__ ((visibility ("default")))
+#else // !(defined(_WIN32) && defined(_MSC_VER)) || LOG4CXX_ABI_VERSION <= 15 || __GNUC__ < 4
+  #define LOG4CXX_EXPORT
+#endif
 
 #define LOG4CXX_NS @LOG4CXX_NS@
 


### PR DESCRIPTION
This PR will reduce the number of exported log4cxx symbols to 5509 from 6737 and reduces other exported symbols to 67 from 108 (in liblog4cxx.so).