### PR TITLE
Reduce the overhead of unconfigured loggers

### DIFF
--- a/src/main/cpp/appenderattachableimpl.cpp
+++ b/src/main/cpp/appenderattachableimpl.cpp
@@ -137,7 +137,6 @@ void AppenderAttachableImpl::removeAllAppenders()
 		std::lock_guard<std::mutex> lock( m_priv->m_mutex );
 		m_priv->appenderList.clear();
 	}
-	m_priv.reset();
 }
 
 void AppenderAttachableImpl::removeAppender(const AppenderPtr appender)


### PR DESCRIPTION
AppenderAttachableImpl::appendLoopOnAppenders does not need to lock a mutex for any Logger in the path to the root Logger which has no appenders attached (This partly addressed #347).