### PR TITLE
Prevent abnormal termination when telnet appender has no layout

### DIFF
--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -19,11 +19,14 @@
 #include <log4cxx/helpers/loglog.h>
 #include <log4cxx/helpers/optionconverter.h>
 #include <log4cxx/helpers/stringhelper.h>
+#include <log4cxx/helpers/serversocket.h>
 #include <log4cxx/helpers/charsetencoder.h>
 #include <log4cxx/helpers/bytebuffer.h>
 #include <log4cxx/helpers/threadutility.h>
 #include <log4cxx/private/appenderskeleton_priv.h>
 #include <mutex>
+#include <thread>
+#include <vector>
 
 #if LOG4CXX_EVENTS_AT_EXIT
 #include <log4cxx/private/atexitregistry.h>

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -33,6 +33,9 @@ using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
 using namespace LOG4CXX_NS::net;
 
+typedef helpers::SocketPtr Connection;
+LOG4CXX_LIST_DEF(ConnectionList, Connection);
+
 IMPLEMENT_LOG4CXX_OBJECT(TelnetAppender)
 
 struct TelnetAppender::TelnetAppenderPriv : public AppenderSkeletonPrivate

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -340,7 +340,19 @@ int TelnetAppender::getMaxConnections() const
 
 void TelnetAppender::setMaxConnections(int newValue)
 {
-	_priv->connections.resize(newValue);
+	std::lock_guard<std::recursive_mutex> lock(_priv->mutex);
+	if (_priv->connections.size() < newValue)
+		_priv->connections.resize(newValue);
+	else while (newValue < _priv->connections.size())
+	{
+		auto item = _priv->connections.back();
+		_priv->connections.pop_back()
+		if (item)
+		{
+			item->close();
+			--_priv->activeConnections;
+		}
+	}
 }
 
 bool TelnetAppender::requiresLayout() const

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -117,6 +117,10 @@ void TelnetAppender::setOption(const LogString& option,
 	{
 		setPort(OptionConverter::toInt(value, DEFAULT_PORT));
 	}
+	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("MAXCONNECTIONS"), LOG4CXX_STR("maxconnections")))
+	{
+		setMaxConnections(OptionConverter::toInt(value, MAX_CONNECTIONS));
+	}
 	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("ENCODING"), LOG4CXX_STR("encoding")))
 	{
 		setEncoding(value);
@@ -203,7 +207,10 @@ void TelnetAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 	if (count > 0)
 	{
 		LogString msg;
-		_priv->layout->format(msg, event, _priv->pool);
+		if (_priv->layout)
+			_priv->layout->format(msg, event, p);
+		else
+			msg = event->getMessage();
 		msg.append(LOG4CXX_STR("\r\n"));
 		size_t bytesSize = msg.size() * 2;
 		char* bytes = p.pstralloc(bytesSize);
@@ -317,4 +324,14 @@ int TelnetAppender::getPort() const
 void TelnetAppender::setPort(int port1)
 {
 	_priv->port = port1;
+}
+
+int TelnetAppender::getMaxConnections() const
+{
+	return static_cast<int>(_priv->connections.size());
+}
+
+void TelnetAppender::setMaxConnections(int newValue)
+{
+	_priv->connections.resize(newValue);
 }

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -107,7 +107,8 @@ void TelnetAppender::activateOptions(Pool& /* p */)
 		_priv->serverSocket->setSoTimeout(1000);
 	}
 
-	_priv->sh = ThreadUtility::instance()->createThread( LOG4CXX_STR("TelnetAppender"), &TelnetAppender::acceptConnections, this );
+	if (!_priv->sh.joinable())
+		_priv->sh = ThreadUtility::instance()->createThread( LOG4CXX_STR("TelnetAppender"), &TelnetAppender::acceptConnections, this );
 }
 
 void TelnetAppender::setOption(const LogString& option,

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -335,3 +335,8 @@ void TelnetAppender::setMaxConnections(int newValue)
 {
 	_priv->connections.resize(newValue);
 }
+
+bool TelnetAppender::requiresLayout() const
+{
+	return false;
+}

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -346,7 +346,7 @@ void TelnetAppender::setMaxConnections(int newValue)
 	else while (newValue < _priv->connections.size())
 	{
 		auto item = _priv->connections.back();
-		_priv->connections.pop_back()
+		_priv->connections.pop_back();
 		if (item)
 		{
 			item->close();

--- a/src/main/include/log4cxx/net/telnetappender.h
+++ b/src/main/include/log4cxx/net/telnetappender.h
@@ -115,6 +115,7 @@ class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 		Supported options | Supported values | Default value
 		-------------- | ---------------- | ---------------
 		Port | {int} | 23
+		MaxConnections | {int} | 20
 		Encoding | C,UTF-8,UTF-16,UTF-16BE,UTF-16LE,646,US-ASCII,ISO646-US,ANSI_X3.4-1968,ISO-8859-1,ISO-LATIN-1 | UTF-8
 
 		\sa AppenderSkeleton::setOption()
@@ -131,6 +132,20 @@ class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 		the port where the server is waiting for connections.
 		*/
 		void setPort(int port1);
+
+		/**
+		The number of allowed concurrent conections.
+
+		\sa setOption
+		 */
+		int getMaxConnections() const;
+
+		/**
+		Set the number of allowed concurrent conections to \c newValue.
+
+		\sa setOption
+		 */
+		void setMaxConnections(int newValue);
 
 
 		/** shuts down the appender. */

--- a/src/main/include/log4cxx/net/telnetappender.h
+++ b/src/main/include/log4cxx/net/telnetappender.h
@@ -33,8 +33,6 @@ class ByteBuffer;
 }
 namespace net
 {
-typedef LOG4CXX_NS::helpers::SocketPtr Connection;
-LOG4CXX_LIST_DEF(ConnectionList, Connection);
 
 /**
 The TelnetAppender writes log messages to
@@ -52,8 +50,6 @@ See TelnetAppender::setOption() for the available options.
 */
 class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 {
-		class SocketHandler;
-		friend class SocketHandler;
 	private:
 		static const int DEFAULT_PORT;
 		static const int MAX_CONNECTIONS;
@@ -141,15 +137,13 @@ class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 		*/
 		void append(const spi::LoggingEventPtr& event, helpers::Pool& p) override;
 
-		//---------------------------------------------------------- SocketHandler:
-
 	private:
 		//   prevent copy and assignment statements
 		TelnetAppender(const TelnetAppender&);
 		TelnetAppender& operator=(const TelnetAppender&);
 
-		void write(LOG4CXX_NS::helpers::ByteBuffer&);
-		void writeStatus(const LOG4CXX_NS::helpers::SocketPtr& socket, const LogString& msg, LOG4CXX_NS::helpers::Pool& p);
+		void write(helpers::ByteBuffer&);
+		void writeStatus(const helpers::SocketPtr& socket, const LogString& msg, helpers::Pool& p);
 		void acceptConnections();
 
 		struct TelnetAppenderPriv;

--- a/src/main/include/log4cxx/net/telnetappender.h
+++ b/src/main/include/log4cxx/net/telnetappender.h
@@ -120,26 +120,26 @@ class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 		void setPort(int port1);
 
 		/**
-		The number of allowed concurrent conections.
+		The number of allowed concurrent connections.
 
 		\sa setOption
 		 */
 		int getMaxConnections() const;
 
 		/**
-		Set the number of allowed concurrent conections to \c newValue.
+		Set the number of allowed concurrent connections to \c newValue.
 
 		\sa setOption
 		 */
 		void setMaxConnections(int newValue);
 
 
-		/** shuts down the appender. */
+		/** Shutdown this appender. */
 		void close() override;
 
 	protected:
-		/** Handles a log event.  For this appender, that means writing the
-		message to each connected client.  */
+		/** Send \c event to each connected client.
+		*/
 		void append(const spi::LoggingEventPtr& event, helpers::Pool& p) override;
 
 		//---------------------------------------------------------- SocketHandler:

--- a/src/main/include/log4cxx/net/telnetappender.h
+++ b/src/main/include/log4cxx/net/telnetappender.h
@@ -36,8 +36,9 @@ clients that connect to the TCP port.
 
 This allows logging output to be monitored using TCP/IP.
 To receive log data, use telnet to connect to the configured port number.
-This is handy for remote monitoring, especially when monitoring a
-servlet.
+
+TelnetAppender is most useful as a secondary appender,
+especially when monitoring a servlet remotely.
 
 If no layout is provided, the log message only is sent to attached client(s).
 

--- a/src/main/include/log4cxx/net/telnetappender.h
+++ b/src/main/include/log4cxx/net/telnetappender.h
@@ -37,29 +37,18 @@ typedef LOG4CXX_NS::helpers::SocketPtr Connection;
 LOG4CXX_LIST_DEF(ConnectionList, Connection);
 
 /**
-<p>The TelnetAppender is a log4cxx appender that specializes in
-writing to a read-only socket.  The output is provided in a
-telnet-friendly way so that a log can be monitored over TCP/IP.
-Clients using telnet connect to the socket and receive log data.
+The TelnetAppender writes log messages to
+clients that connect to the TCP port.
+
+This allows logging output to be monitored using TCP/IP.
+To receive log data, use telnet to connect to the configured port number.
 This is handy for remote monitoring, especially when monitoring a
 servlet.
 
-<p>Here is a list of the available configuration options:
+If no layout is provided, the log message only is sent to attached client(s).
 
-<table border=1>
-<tr>
-<td align=center><b>Name</b></td>
-<td align=center><b>Requirement</b></td>
-<td align=center><b>Description</b></td>
-<td align=center><b>Sample Value</b></td>
-</tr>
+See TelnetAppender::setOption() for the available options.
 
-<tr>
-<td>Port</td>
-<td>optional</td>
-<td>This parameter determines the port to use for announcing log events.  The default port is 23 (telnet).</td>
-<td>5875</td>
-</table>
 */
 class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 {
@@ -80,12 +69,9 @@ class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 		~TelnetAppender();
 
 		/**
-		This appender requires a layout to format the text to the
-		attached client(s). */
-		bool requiresLayout() const override
-		{
-			return true;
-		}
+		If no layout is provided, sends only the log message to attached client(s).
+		*/
+		bool requiresLayout() const override;
 
 		/**
 		The current encoding value.

--- a/src/main/include/log4cxx/net/telnetappender.h
+++ b/src/main/include/log4cxx/net/telnetappender.h
@@ -20,10 +20,6 @@
 
 #include <log4cxx/appenderskeleton.h>
 #include <log4cxx/helpers/socket.h>
-#include <log4cxx/helpers/serversocket.h>
-#include <thread>
-#include <vector>
-#include <log4cxx/helpers/charsetencoder.h>
 
 namespace LOG4CXX_NS
 {

--- a/src/main/include/log4cxx/net/telnetappender.h
+++ b/src/main/include/log4cxx/net/telnetappender.h
@@ -109,15 +109,14 @@ class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 		void setOption(const LogString& option, const LogString& value) override;
 
 		/**
-		Returns value of the <b>Port</b> option.
+		The TCP <b>Port</b> number on which to accept connections.
 		*/
 		int getPort() const;
 
 		/**
-		The <b>Port</b> option takes a positive integer representing
-		the port where the server is waiting for connections.
+		Use \c newValue as the TCP port number on which to accept connections.
 		*/
-		void setPort(int port1);
+		void setPort(int newValue);
 
 		/**
 		The number of allowed concurrent connections.

--- a/src/site/markdown/concepts.md
+++ b/src/site/markdown/concepts.md
@@ -454,7 +454,8 @@ Log4cxx provides appenders to write to:
 - [files](@ref log4cxx.rolling.RollingFileAppender)
 - [the NT Event log](@ref log4cxx.nt.NTEventLogAppender)
 - [the UNIX Syslog](@ref log4cxx.net.SyslogAppender)
-- [a socket server](@ref log4cxx.net.XMLSocketAppender)
+- [a TCP port](@ref log4cxx.net.TelnetAppender)
+- [a remote log processor](@ref log4cxx.net.XMLSocketAppender)
 - [a SMTP server](@ref log4cxx.net.SMTPAppender)
 - [a database](@ref log4cxx.db.ODBCAppender)
 

--- a/src/test/cpp/net/telnetappendertestcase.cpp
+++ b/src/test/cpp/net/telnetappendertestcase.cpp
@@ -20,6 +20,7 @@
 #include "../appenderskeletontestcase.h"
 #include <apr_thread_proc.h>
 #include <apr_time.h>
+#include <thread>
 
 using namespace log4cxx;
 using namespace log4cxx::helpers;

--- a/src/test/cpp/net/telnetappendertestcase.cpp
+++ b/src/test/cpp/net/telnetappendertestcase.cpp
@@ -102,8 +102,8 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 		void testActivateWriteNoClose()
 		{
 			TelnetAppenderPtr appender(new TelnetAppender());
-			appender->setLayout(createLayout());
 			appender->setPort(TEST_PORT);
+			appender->setMaxConnections(1);
 			Pool p;
 			appender->activateOptions(p);
 			LoggerPtr root(Logger::getRootLogger());
@@ -111,6 +111,10 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 
 			for (int i = 0; i < 50; i++)
 			{
+//#define ALLOW_TESTING_WITH_TELNET
+#ifdef ALLOW_TESTING_WITH_TELNET
+				std::this_thread::sleep_for( std::chrono::milliseconds( 1000 ) );
+#endif
 				LOG4CXX_INFO(root, "Hello, World " << i);
 			}
 		}


### PR DESCRIPTION
Sending just the log message seems a reasonable default when a layout is not specified in the configuration. Currently Log4cxx causes abnormal termination in this case.

Also, the number of allowed connections was not documented and could not be configured.