### PR TITLE
Improve utility of benchmark checks

### DIFF
--- a/src/test/cpp/benchmark/benchmark.cpp
+++ b/src/test/cpp/benchmark/benchmark.cpp
@@ -5,6 +5,9 @@
 #include <log4cxx/helpers/optionconverter.h>
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/asyncappender.h>
+#include <log4cxx/net/smtpappender.h>
+#include <log4cxx/fileappender.h>
+#include <log4cxx/private/appenderskeleton_priv.h>
 #if LOG4CXX_USING_STD_FORMAT
 #include <format>
 #elif LOG4CXX_HAS_FMT
@@ -20,17 +23,10 @@ using namespace log4cxx;
 class NullWriterAppender : public AppenderSkeleton
 {
 public:
-	DECLARE_LOG4CXX_OBJECT(NullWriterAppender)
-	BEGIN_LOG4CXX_CAST_MAP()
-	LOG4CXX_CAST_ENTRY(NullWriterAppender)
-	LOG4CXX_CAST_ENTRY_CHAIN(AppenderSkeleton)
-	END_LOG4CXX_CAST_MAP()
-
-	NullWriterAppender() {}
-
 	NullWriterAppender(const LayoutPtr& layout)
-		: AppenderSkeleton(layout)
-	{}
+	{
+		setLayout(layout);
+	}
 
 	void close() override {}
 
@@ -41,16 +37,31 @@ public:
 
 	void append(const spi::LoggingEventPtr& event, helpers::Pool& p) override
 	{
-		// This gets called whenever there is a valid event for our appender.
+		LogString buf;
+		m_priv->layout->format(buf, event, p);
 	}
 
 	void activateOptions(helpers::Pool& /* pool */) override
 	{
-		// Given all of our options, do something useful(e.g. open a file)
 	}
 
 	void setOption(const LogString& option, const LogString& value) override
 	{
+	}
+};
+
+class BenchmarkFileAppender : public FileAppender
+{
+public:
+	BenchmarkFileAppender(const LayoutPtr& layout)
+	{
+		setLayout(layout);
+		auto tempDir = helpers::OptionConverter::getSystemProperty(LOG4CXX_STR("TEMP"), LOG4CXX_STR("/tmp"));
+		setFile(tempDir + LOG4CXX_STR("/") + LOG4CXX_STR("benchmark.log"));
+		setAppend(false);
+		setBufferedIO(true);
+		helpers::Pool p;
+		activateOptions(p);
 	}
 };
 
@@ -60,13 +71,12 @@ void disableThousandSeparatorsInJSON()
 	std::locale::global(std::locale("C")); /* set locale for C++ functions */
 }
 
-IMPLEMENT_LOG4CXX_OBJECT(NullWriterAppender)
-
 class benchmarker : public ::benchmark::Fixture
 {
 public: // Attributes
 	LoggerPtr m_logger = getLogger();
 	LoggerPtr m_asyncLogger = getAsyncLogger();
+	LoggerPtr m_fileLogger = getFileLogger();
 
 public: // Class methods
 	static int threadCount()
@@ -95,9 +105,9 @@ public: // Class methods
 		r->ensureIsConfigured([r]()
 			{
 			disableThousandSeparatorsInJSON();
-			auto nullWriter = std::make_shared<NullWriterAppender>(std::make_shared<PatternLayout>(LOG4CXX_STR("%m%n")));
-			nullWriter->setName(LOG4CXX_STR("NullWriterAppender"));
-			r->getRootLogger()->addAppender(nullWriter);
+			auto writer = std::make_shared<NullWriterAppender>(std::make_shared<PatternLayout>(LOG4CXX_STR("%m%n")));
+			writer->setName(LOG4CXX_STR("NullAppender"));
+			r->getRootLogger()->addAppender(writer);
 			});
 	}
 
@@ -114,9 +124,9 @@ public: // Class methods
 			result = r->getLogger(name);
 			result->setAdditivity(false);
 			result->setLevel(Level::getInfo());
-			auto nullWriter = std::make_shared<NullWriterAppender>(std::make_shared<PatternLayout>(pattern));
-			nullWriter->setName(LOG4CXX_STR("NullWriterAppender.") + pattern);
-			result->addAppender(nullWriter);
+			auto writer = std::make_shared<NullWriterAppender>(std::make_shared<PatternLayout>(pattern));
+			writer->setName(LOG4CXX_STR("NullAppender.") + pattern);
+			result->addAppender(writer);
 		}
 		return result;
 	}
