### PR TITLE
Improve AsyncAppender throughput

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -529,12 +529,11 @@ void AsyncAppender::dispatch()
 		}
 		priv->bufferNotFull.notify_all();
 		{
-			std::unique_lock<std::mutex> lock(priv->bufferMutex);
+			std::lock_guard<std::mutex> lock(priv->bufferMutex);
 			for (auto discardItem : priv->discardMap)
 			{
 				events.push_back(discardItem.second.createEvent(p));
 			}
-
 			priv->discardMap.clear();
 		}
 


### PR DESCRIPTION
This PR enables a higher rate at which logging events can be sent through AsyncAppender by avoiding some mutex contention inside the `bufferNotEmpty` [std::condition_variable](https://en.cppreference.com/w/cpp/thread/condition_variable)