### PR TITLE
Support --benchmark_format=json/csv for benchmark comparison

### DIFF
--- a/src/test/cpp/benchmark/benchmark.cpp
+++ b/src/test/cpp/benchmark/benchmark.cpp
@@ -75,8 +75,8 @@ public:
 
 	void SetUp(const ::benchmark::State& state)
 	{
-		std::setlocale( LC_ALL, "" ); /* Set locale for C functions */
-		std::locale::global(std::locale("")); /* set locale for C++ functions */
+		std::setlocale( LC_ALL, "C" ); /* Set locale for C functions */
+		std::locale::global(std::locale("C")); /* set locale for C++ functions */
 		SetupLogger();
 	}
 


### PR DESCRIPTION
Google benchmark does not prevent insertion of a thousand separator character when writing JSON or csv reports.