@@ -129,13 +139,33 @@ public: // Class methods
 		LoggerPtr result = r->exists(name);
 		if (!result)
 		{
-			auto nullWriter = r->getRootLogger()->getAppender(LOG4CXX_STR("NullWriterAppender"));
+			auto writer = std::make_shared<net::SMTPAppender>();
+			writer->setLayout(std::make_shared<PatternLayout>(LOG4CXX_STR("%m%n")));
 			auto asyncAppender = std::make_shared<AsyncAppender>();
-			asyncAppender->addAppender(nullWriter);
+			asyncAppender->addAppender(writer);
+			asyncAppender->setBlocking(true);
 			result = r->getLogger(name);
 			result->setAdditivity(false);
 			result->setLevel(Level::getInfo());
 			result->addAppender(asyncAppender);
+		}
+		return result;
+	}
+
+	static LoggerPtr getFileLogger()
+	{
+		LogString name = LOG4CXX_STR("benchmark.fixture.file");
+		setDefaultAppender();
+		auto r = LogManager::getLoggerRepository();
+		LoggerPtr result;
+		if (!(result = r->exists(name)))
+		{
+			result = r->getLogger(name);
+			result->setAdditivity(false);
+			result->setLevel(Level::getInfo());
+			auto writer = std::make_shared<BenchmarkFileAppender>(std::make_shared<PatternLayout>(LOG4CXX_STR("%m%n")));
+			writer->setName(LOG4CXX_STR("FileAppender"));
+			result->addAppender(writer);
 		}
 		return result;
 	}
