### PR TITLE
Remove duplicated and outdated information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Apache Log4cxx is a logging framework for C++.
 
 For answers to such questions as "What is logging?",
-"What should a logging framework do?' and
+"What should a logging framework do?" and
 "How to do logging properly?"
 refer to the [logging overview page](https://logging.apache.org/what-is-logging.html).
 
@@ -27,6 +27,7 @@ shows what code you write to use Log4cxx in your project.
 
 For other information about Log4cxx
 (e.g. [getting help](https://logging.apache.org/log4cxx/latest_stable/community.html),
+[official release downloads](https://logging.apache.org/log4cxx/latest_stable/download.html),
 [building Log4cxx](https://logging.apache.org/log4cxx/latest_stable/build.html)) use
 [the Log4cxx project website](https://logging.apache.org/log4cxx/latest_stable).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
  limitations under the License.
 -->
 
+[![Linux](https://github.com/apache/logging-log4cxx/actions/workflows/blog4cxx-ubuntu.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/blog4cxx-ubuntu.yml)
+[![MacOS](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml)
+<br/>
+[![Windows (dll)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml)
+[![Windows (static)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml)
+
 Apache Log4cxx is a logging framework for C++.
 
 For answers to such questions as "What is logging?",

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
  limitations under the License.
 -->
 
-![Linux](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml/badge.svg)
-![MacOS](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml/badge.svg)
+[![Linux](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml)
+[![MacOS](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml)
 <br/>
-![Windows (dll)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml/badge.svg)
-![Windows (static)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml/badge.svg)
+[![Windows (dll)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml)
+[![Windows (static)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml)
 
 Apache Log4cxx is a logging framework for C++.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 Apache Log4cxx is a logging framework for C++.
 For more information see
 [the Log4cxx project website](https://logging.apache.org/log4cxx/latest_stable).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
 <br/>
 [![Windows (dll)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml)
 [![Windows (static)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml)
+<br/>
+[![ABI stability](https://github.com/apache/logging-log4cxx/actions/workflows/abi-compatibility.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/abi-compatibility.yml)
+[![Quality gate](https://github.com/apache/logging-log4cxx/actions/workflows/sonarcloud.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/sonarcloud.yml)
 
 Apache Log4cxx is a logging framework for C++.
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
  limitations under the License.
 -->
 
-[![Linux](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml)
-[![MacOS](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml)
+![Linux](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml/badge.svg)
+![MacOS](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml/badge.svg)
 <br/>
-[![Windows (dll)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml)
-[![Windows (static)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml)
+![Windows (dll)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml/badge.svg)
+![Windows (static)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows-static.yml/badge.svg)
 
 Apache Log4cxx is a logging framework for C++.
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,5 @@
-# Apache Log4cxx
-
-Apache Log4cxx is a logging framework for C++.  More information is available on the
-[Log4cxx Website](https://logging.apache.org/log4cxx/latest_stable).
+Apache Log4cxx is a logging framework for C++.
+For more information see
+[the Log4cxx project website](https://logging.apache.org/log4cxx/latest_stable).
 
 Log4cxx is part of the [Apache Logging Services](https://logging.apache.org/) PMC.
-
-# Issues and pull requests
-
-Issues are maintained in the [Apache JIRA](https://issues.apache.org/jira/projects/LOGCXX/issues) by
-default, so before posting pull requests, please have a look there if an associated issue with your
-problem/feature/... exists already. If not, it's generally OK to directly create pull requests IF 
-code is already available, but please be somewhat verbose: Provide some background information about
-what actual problem the PR solves, why this needs to be solved etc. Don't just provide commits about
-the fact that you changed something.
-
-Because new signups are not allowed on JIRA anymore, you may also submit a bug report through the
-GitHub mirror.
-
-If any discussion is needed before actually having any code, simply create a issue on GitHub,
-a ticket on JIRA (if you have an old account), or send a message to the corresponding
-[mailing list](https://logging.apache.org/log4cxx/latest_stable/mail-lists.html).
-Thanks!

--- a/README.md
+++ b/README.md
@@ -16,7 +16,18 @@
 -->
 
 Apache Log4cxx is a logging framework for C++.
-For more information see
+
+For answers to such questions as "What is logging?",
+"What should a logging framework do?' and
+"How to do logging properly?"
+refer to the [logging overview page](https://logging.apache.org/what-is-logging.html).
+
+The [quick start guide](https://logging.apache.org/log4cxx/latest_stable/quick-start.html)
+shows what code you write to use Log4cxx in your project.
+
+For other information about Log4cxx
+(e.g. [getting help](https://logging.apache.org/log4cxx/latest_stable/community.html),
+[building Log4cxx](https://logging.apache.org/log4cxx/latest_stable/build.html)) use
 [the Log4cxx project website](https://logging.apache.org/log4cxx/latest_stable).
 
 Log4cxx is part of the [Apache Logging Services](https://logging.apache.org/) PMC.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
  limitations under the License.
 -->
 
-<br/>
 [![Linux](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml)
 [![MacOS](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml)
 <br/>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
  limitations under the License.
 -->
 
-[![Linux](https://github.com/apache/logging-log4cxx/actions/workflows/blog4cxx-ubuntu.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/blog4cxx-ubuntu.yml)
+<br/>
+[![Linux](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-ubuntu.yml)
 [![MacOS](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-macos.yml)
 <br/>
 [![Windows (dll)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml/badge.svg)](https://github.com/apache/logging-log4cxx/actions/workflows/log4cxx-windows.yml)


### PR DESCRIPTION
This PR aims to make the Log4cxx README similar to the Log4j2 readme.

Note: The mailing list link was broken.