### PR TITLE
Improve benchmark correctness by avoiding side effects

### DIFF
--- a/src/test/cpp/benchmark/benchmark.cpp
+++ b/src/test/cpp/benchmark/benchmark.cpp
@@ -103,16 +103,15 @@ public: // Class methods
 
 	static LoggerPtr getLogger(const LogString& pattern = LogString())
 	{
+		LogString name = LOG4CXX_STR("benchmark.fixture");
 		LoggerPtr result;
 		setDefaultAppender();
 		auto r = LogManager::getLoggerRepository();
 		if (pattern.empty())
-			result = r->getLogger(LOG4CXX_STR("benchmark.fixture"));
-		else if (r->exists(LOG4CXX_STR("benchmark.fixture.") + pattern))
-			result = r->getLogger(LOG4CXX_STR("benchmark.fixture.") + pattern);
-		else
+			result = r->getLogger(name);
+		else if (!(result = r->exists(name += LOG4CXX_STR(".") + pattern)))
 		{
-			result = r->getLogger(LOG4CXX_STR("benchmark.fixture.") + pattern);
+			result = r->getLogger(name);
 			result->setAdditivity(false);
 			result->setLevel(Level::getInfo());
 			auto nullWriter = std::make_shared<NullWriterAppender>(std::make_shared<PatternLayout>(pattern));
@@ -124,13 +123,11 @@ public: // Class methods
 
 	static LoggerPtr getAsyncLogger()
 	{
-		LoggerPtr result;
+		LogString name = LOG4CXX_STR("benchmark.fixture.async");
 		setDefaultAppender();
 		auto r = LogManager::getLoggerRepository();
-		LogString name = LOG4CXX_STR("benchmark.fixture.async");
-		if (r->exists(name))
-			result = r->getLogger(name);
-		else
+		LoggerPtr result = r->exists(name);
+		if (!result)
 		{
 			auto nullWriter = r->getRootLogger()->getAppender(LOG4CXX_STR("NullWriterAppender"));
 			auto asyncAppender = std::make_shared<AsyncAppender>();

--- a/src/test/cpp/benchmark/benchmark.cpp
+++ b/src/test/cpp/benchmark/benchmark.cpp
@@ -132,7 +132,6 @@ public: // Class methods
 			auto nullWriter = r->getRootLogger()->getAppender(LOG4CXX_STR("NullWriterAppender"));
 			auto asyncAppender = std::make_shared<AsyncAppender>();
 			asyncAppender->addAppender(nullWriter);
-			asyncAppender->setBufferSize(5);
 			result = r->getLogger(name);
 			result->setAdditivity(false);
 			result->setLevel(Level::getInfo());


### PR DESCRIPTION
Before this PR, the values reported as "Async, int value using MessageBuffer" were incorrect (did not use AsyncAppender).

Also, the layout pattern in the check name was not reliable when using a single logger name.

The correct measurements for AsyncAppender on Windows are:
 | Benchmark | Time | CPU | Iterations | 
 | -------- | ----- | ----- | ----- | 
 | Async, int value using MessageBuffer, pattern: %m%n | 2747 ns | 907 ns | 1120000 | 
 | Async, int value using MessageBuffer, pattern: %m%n/threads:4 | 937 ns | 1397 ns | 995556 | 

on Ubuntu gcc 12:
 | Benchmark | Time | CPU | Iterations | 
 | -------- | ----- | ----- | ----- | 
 | Async, int value using MessageBuffer, pattern: %m%n | 1296 ns | 1270 ns | 549479 | 
 | Async, int value using MessageBuffer, pattern: %m%n/threads:4 | 759 ns | 2259 ns | 296168 | 
