### PR TITLE
Improve APRInitiializer interface in next ABI version

### DIFF
--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -131,7 +131,9 @@ APRInitializer& APRInitializer::getInstance()
 
 #if LOG4CXX_ABI_VERSION <= 15
 log4cxx_time_t APRInitializer::initialize()
-{}
+{
+	return getInstance().m_priv->startTime;
+}
 #endif
 
 log4cxx_time_t APRInitializer::getStartTime()

--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -131,9 +131,10 @@ APRInitializer& APRInitializer::getInstance()
 
 #if LOG4CXX_ABI_VERSION <= 15
 log4cxx_time_t APRInitializer::initialize()
-#else
-log4cxx_time_t APRInitializer::getStartTime()
+{}
 #endif
+
+log4cxx_time_t APRInitializer::getStartTime()
 {
 	return getInstance().m_priv->startTime;
 }

--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -129,7 +129,11 @@ APRInitializer& APRInitializer::getInstance()
 }
 
 
+#if LOG4CXX_ABI_VERSION <= 15
 log4cxx_time_t APRInitializer::initialize()
+#else
+log4cxx_time_t APRInitializer::getStartTime()
+#endif
 {
 	return getInstance().m_priv->startTime;
 }
@@ -173,7 +177,7 @@ const ObjectPtr& APRInitializer::findOrAddObject(size_t key, std::function<Objec
 	if (m_priv->objects.empty())
 	{
 		// Ensure the internal logger has a longer life than other Log4cxx static data
-		LogLog::debug(LOG4CXX_STR("Log4cxx starting"));
+		LogLog::debug(LOG4CXX_STR("Started"));
 	}
 	auto pItem = m_priv->objects.find(key);
 	if (m_priv->objects.end() == pItem)

--- a/src/main/cpp/level.cpp
+++ b/src/main/cpp/level.cpp
@@ -85,7 +85,6 @@ Level::Level(int level1,
 	const LogString& name1, int syslogEquivalent1)
 	: level(level1), name(name1), syslogEquivalent(syslogEquivalent1)
 {
-	APRInitializer::initialize();
 }
 
 

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -173,11 +173,7 @@ IMPLEMENT_LOG4CXX_OBJECT(LoggingEvent)
 //
 log4cxx_time_t LoggingEvent::getStartTime()
 {
-#if LOG4CXX_ABI_VERSION <= 15
-	return LOG4CXX_NS::helpers::APRInitializer::initialize();
-#else
 	return APRInitializer::getStartTime();
-#endif
 }
 
 LoggingEvent::LoggingEvent() :

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -173,7 +173,11 @@ IMPLEMENT_LOG4CXX_OBJECT(LoggingEvent)
 //
 log4cxx_time_t LoggingEvent::getStartTime()
 {
+#if LOG4CXX_ABI_VERSION <= 15
 	return LOG4CXX_NS::helpers::APRInitializer::initialize();
+#else
+	return APRInitializer::getStartTime();
+#endif
 }
 
 LoggingEvent::LoggingEvent() :

--- a/src/main/include/log4cxx/helpers/aprinitializer.h
+++ b/src/main/include/log4cxx/helpers/aprinitializer.h
@@ -44,7 +44,11 @@ class FileWatchdog;
 class APRInitializer
 {
 	public:
+#if LOG4CXX_ABI_VERSION <= 15
 		static log4cxx_time_t initialize();
+#else
+		static log4cxx_time_t getStartTime();
+#endif
 		static apr_pool_t* getRootPool();
 		static apr_threadkey_t* getTlsKey();
 		static bool isDestructed;

--- a/src/main/include/log4cxx/helpers/aprinitializer.h
+++ b/src/main/include/log4cxx/helpers/aprinitializer.h
@@ -46,10 +46,9 @@ class APRInitializer
 	public:
 #if LOG4CXX_ABI_VERSION <= 15
 		static log4cxx_time_t initialize();
-#else
-		static log4cxx_time_t getStartTime();
 #endif
 		static apr_pool_t* getRootPool();
+		static log4cxx_time_t getStartTime();
 		static apr_threadkey_t* getTlsKey();
 		static bool isDestructed;
 


### PR DESCRIPTION
This PR removes the `initialize` method from APRInitiializer. It has not been required since 7fedcdbfd