@@ -160,8 +190,8 @@ BENCHMARK_DEFINE_F(benchmarker, logShortString)(benchmark::State& state)
 		LOG4CXX_INFO(m_logger, LOG4CXX_STR("Hello"));
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, logShortString)->Name("Logging 5 char string using MessageBuffer, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, logShortString)->Name("Logging 5 char string using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, logShortString)->Name("Appending 5 char string using MessageBuffer, pattern: %m%n");
+BENCHMARK_REGISTER_F(benchmarker, logShortString)->Name("Appending 5 char string using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
 
 BENCHMARK_DEFINE_F(benchmarker, logLongString)(benchmark::State& state)
 {
@@ -171,8 +201,8 @@ BENCHMARK_DEFINE_F(benchmarker, logLongString)(benchmark::State& state)
 		LOG4CXX_INFO( m_logger, LOG4CXX_STR("Hello: this is a long static string message"));
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, logLongString)->Name("Logging 49 char string using MessageBuffer, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, logLongString)->Name("Logging 49 char string using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, logLongString)->Name("Appending 49 char string using MessageBuffer, pattern: %m%n");
+BENCHMARK_REGISTER_F(benchmarker, logLongString)->Name("Appending 49 char string using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
 
 BENCHMARK_DEFINE_F(benchmarker, logIntValueMessageBuffer)(benchmark::State& state)
 {
@@ -182,8 +212,8 @@ BENCHMARK_DEFINE_F(benchmarker, logIntValueMessageBuffer)(benchmark::State& stat
 		LOG4CXX_INFO( m_logger, "Hello: message number " << ++x);
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, logIntValueMessageBuffer)->Name("Logging int value using MessageBuffer, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, logIntValueMessageBuffer)->Name("Logging int value using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, logIntValueMessageBuffer)->Name("Appending int value using MessageBuffer, pattern: %m%n");
+BENCHMARK_REGISTER_F(benchmarker, logIntValueMessageBuffer)->Name("Appending int value using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
 
 BENCHMARK_DEFINE_F(benchmarker, logIntPlusFloatMessageBuffer)(benchmark::State& state)
 {
@@ -195,8 +225,8 @@ BENCHMARK_DEFINE_F(benchmarker, logIntPlusFloatMessageBuffer)(benchmark::State& 
 			<< " pseudo-random float " << std::setprecision(3) << std::fixed << f);
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, logIntPlusFloatMessageBuffer)->Name("Logging int+float using MessageBuffer, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, logIntPlusFloatMessageBuffer)->Name("Logging int+float using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, logIntPlusFloatMessageBuffer)->Name("Appending int+float using MessageBuffer, pattern: %m%n");
+BENCHMARK_REGISTER_F(benchmarker, logIntPlusFloatMessageBuffer)->Name("Appending int+float using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
 
 template <class ...Args>
 void logWithConversionPattern(benchmark::State& state, Args&&... args)
@@ -210,8 +240,8 @@ void logWithConversionPattern(benchmark::State& state, Args&&... args)
 		LOG4CXX_INFO( logger, LOG4CXX_STR("Hello: msg number ") << ++x);
 	}
 }
-BENCHMARK_CAPTURE(logWithConversionPattern, DateMessage, LOG4CXX_STR("[%d] %m%n"))->Name("Logging int value using MessageBuffer, pattern: [%d] %m%n");
-BENCHMARK_CAPTURE(logWithConversionPattern, DateClassLevelMessage, LOG4CXX_STR("[%d] [%c] [%p] %m%n"))->Name("Logging int value using MessageBuffer, pattern: [%d] [%c] [%p] %m%n");
+BENCHMARK_CAPTURE(logWithConversionPattern, DateMessage, LOG4CXX_STR("[%d] %m%n"))->Name("Appending int value using MessageBuffer, pattern: [%d] %m%n");
+BENCHMARK_CAPTURE(logWithConversionPattern, DateClassLevelMessage, LOG4CXX_STR("[%d] [%c] [%p] %m%n"))->Name("Appending int value using MessageBuffer, pattern: [%d] [%c] [%p] %m%n");
 
 #if  LOG4CXX_USING_STD_FORMAT || LOG4CXX_HAS_FMT
 BENCHMARK_DEFINE_F(benchmarker, logLongStringFMT)(benchmark::State& state)
@@ -221,8 +251,8 @@ BENCHMARK_DEFINE_F(benchmarker, logLongStringFMT)(benchmark::State& state)
 		LOG4CXX_INFO_FMT(m_logger, "Hello: this is a long static string message", 0);
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, logLongStringFMT)->Name("Logging 49 char string using FMT, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, logLongStringFMT)->Name("Logging 49 char string using FMT, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, logLongStringFMT)->Name("Appending 49 char string using FMT, pattern: %m%n");
+BENCHMARK_REGISTER_F(benchmarker, logLongStringFMT)->Name("Appending 49 char string using FMT, pattern: %m%n")->Threads(benchmarker::threadCount());
 
 BENCHMARK_DEFINE_F(benchmarker, logIntValueFMT)(benchmark::State& state)
 {
@@ -232,8 +262,8 @@ BENCHMARK_DEFINE_F(benchmarker, logIntValueFMT)(benchmark::State& state)
 		LOG4CXX_INFO_FMT(m_logger, "Hello: msg number {}", ++x);
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, logIntValueFMT)->Name("Logging int value using FMT, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, logIntValueFMT)->Name("Logging int value using FMT, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, logIntValueFMT)->Name("Appending int value using FMT, pattern: %m%n");
+BENCHMARK_REGISTER_F(benchmarker, logIntValueFMT)->Name("Appending int value using FMT, pattern: %m%n")->Threads(benchmarker::threadCount());
 
 BENCHMARK_DEFINE_F(benchmarker, logIntPlusFloatValueFMT)(benchmark::State& state)
 {
@@ -244,20 +274,35 @@ BENCHMARK_DEFINE_F(benchmarker, logIntPlusFloatValueFMT)(benchmark::State& state
 		LOG4CXX_INFO_FMT(m_logger, "Hello: msg number {} pseudo-random float {:.3f}", ++x, f);
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, logIntPlusFloatValueFMT)->Name("Logging int+float using FMT, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, logIntPlusFloatValueFMT)->Name("Logging int+float using FMT, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, logIntPlusFloatValueFMT)->Name("Appending int+float using FMT, pattern: %m%n");
+BENCHMARK_REGISTER_F(benchmarker, logIntPlusFloatValueFMT)->Name("Appending int+float using FMT, pattern: %m%n")->Threads(benchmarker::threadCount());
 #endif
 
-BENCHMARK_DEFINE_F(benchmarker, asyncIntValueMessageBuffer)(benchmark::State& state)
+BENCHMARK_DEFINE_F(benchmarker, asyncIntPlusFloatValueMessageBuffer)(benchmark::State& state)
 {
 	int x = 0;
 	for (auto _ : state)
 	{
-		LOG4CXX_INFO( m_asyncLogger, "Hello: message number " << ++x);
+		auto f = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+		LOG4CXX_INFO( m_logger, "Hello: message number " << ++x
+			<< " pseudo-random float " << std::setprecision(3) << std::fixed << f);
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, asyncIntValueMessageBuffer)->Name("Async, int value using MessageBuffer, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, asyncIntValueMessageBuffer)->Name("Async, int value using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, asyncIntPlusFloatValueMessageBuffer)->Name("Async, Sending int+float using MessageBuffer");
+BENCHMARK_REGISTER_F(benchmarker, asyncIntPlusFloatValueMessageBuffer)->Name("Async, Sending int+float using MessageBuffer")->Threads(benchmarker::threadCount());
+
+BENCHMARK_DEFINE_F(benchmarker, fileIntPlusFloatValueMessageBuffer)(benchmark::State& state)
+{
+	int x = 0;
+	for (auto _ : state)
+	{
+		auto f = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+		LOG4CXX_INFO( m_logger, "Hello: message number " << ++x
+			<< " pseudo-random float " << std::setprecision(3) << std::fixed << f);
+	}
+}
+BENCHMARK_REGISTER_F(benchmarker, fileIntPlusFloatValueMessageBuffer)->Name("Logging int+float using MessageBuffer, pattern: %m%n");
+BENCHMARK_REGISTER_F(benchmarker, fileIntPlusFloatValueMessageBuffer)->Name("Logging int+float using MessageBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
 
 BENCHMARK_MAIN();
 


### PR DESCRIPTION
This PR fixes the following issues with benchmark checks:
- the PatternLayout::format method was not called
- a check for writing logging messages to a file was not included
- check descriptions did not clearly indicate no data was written
- the AsyncAppender time values included some blocking duration on a full buffer due to the excessive rate logging events were added.
