### PR TITLE
Join background threads when LOG4CXX_EVENTS_AT_EXIT=on

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -124,35 +124,13 @@ struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkele
 		locationInfo(false),
 		blocking(true)
 #if LOG4CXX_EVENTS_AT_EXIT
-		, atExitRegistryRaii([this]{atExitActivated();})
+		, atExitRegistryRaii([this]{stopDispatcher();})
 #endif
 		, eventCount(0)
 		, dispatchedCount(0)
 		, commitCount(0)
 	{
 	}
-
-#if LOG4CXX_EVENTS_AT_EXIT
-	void atExitActivated()
-	{
-		{
-			std::lock_guard<std::mutex> lock(bufferMutex);
-			closed = true;
-		}
-		bufferNotEmpty.notify_all();
-		bufferNotFull.notify_all();
-
-		if (dispatcher.joinable())
-		{
-			dispatcher.join();
-		}
-
-		for (auto item : appenders.getAllAppenders())
-		{
-			item->close();
-		}
-	}
-#endif
 
 	/**
 	 * Event buffer.
@@ -191,6 +169,21 @@ struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkele
 	 *  Dispatcher.
 	 */
 	std::thread dispatcher;
+
+	void stopDispatcher()
+	{
+		{
+			std::lock_guard<std::mutex> lock(bufferMutex);
+			closed = true;
+		}
+		bufferNotEmpty.notify_all();
+		bufferNotFull.notify_all();
+
+		if (dispatcher.joinable())
+		{
+			dispatcher.join();
+		}
+	}
 
 	/**
 	 * Should location info be included in dispatched messages.
@@ -362,18 +355,7 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 
 void AsyncAppender::close()
 {
-	{
-		std::lock_guard<std::mutex> lock(priv->bufferMutex);
-		priv->closed = true;
-		priv->bufferNotEmpty.notify_all();
-		priv->bufferNotFull.notify_all();
-	}
-
-	if ( priv->dispatcher.joinable() )
-	{
-		priv->dispatcher.join();
-	}
-
+	priv->stopDispatcher();
 	for (auto item : priv->appenders.getAllAppenders())
 	{
 		item->close();

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -25,6 +25,10 @@
 #include <functional>
 #include <chrono>
 
+#if LOG4CXX_EVENTS_AT_EXIT
+#include <log4cxx/private/atexitregistry.h>
+#endif
+
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
 
@@ -33,8 +37,11 @@ long FileWatchdog::DEFAULT_DELAY = 60000;
 struct FileWatchdog::FileWatchdogPrivate{
 	FileWatchdogPrivate(const File& file1) :
 		file(file1), delay(DEFAULT_DELAY), lastModif(0),
-		warnedAlready(false), interrupted(0), thread(){}
-
+		warnedAlready(false), interrupted(0), thread()
+#if LOG4CXX_EVENTS_AT_EXIT
+		, atExitRegistryRaii([this]{atExitActivated();})
+#endif
+        {}
 	/**
 	The name of the file to observe  for changes.
 	*/
@@ -51,6 +58,23 @@ struct FileWatchdog::FileWatchdogPrivate{
 	std::thread thread;
 	std::condition_variable interrupt;
 	std::mutex interrupt_mutex;
+
+#if LOG4CXX_EVENTS_AT_EXIT
+	helpers::AtExitRegistry::Raii atExitRegistryRaii;
+#endif
+
+#if LOG4CXX_EVENTS_AT_EXIT
+	void atExitActivated()
+	{
+        {
+            std::lock_guard<std::mutex> lock(interrupt_mutex);
+            interrupted = 0xFFFF;
+        }
+        interrupt.notify_all();
+        if (thread.joinable())
+            thread.join();
+	}
+#endif
 };
 
 FileWatchdog::FileWatchdog(const File& file1)

--- a/src/main/cpp/socketappenderskeleton.cpp
+++ b/src/main/cpp/socketappenderskeleton.cpp
@@ -194,6 +194,19 @@ void SocketAppenderSkeleton::monitor()
 	}
 }
 
+void SocketAppenderSkeleton::SocketAppenderSkeletonPriv::stopMonitor()
+{
+	{
+		std::lock_guard<std::mutex> lock(this->interrupt_mutex);
+		if (this->closed)
+			return;
+		this->closed = true;
+	}
+	this->interrupt.notify_all();
+	if (this->thread.joinable())
+		this->thread.join();
+}
+
 bool SocketAppenderSkeleton::is_closed()
 {
 	return _priv->closed;

--- a/src/main/cpp/socketappenderskeleton.cpp
+++ b/src/main/cpp/socketappenderskeleton.cpp
@@ -68,22 +68,8 @@ void SocketAppenderSkeleton::activateOptions(Pool& p)
 
 void SocketAppenderSkeleton::close()
 {
-	{
-		std::lock_guard<std::mutex> lock(_priv->interrupt_mutex);
-
-		if (_priv->closed)
-		{
-			return;
-		}
-
-		_priv->closed = true;
-		cleanUp(_priv->pool);
-	}
-	_priv->interrupt.notify_all();
-	if ( _priv->thread.joinable() )
-	{
-		_priv->thread.join();
-	}
+    _priv->stopMonitor();
+    cleanUp(_priv->pool);
 }
 
 void SocketAppenderSkeleton::connect(Pool& p)

--- a/src/main/include/log4cxx/private/socketappenderskeleton_priv.h
+++ b/src/main/include/log4cxx/private/socketappenderskeleton_priv.h
@@ -89,18 +89,7 @@ struct SocketAppenderSkeleton::SocketAppenderSkeletonPriv : public AppenderSkele
 	helpers::AtExitRegistry::Raii atExitRegistryRaii;
 #endif
 
-	void stopMonitor()
-	{
-		{
-			std::lock_guard<std::mutex> lock(this->interrupt_mutex);
-			if (this->closed)
-				return;
-			this->closed = true;
-		}
-		this->interrupt.notify_all();
-		if (this->thread.joinable())
-			this->thread.join();
-	}
+	void stopMonitor();
 };
 
 } // namespace net

