### PR TITLE
Use a compile-time evaluated LocationInfo::calcShortFileName implementation

### DIFF
--- a/src/main/cpp/locationinfo.cpp
+++ b/src/main/cpp/locationinfo.cpp
@@ -45,9 +45,9 @@ LocationInfo::LocationInfo( const char* const fileName1,
 	const char* const methodName1,
 	int lineNumber1 )
 	:  lineNumber( lineNumber1 ),
-	   fileName( fileName1 ),
-	   shortFileName(shortFileName1),
-	   methodName( methodName1 )
+	   fileName( fileName1 ? fileName1 : LocationInfo::NA ),
+	   shortFileName(shortFileName1 ? shortFileName1 : LocationInfo::NA ),
+	   methodName( methodName1 ? methodName1 : LocationInfo::NA_METHOD )
 {
 }
 
@@ -81,6 +81,7 @@ LocationInfo::LocationInfo( const LocationInfo& src )
 LocationInfo& LocationInfo::operator = ( const LocationInfo& src )
 {
 	fileName = src.fileName;
+	shortFileName = src.shortFileName;
 	methodName = src.methodName;
 	lineNumber = src.lineNumber;
 	return * this;
@@ -92,6 +93,7 @@ LocationInfo& LocationInfo::operator = ( const LocationInfo& src )
 void LocationInfo::clear()
 {
 	fileName = NA;
+	shortFileName = NA;
 	methodName = NA_METHOD;
 	lineNumber = -1;
 }

--- a/src/main/include/log4cxx/spi/location/locationinfo.h
+++ b/src/main/include/log4cxx/spi/location/locationinfo.h
@@ -20,6 +20,7 @@
 
 #include <log4cxx/log4cxx.h>
 #include <string>
+#include <string.h>
 
 #if defined(_WIN32)
 #define LOG4CXX_SHORT_FILENAME_SPLIT_CHAR '\\'

--- a/src/main/include/log4cxx/spi/location/locationinfo.h
+++ b/src/main/include/log4cxx/spi/location/locationinfo.h
@@ -20,7 +20,6 @@
 
 #include <log4cxx/log4cxx.h>
 #include <string>
-#include <string.h>
 
 #if defined(_WIN32)
 #define LOG4CXX_SHORT_FILENAME_SPLIT_CHAR '\\'
@@ -51,7 +50,14 @@ class LOG4CXX_EXPORT LocationInfo
 
 		static const char* calcShortFileName(const char* fileName){
 			if (fileName == nullptr) return nullptr;
+#if defined(_MSC_VER)
+			const char* location = nullptr;
+			for (auto p = fileName; *p; ++p)
+				if (*p == LOG4CXX_SHORT_FILENAME_SPLIT_CHAR)
+					location = p;
+#else
 			const char* location = strrchr(fileName, LOG4CXX_SHORT_FILENAME_SPLIT_CHAR);
+#endif
 			return location == nullptr ? fileName : location + 1;
 		}
 

--- a/src/main/include/log4cxx/spi/location/locationinfo.h
+++ b/src/main/include/log4cxx/spi/location/locationinfo.h
@@ -54,7 +54,11 @@ class LOG4CXX_EXPORT LocationInfo
 		 *
 		 *  Implemented to allow compile-time evaluation when called with a literal string
 		 */
+#if 201304L <= __cpp_constexpr
 		static constexpr const char* calcShortFileName(const char* fileName){
+#else
+		static const char* calcShortFileName(const char* fileName){
+#endif
 			if (fileName == nullptr) return nullptr;
 #if defined(_MSC_VER)
 			// As at 2024, the MSVC optimizer does not inline a function that calls another function

--- a/src/main/include/log4cxx/spi/location/locationinfo.h
+++ b/src/main/include/log4cxx/spi/location/locationinfo.h
@@ -52,9 +52,9 @@ class LOG4CXX_EXPORT LocationInfo
 		/**
 		 *   The part of \c fileName after the path.
 		 *
-		 *  Implemented to be optimes away when called with a literal string
+		 *  Implemented to allow compile-time evaluation when called with a literal string
 		 */
-		static const char* calcShortFileName(const char* fileName){
+		static constexpr const char* calcShortFileName(const char* fileName){
 			if (fileName == nullptr) return nullptr;
 #if defined(_MSC_VER)
 			// As at 2024, the MSVC optimizer does not inline a function that calls another function

--- a/src/main/include/log4cxx/spi/location/locationinfo.h
+++ b/src/main/include/log4cxx/spi/location/locationinfo.h
@@ -20,13 +20,7 @@
 
 #include <log4cxx/log4cxx.h>
 #include <string>
-
-#if __cpp_lib_string_view || (_MSVC_LANG >= 201703L)
-#include <string_view>
-#define LOG4CXX_HAS_STRING_VIEW
-#else
 #include <string.h>
-#endif
 
 #if defined(_WIN32)
 #define LOG4CXX_SHORT_FILENAME_SPLIT_CHAR '\\'
@@ -46,8 +40,6 @@ class LOG4CXX_EXPORT LocationInfo
 {
 	public:
 
-
-
 		/**
 		  *   When location information is not available the constant
 		  * <code>NA</code> is returned. Current value of this string constant is <b>?</b>.
@@ -57,20 +49,11 @@ class LOG4CXX_EXPORT LocationInfo
 
 		static const LocationInfo& getLocationUnavailable();
 
-#ifdef LOG4CXX_HAS_STRING_VIEW
-		static constexpr const char* calcShortFileName(const char* fileName){
-			if(fileName == nullptr) return NA;
-			std::string_view view(fileName);
-			// If the separator is not found, rfind will return -1.  Adding 1 to
-			// that will have it pointing at fileName, which is a good fallback.
-			return fileName + view.rfind(LOG4CXX_SHORT_FILENAME_SPLIT_CHAR) + 1;
-		}
-#else
 		static const char* calcShortFileName(const char* fileName){
+			if (fileName == nullptr) return nullptr;
 			const char* location = strrchr(fileName, LOG4CXX_SHORT_FILENAME_SPLIT_CHAR);
 			return location == nullptr ? fileName : location + 1;
 		}
-#endif
 
 		/**
 		 *   Constructor.
@@ -164,7 +147,7 @@ class LOG4CXX_EXPORT LocationInfo
 	#endif
 #endif
 #if !defined(__LOG4CXX_FUNC__)
-	#define __LOG4CXX_FUNC__ ""
+	#define __LOG4CXX_FUNC__ nullptr
 #endif
 
 

--- a/src/main/include/log4cxx/spi/location/locationinfo.h
+++ b/src/main/include/log4cxx/spi/location/locationinfo.h
@@ -49,9 +49,15 @@ class LOG4CXX_EXPORT LocationInfo
 
 		static const LocationInfo& getLocationUnavailable();
 
+		/**
+		 *   The part of \c fileName after the path.
+		 *
+		 *  Implemented to be optimes away when called with a literal string
+		 */
 		static const char* calcShortFileName(const char* fileName){
 			if (fileName == nullptr) return nullptr;
 #if defined(_MSC_VER)
+			// As at 2024, the MSVC optimizer does not inline a function that calls another function
 			const char* location = nullptr;
 			for (auto p = fileName; *p; ++p)
 				if (*p == LOG4CXX_SHORT_FILENAME_SPLIT_CHAR)


### PR DESCRIPTION
Using std::string_view to implement LocationInfo::calcShortFileName results in runtime evaluation on gcc.

Using strrchr to implement LocationInfo::calcShortFileName give a compile time evaluated implementation more often.

To see the generated assembler see [Compiler Explorer](https://godbolt.org/z/nzjjhz4e9)