### PR TITLE
Prefer std::lock_guard when std::unique_lock features are not required

### DIFF
--- a/src/main/cpp/action.cpp
+++ b/src/main/cpp/action.cpp
@@ -43,7 +43,7 @@ Action::~Action()
  */
 void Action::run(LOG4CXX_NS::helpers::Pool& pool1)
 {
-	std::unique_lock<std::mutex> lock(m_priv->mutex);
+	std::lock_guard<std::mutex> lock(m_priv->mutex);
 
 	if (!m_priv->interrupted)
 	{
@@ -66,7 +66,7 @@ void Action::run(LOG4CXX_NS::helpers::Pool& pool1)
  */
 void Action::close()
 {
-	std::unique_lock<std::mutex> lock(m_priv->mutex);
+	std::lock_guard<std::mutex> lock(m_priv->mutex);
 	m_priv->interrupted = true;
 }
 

--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -98,14 +98,14 @@ APRInitializer::~APRInitializer()
 	stopWatchDogs();
 	isDestructed = true;
 #if APR_HAS_THREADS
-	std::unique_lock<std::mutex> lock(m_priv->mutex);
+	std::lock_guard<std::mutex> lock(m_priv->mutex);
 	apr_threadkey_private_delete(m_priv->tlsKey);
 #endif
 }
 
 void APRInitializer::stopWatchDogs()
 {
-	std::unique_lock<std::mutex> lock(m_priv->mutex);
+	std::lock_guard<std::mutex> lock(m_priv->mutex);
 
 	while (!m_priv->watchdogs.empty())
 	{
@@ -146,14 +146,14 @@ apr_threadkey_t* APRInitializer::getTlsKey()
 void APRInitializer::registerCleanup(FileWatchdog* watchdog)
 {
 	APRInitializer& instance(getInstance());
-	std::unique_lock<std::mutex> lock(instance.m_priv->mutex);
+	std::lock_guard<std::mutex> lock(instance.m_priv->mutex);
 	instance.m_priv->watchdogs.push_back(watchdog);
 }
 
 void APRInitializer::unregisterCleanup(FileWatchdog* watchdog)
 {
 	APRInitializer& instance(getInstance());
-	std::unique_lock<std::mutex> lock(instance.m_priv->mutex);
+	std::lock_guard<std::mutex> lock(instance.m_priv->mutex);
 
 	auto iter = std::find(instance.m_priv->watchdogs.begin(), instance.m_priv->watchdogs.end(), watchdog);
 	if (iter != instance.m_priv->watchdogs.end())
@@ -162,13 +162,13 @@ void APRInitializer::unregisterCleanup(FileWatchdog* watchdog)
 
 void APRInitializer::addObject(size_t key, const ObjectPtr& pObject)
 {
-	std::unique_lock<std::mutex> lock(m_priv->mutex);
+	std::lock_guard<std::mutex> lock(m_priv->mutex);
 	m_priv->objects[key] = pObject;
 }
 
 const ObjectPtr& APRInitializer::findOrAddObject(size_t key, std::function<ObjectPtr()> creator)
 {
-	std::unique_lock<std::mutex> lock(m_priv->mutex);
+	std::lock_guard<std::mutex> lock(m_priv->mutex);
 	auto pItem = m_priv->objects.find(key);
 	if (m_priv->objects.end() == pItem)
 		pItem = m_priv->objects.emplace(key, creator()).first;

--- a/src/main/cpp/aprserversocket.cpp
+++ b/src/main/cpp/aprserversocket.cpp
@@ -82,7 +82,7 @@ APRServerSocket::APRServerSocket(int port) :
 }
 
 void APRServerSocket::close(){
-	std::unique_lock<std::mutex> lock(_priv->mutex);
+	std::lock_guard<std::mutex> lock(_priv->mutex);
 
 	if (_priv->socket != 0)
 	{
@@ -103,7 +103,7 @@ accepts it
 */
 SocketPtr APRServerSocket::accept()
 {
-	std::unique_lock<std::mutex> lock(_priv->mutex);
+	std::lock_guard<std::mutex> lock(_priv->mutex);
 
 	if (_priv->socket == 0)
 	{

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -257,7 +257,7 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 
 	if (!priv->dispatcher.joinable())
 	{
-		std::unique_lock<std::mutex> lock(priv->bufferMutex);
+		std::lock_guard<std::mutex> lock(priv->bufferMutex);
 		if (!priv->dispatcher.joinable())
 			priv->dispatcher = ThreadUtility::instance()->createThread( LOG4CXX_STR("AsyncAppender"), &AsyncAppender::dispatch, this );
 	}

--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -98,7 +98,7 @@ class APRCharsetDecoder : public CharsetDecoder
 			{
 				size_t outbytes_left = initial_outbytes_left;
 				{
-					std::unique_lock<std::mutex> lock(mutex);
+					std::lock_guard<std::mutex> lock(mutex);
 					stat = apr_xlate_conv_buffer((apr_xlate_t*) convset,
 							NULL, NULL, (char*) buf, &outbytes_left);
 				}
@@ -113,7 +113,7 @@ class APRCharsetDecoder : public CharsetDecoder
 					size_t pos = in.position();
 					apr_size_t outbytes_left = initial_outbytes_left;
 					{
-						std::unique_lock<std::mutex> lock(mutex);
+						std::lock_guard<std::mutex> lock(mutex);
 						stat = apr_xlate_conv_buffer((apr_xlate_t*) convset,
 								in.data() + pos,
 								&inbytes_left,

--- a/src/main/cpp/charsetencoder.cpp
+++ b/src/main/cpp/charsetencoder.cpp
@@ -91,7 +91,7 @@ class APRCharsetEncoder : public CharsetEncoder
 
 			if (iter == in.end())
 			{
-				std::unique_lock<std::mutex> lock(mutex);
+				std::lock_guard<std::mutex> lock(mutex);
 				stat = apr_xlate_conv_buffer(convset, NULL, NULL,
 						out.data() + position, &outbytes_left);
 			}
@@ -102,7 +102,7 @@ class APRCharsetEncoder : public CharsetEncoder
 					(in.size() - inOffset) * sizeof(LogString::value_type);
 				apr_size_t initial_inbytes_left = inbytes_left;
 				{
-					std::unique_lock<std::mutex> lock(mutex);
+					std::lock_guard<std::mutex> lock(mutex);
 					stat = apr_xlate_conv_buffer(convset,
 							(const char*) (in.data() + inOffset),
 							&inbytes_left,

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -74,11 +74,7 @@ void FileWatchdog::stop()
 {
 	LogLog::debug(LOG4CXX_STR("Stopping file watchdog"));
 	m_priv->interrupted = 0xFFFF;
-
-	{
-		std::unique_lock<std::mutex> lock(m_priv->interrupt_mutex);
-		m_priv->interrupt.notify_all();
-	}
+	m_priv->interrupt.notify_all();
 	m_priv->thread.join();
 }
 

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -297,7 +297,7 @@ bool Hierarchy::isDisabled(int level) const
 
 void Hierarchy::ensureIsConfigured(std::function<void()> configurator)
 {
-	std::unique_lock<std::mutex> lock(m_priv->configuredMutex);
+	std::lock_guard<std::mutex> lock(m_priv->configuredMutex);
 	if (!m_priv->configured)
 	{
 		configurator();
@@ -446,7 +446,7 @@ void Hierarchy::setConfigured(bool newValue)
 
 bool Hierarchy::isConfigured()
 {
-	std::unique_lock<std::mutex> lock(m_priv->configuredMutex); // Blocks while auto-configuration is active
+	std::lock_guard<std::mutex> lock(m_priv->configuredMutex); // Blocks while auto-configuration is active
 	return m_priv->configured;
 }
 

--- a/src/main/cpp/loglog.cpp
+++ b/src/main/cpp/loglog.cpp
@@ -69,7 +69,7 @@ LogLog& LogLog::getInstance()
 void LogLog::setInternalDebugging(bool debugEnabled1)
 {
 	auto p = getInstance().m_priv.get();
-	std::unique_lock<std::mutex> lock(p->mutex);
+	std::lock_guard<std::mutex> lock(p->mutex);
 
 	p->debugEnabled = debugEnabled1;
 }
@@ -84,7 +84,7 @@ void LogLog::debug(const LogString& msg)
 			return;
 		}
 
-		std::unique_lock<std::mutex> lock(p->mutex);
+		std::lock_guard<std::mutex> lock(p->mutex);
 
 		emit(msg);
 	}
@@ -98,7 +98,7 @@ void LogLog::debug(const LogString& msg, const std::exception& e)
 		if (!p->debugEnabled)
 			return;
 
-		std::unique_lock<std::mutex> lock(p->mutex);
+		std::lock_guard<std::mutex> lock(p->mutex);
 		emit(msg);
 		emit(e);
 	}
@@ -110,7 +110,7 @@ void LogLog::error(const LogString& msg)
 	auto p = getInstance().m_priv.get();
 	if (p && !p->quietMode) // Not deleted by onexit processing?
 	{
-		std::unique_lock<std::mutex> lock(p->mutex);
+		std::lock_guard<std::mutex> lock(p->mutex);
 
 		emit(msg);
 	}
@@ -121,7 +121,7 @@ void LogLog::error(const LogString& msg, const std::exception& e)
 	auto p = getInstance().m_priv.get();
 	if (p && !p->quietMode) // Not deleted by onexit processing?
 	{
-		std::unique_lock<std::mutex> lock(p->mutex);
+		std::lock_guard<std::mutex> lock(p->mutex);
 		emit(msg);
 		emit(e);
 	}
@@ -130,7 +130,7 @@ void LogLog::error(const LogString& msg, const std::exception& e)
 void LogLog::setQuietMode(bool quietMode1)
 {
 	auto p = getInstance().m_priv.get();
-	std::unique_lock<std::mutex> lock(p->mutex);
+	std::lock_guard<std::mutex> lock(p->mutex);
 
 	p->quietMode = quietMode1;
 }
@@ -140,7 +140,7 @@ void LogLog::warn(const LogString& msg)
 	auto p = getInstance().m_priv.get();
 	if (p && !p->quietMode) // Not deleted by onexit processing?
 	{
-		std::unique_lock<std::mutex> lock(p->mutex);
+		std::lock_guard<std::mutex> lock(p->mutex);
 		emit(msg);
 	}
 }
@@ -150,7 +150,7 @@ void LogLog::warn(const LogString& msg, const std::exception& e)
 	auto p = getInstance().m_priv.get();
 	if (p && !p->quietMode) // Not deleted by onexit processing?
 	{
-		std::unique_lock<std::mutex> lock(p->mutex);
+		std::lock_guard<std::mutex> lock(p->mutex);
 		emit(msg);
 		emit(e);
 	}

--- a/src/main/cpp/socketappenderskeleton.cpp
+++ b/src/main/cpp/socketappenderskeleton.cpp
@@ -77,12 +77,7 @@ void SocketAppenderSkeleton::close()
 
 	_priv->closed = true;
 	cleanUp(_priv->pool);
-
-	{
-		std::unique_lock<std::mutex> lock2(_priv->interrupt_mutex);
-		_priv->interrupt.notify_all();
-	}
-
+	_priv->interrupt.notify_all();
 	if ( _priv->thread.joinable() )
 	{
 		_priv->thread.join();

--- a/src/main/cpp/writerappender.cpp
+++ b/src/main/cpp/writerappender.cpp
@@ -290,7 +290,7 @@ void WriterAppender::writeHeader(Pool& p)
 
 void WriterAppender::setWriter(const WriterPtr& newWriter)
 {
-	std::unique_lock<std::recursive_mutex> lock(_priv->mutex);
+	std::lock_guard<std::recursive_mutex> lock(_priv->mutex);
 	setWriterInternal(newWriter);
 }
 

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -84,7 +84,7 @@ class BlockableVectorAppender : public VectorAppender
 		 */
 		void append(const spi::LoggingEventPtr& event, log4cxx::helpers::Pool& p) override
 		{
-			std::unique_lock<std::mutex> lock( blocker );
+			std::lock_guard<std::mutex> lock( blocker );
 			VectorAppender::append(event, p);
 
 			//
@@ -332,7 +332,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			LOG4CXX_INFO(rootLogger, "Hello, World"); // This causes the dispatch thread creation
 			std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) ); // Wait for the dispatch thread  to be ready
 			{
-				std::unique_lock<std::mutex> sync(blockableAppender->getBlocker());
+				std::lock_guard<std::mutex> sync(blockableAppender->getBlocker());
 
 				for (int i = 0; i < 140; i++)
 				{

--- a/src/test/cpp/helpers/charsetencodertestcase.cpp
+++ b/src/test/cpp/helpers/charsetencodertestcase.cpp
@@ -251,7 +251,6 @@ public:
 
 			void signalAll()
 			{
-				std::unique_lock<std::mutex> sync(lock);
 				condition.notify_all();
 			}
 

--- a/src/test/cpp/throughput/throughput-main.cpp
+++ b/src/test/cpp/throughput/throughput-main.cpp
@@ -50,7 +50,7 @@ static void benchmark_function( const std::string& name, void (*fn)(int), int ho
 	auto delta = high_resolution_clock::now() - start;
 	auto delta_d = duration_cast<duration<double>>(delta).count();
 
-	std::unique_lock<std::mutex> lk(results_mutex);
+	std::lock_guard<std::mutex> lk(results_mutex);
 	results.push_back( uint64_t(howmany / delta_d) );
 	LOG4CXX_INFO_FMT( console, "Log4cxx {} Elapsed: {:.4} secs {:L}/sec",
 		name,
@@ -73,7 +73,7 @@ static void benchmark_conversion_pattern( const std::string& name,
 	auto delta = high_resolution_clock::now() - start;
 	auto delta_d = duration_cast<duration<double>>(delta).count();
 
-	std::unique_lock<std::mutex> lk(results_mutex);
+	std::lock_guard<std::mutex> lk(results_mutex);
 	results.push_back( uint64_t(howmany / delta_d) );
 	LOG4CXX_INFO_FMT( console, "Log4cxx {} pattern: {} Elapsed: {:.4} secs {:L}/sec",
 		name,


### PR DESCRIPTION
This PR applies the guidelines in [this highly rated answer on StackOverflow](https://stackoverflow.com/questions/43019598/stdlock-guard-or-stdscoped-lock).

Also, the call site of [std::condition_variable::notify_all](https://en.cppreference.com/w/cpp/thread/condition_variable/notify_all) does not need to hold the lock on the same mutex as the one held by the waiting thread(s)