--- a/src/main/include/log4cxx/private/socketappenderskeleton_priv.h
+++ b/src/main/include/log4cxx/private/socketappenderskeleton_priv.h
@@ -21,6 +21,10 @@
 #include <log4cxx/private/appenderskeleton_priv.h>
 #include <log4cxx/helpers/inetaddress.h>
 
+#if LOG4CXX_EVENTS_AT_EXIT
+#include <log4cxx/private/atexitregistry.h>
+#endif
+
 namespace LOG4CXX_NS
 {
 namespace net
@@ -34,8 +38,11 @@ struct SocketAppenderSkeleton::SocketAppenderSkeletonPriv : public AppenderSkele
 		address(),
 		port(defaultPort),
 		reconnectionDelay(reconnectionDelay),
-		locationInfo(false),
-		thread() {}
+		locationInfo(false)
+#if LOG4CXX_EVENTS_AT_EXIT
+		, atExitRegistryRaii([this]{stopMonitor();})
+#endif
+        {}
 
 	SocketAppenderSkeletonPriv(helpers::InetAddressPtr address, int defaultPort, int reconnectionDelay) :
 		AppenderSkeletonPrivate(),
@@ -43,8 +50,11 @@ struct SocketAppenderSkeleton::SocketAppenderSkeletonPriv : public AppenderSkele
 		address(address),
 		port(defaultPort),
 		reconnectionDelay(reconnectionDelay),
-		locationInfo(false),
-		thread() {}
+		locationInfo(false)
+#if LOG4CXX_EVENTS_AT_EXIT
+		, atExitRegistryRaii([this]{stopMonitor();})
+#endif
+        {}
 
 	SocketAppenderSkeletonPriv(const LogString& host, int port, int delay) :
 		AppenderSkeletonPrivate(),
@@ -52,8 +62,11 @@ struct SocketAppenderSkeleton::SocketAppenderSkeletonPriv : public AppenderSkele
 		address(helpers::InetAddress::getByName(host)),
 		port(port),
 		reconnectionDelay(delay),
-		locationInfo(false),
-		thread() {}
+		locationInfo(false)
+#if LOG4CXX_EVENTS_AT_EXIT
+		, atExitRegistryRaii([this]{stopMonitor();})
+#endif
+        {}
 
 	/**
 	host name
@@ -71,6 +84,23 @@ struct SocketAppenderSkeleton::SocketAppenderSkeletonPriv : public AppenderSkele
 	std::thread thread;
 	std::condition_variable interrupt;
 	std::mutex interrupt_mutex;
+
+#if LOG4CXX_EVENTS_AT_EXIT
+	helpers::AtExitRegistry::Raii atExitRegistryRaii;
+#endif
+
+	void stopMonitor()
+	{
+		{
+			std::lock_guard<std::mutex> lock(this->interrupt_mutex);
+			if (this->closed)
+				return;
+			this->closed = true;
+		}
+		this->interrupt.notify_all();
+		if (this->thread.joinable())
+			this->thread.join();
+	}
 };
 
 } // namespace net

--- a/src/test/cpp/net/telnetappendertestcase.cpp
+++ b/src/test/cpp/net/telnetappendertestcase.cpp
@@ -39,6 +39,7 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 		LOGUNIT_TEST(testActivateClose);
 		LOGUNIT_TEST(testActivateSleepClose);
 		LOGUNIT_TEST(testActivateWriteClose);
+		LOGUNIT_TEST(testActivateWriteNoClose);
 
 		LOGUNIT_TEST_SUITE_END();
 
@@ -75,7 +76,7 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 			appender->setPort(TEST_PORT);
 			Pool p;
 			appender->activateOptions(p);
-			std::this_thread::sleep_for( std::chrono::milliseconds( 1000 ) );
+			std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
 			appender->close();
 		}
 
@@ -95,6 +96,23 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 			}
 
 			appender->close();
+			root->removeAppender(appender);
+		}
+
+		void testActivateWriteNoClose()
+		{
+			TelnetAppenderPtr appender(new TelnetAppender());
+			appender->setLayout(createLayout());
+			appender->setPort(TEST_PORT);
+			Pool p;
+			appender->activateOptions(p);
+			LoggerPtr root(Logger::getRootLogger());
+			root->addAppender(appender);
+
+			for (int i = 0; i < 50; i++)
+			{
+				LOG4CXX_INFO(root, "Hello, World " << i);
+			}
 		}
 
 };

--- a/src/test/cpp/terminationtestcase.cpp
+++ b/src/test/cpp/terminationtestcase.cpp
@@ -51,7 +51,9 @@ public:
 		static struct initializer
 		{
 			initializer() { setDefaultAppender(); }
+#if !LOG4CXX_EVENTS_AT_EXIT
 			~initializer() { LogManager::shutdown(); }
+#endif
 		} x;
 		auto r = LogManager::getLoggerRepository();
 		return name.empty() ? r->getLogger(name) : r->getRootLogger();


### PR DESCRIPTION
This PR ensures Log4cxx threads are joined even when LogManager::shutdown is never called