### PR TITLE
Add a simple termination test using AsyncAppender

### DIFF
--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -25,6 +25,7 @@
 #include <apr_thread_proc.h>
 #include <log4cxx/helpers/filewatchdog.h>
 #include <log4cxx/helpers/date.h>
+#include <log4cxx/helpers/loglog.h>
 #include <list>
 #include <algorithm>
 
@@ -169,6 +170,11 @@ void APRInitializer::addObject(size_t key, const ObjectPtr& pObject)
 const ObjectPtr& APRInitializer::findOrAddObject(size_t key, std::function<ObjectPtr()> creator)
 {
 	std::lock_guard<std::mutex> lock(m_priv->mutex);
+	if (m_priv->objects.empty())
+	{
+		// Ensure the internal logger has a longer life than other Log4cxx static data
+		LogLog::debug(LOG4CXX_STR("Log4cxx starting"));
+	}
 	auto pItem = m_priv->objects.find(key);
 	if (m_priv->objects.end() == pItem)
 		pItem = m_priv->objects.emplace(key, creator()).first;

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -61,6 +61,7 @@ set(ALL_LOG4CXX_TESTS
     streamtestcase
     locationtest
     locationdisabledtest
+    terminationtestcase
 )
 if(${ENABLE_FMT_LAYOUT})
     set(ALL_LOG4CXX_TESTS ${ALL_LOG4CXX_TESTS} fmttest)

--- a/src/test/cpp/terminationtestcase.cpp
+++ b/src/test/cpp/terminationtestcase.cpp
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "logunit.h"
+
+#include <log4cxx/logger.h>
+#include <log4cxx/logmanager.h>
+#include "vectorappender.h"
+#include <log4cxx/asyncappender.h>
+
+using namespace log4cxx;
+
+static VectorAppenderPtr vectorAppender = std::make_shared<VectorAppender>();
+
+LOGUNIT_CLASS(TerminationTestCase)
+{
+	LOGUNIT_TEST_SUITE(TerminationTestCase);
+	LOGUNIT_TEST(logOnce);
+	LOGUNIT_TEST_SUITE_END();
+
+public:
+
+	static void setDefaultAppender()
+	{
+		auto r = LogManager::getLoggerRepository();
+		r->ensureIsConfigured([r]()
+			{
+			auto asyncAppender = std::make_shared<AsyncAppender>();
+			asyncAppender->addAppender(vectorAppender);
+			r->getRootLogger()->addAppender(asyncAppender);
+			}
+		);
+	}
+
+	static LoggerPtr getLogger(const LogString& name = LogString())
+	{
+		static struct initializer
+		{
+			initializer() { setDefaultAppender(); }
+			~initializer() { LogManager::shutdown(); }
+		} x;
+		auto r = LogManager::getLoggerRepository();
+		return r->getLogger(name);
+	}
+
+	void logOnce()
+	{
+		auto root = getLogger();
+		LOG4CXX_INFO(root, "Message");
+		std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+		const std::vector<spi::LoggingEventPtr>& v = vectorAppender->getVector();
+		LOGUNIT_ASSERT_EQUAL((size_t) 1, v.size());
+	}
+};
+
+LOGUNIT_TEST_SUITE_REGISTRATION(TerminationTestCase);

--- a/src/test/cpp/terminationtestcase.cpp
+++ b/src/test/cpp/terminationtestcase.cpp
@@ -54,7 +54,7 @@ public:
 			~initializer() { LogManager::shutdown(); }
 		} x;
 		auto r = LogManager::getLoggerRepository();
-		return r->getLogger(name);
+		return name.empty() ? r->getLogger(name) : r->getRootLogger();
 	}
 
 	void logOnce()

--- a/src/test/cpp/terminationtestcase.cpp
+++ b/src/test/cpp/terminationtestcase.cpp
@@ -20,6 +20,7 @@
 #include <log4cxx/logmanager.h>
 #include "vectorappender.h"
 #include <log4cxx/asyncappender.h>
+#include <thread>
 
 using namespace log4cxx;
 


### PR DESCRIPTION
This PR adds a test (initially failing on Windows) that uses AsyncAppender 