### PR TITLE
Remove APR pool from Logger constructor in next ABI version

### DIFF
--- a/src/main/cpp/appenderattachableimpl.cpp
+++ b/src/main/cpp/appenderattachableimpl.cpp
@@ -30,15 +30,16 @@ struct AppenderAttachableImpl::priv_data
 	mutable std::mutex m_mutex;
 };
 
+AppenderAttachableImpl::AppenderAttachableImpl()
+{
+}
 
 #if LOG4CXX_ABI_VERSION <= 15
 AppenderAttachableImpl::AppenderAttachableImpl(Pool& pool)
 	: m_priv()
-#else
-AppenderAttachableImpl::AppenderAttachableImpl()
-#endif
 {
 }
+#endif
 
 AppenderAttachableImpl::~AppenderAttachableImpl()
 {

--- a/src/main/cpp/appenderattachableimpl.cpp
+++ b/src/main/cpp/appenderattachableimpl.cpp
@@ -20,7 +20,6 @@
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
-using namespace LOG4CXX_NS::spi;
 
 IMPLEMENT_LOG4CXX_OBJECT(AppenderAttachableImpl)
 

--- a/src/main/cpp/appenderattachableimpl.cpp
+++ b/src/main/cpp/appenderattachableimpl.cpp
@@ -14,12 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <log4cxx/logstring.h>
 #include <log4cxx/helpers/appenderattachableimpl.h>
-#include <log4cxx/appender.h>
-#include <log4cxx/spi/loggingevent.h>
 #include <algorithm>
-#include <log4cxx/helpers/pool.h>
 #include <mutex>
 
 using namespace LOG4CXX_NS;
@@ -36,8 +32,12 @@ struct AppenderAttachableImpl::priv_data
 };
 
 
+#if LOG4CXX_ABI_VERSION <= 15
 AppenderAttachableImpl::AppenderAttachableImpl(Pool& pool)
 	: m_priv()
+#else
+AppenderAttachableImpl::AppenderAttachableImpl()
+#endif
 {
 }
 

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -119,9 +119,6 @@ struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkele
 		AppenderSkeletonPrivate(),
 		buffer(DEFAULT_BUFFER_SIZE),
 		bufferSize(DEFAULT_BUFFER_SIZE),
-#if LOG4CXX_ABI_VERSION <= 15
-		appenders(pool),
-#endif
 		dispatcher(),
 		locationInfo(false),
 		blocking(true)

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -119,7 +119,9 @@ struct AsyncAppender::AsyncAppenderPriv : public AppenderSkeleton::AppenderSkele
 		AppenderSkeletonPrivate(),
 		buffer(DEFAULT_BUFFER_SIZE),
 		bufferSize(DEFAULT_BUFFER_SIZE),
+#if LOG4CXX_ABI_VERSION <= 15
 		appenders(pool),
+#endif
 		dispatcher(),
 		locationInfo(false),
 		blocking(true)

--- a/src/main/cpp/defaultloggerfactory.cpp
+++ b/src/main/cpp/defaultloggerfactory.cpp
@@ -22,15 +22,16 @@ using namespace LOG4CXX_NS;
 
 IMPLEMENT_LOG4CXX_OBJECT(DefaultLoggerFactory)
 
-LoggerPtr DefaultLoggerFactory::makeNewLoggerInstance(
+LoggerPtr DefaultLoggerFactory::makeNewLoggerInstance(const LogString& name) const
+{
+	return std::make_shared<Logger>(name);
+}
+
 #if LOG4CXX_ABI_VERSION <= 15
+LoggerPtr DefaultLoggerFactory::makeNewLoggerInstance(
 	helpers::Pool& pool,
-#endif
 	const LogString& name) const
 {
-#if LOG4CXX_ABI_VERSION <= 15
 	return std::make_shared<Logger>(pool, name);
-#else
-	return std::make_shared<Logger>(name);
-#endif
 }
+#endif

--- a/src/main/cpp/defaultloggerfactory.cpp
+++ b/src/main/cpp/defaultloggerfactory.cpp
@@ -18,15 +18,11 @@
 #if LOG4CXX_ABI_VERSION <= 15
 #include <log4cxx/defaultloggerfactory.h>
 #else
-#include <log4cxx/loggerfactory.h>
+#include <log4cxx/spi/loggerfactory.h>
 #endif
 
 using namespace LOG4CXX_NS;
-
-LoggerPtr spi::LoggerFactory::makeNewLoggerInstance(const LogString& name) const
-{
-	return std::make_shared<Logger>(name);
-}
+using namespace spi;
 
 #if LOG4CXX_ABI_VERSION <= 15
 IMPLEMENT_LOG4CXX_OBJECT(DefaultLoggerFactory)
@@ -38,3 +34,9 @@ LoggerPtr DefaultLoggerFactory::makeNewLoggerInstance(
 	return std::make_shared<Logger>(name);
 }
 #endif
+
+LoggerPtr LoggerFactory::makeNewLoggerInstance(const LogString& name) const
+{
+	return std::make_shared<Logger>(name);
+}
+

--- a/src/main/cpp/defaultloggerfactory.cpp
+++ b/src/main/cpp/defaultloggerfactory.cpp
@@ -23,8 +23,14 @@ using namespace LOG4CXX_NS;
 IMPLEMENT_LOG4CXX_OBJECT(DefaultLoggerFactory)
 
 LoggerPtr DefaultLoggerFactory::makeNewLoggerInstance(
-	LOG4CXX_NS::helpers::Pool& pool,
+#if LOG4CXX_ABI_VERSION <= 15
+	helpers::Pool& pool,
+#endif
 	const LogString& name) const
 {
+#if LOG4CXX_ABI_VERSION <= 15
 	return std::make_shared<Logger>(pool, name);
+#else
+	return std::make_shared<Logger>(name);
+#endif
 }

--- a/src/main/cpp/defaultloggerfactory.cpp
+++ b/src/main/cpp/defaultloggerfactory.cpp
@@ -14,24 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <log4cxx/logstring.h>
+
+#if LOG4CXX_ABI_VERSION <= 15
 #include <log4cxx/defaultloggerfactory.h>
-#include <log4cxx/logger.h>
+#else
+#include <log4cxx/loggerfactory.h>
+#endif
 
 using namespace LOG4CXX_NS;
 
-IMPLEMENT_LOG4CXX_OBJECT(DefaultLoggerFactory)
-
-LoggerPtr DefaultLoggerFactory::makeNewLoggerInstance(const LogString& name) const
+LoggerPtr spi::LoggerFactory::makeNewLoggerInstance(const LogString& name) const
 {
 	return std::make_shared<Logger>(name);
 }
 
 #if LOG4CXX_ABI_VERSION <= 15
+IMPLEMENT_LOG4CXX_OBJECT(DefaultLoggerFactory)
+
 LoggerPtr DefaultLoggerFactory::makeNewLoggerInstance(
 	helpers::Pool& pool,
 	const LogString& name) const
 {
-	return std::make_shared<Logger>(pool, name);
+	return std::make_shared<Logger>(name);
 }
 #endif

--- a/src/main/cpp/domconfigurator.cpp
+++ b/src/main/cpp/domconfigurator.cpp
@@ -30,7 +30,11 @@
 #include <log4cxx/config/propertysetter.h>
 #include <log4cxx/spi/errorhandler.h>
 #include <log4cxx/spi/loggerfactory.h>
+#if LOG4CXX_ABI_VERSION <= 15
 #include <log4cxx/defaultloggerfactory.h>
+#else
+#include <log4cxx/loggerfactory.h>
+#endif
 #include <log4cxx/helpers/filewatchdog.h>
 #include <log4cxx/spi/loggerrepository.h>
 #include <log4cxx/spi/loggingevent.h>
@@ -819,7 +823,11 @@ spi::ConfigurationStatus DOMConfigurator::doConfigure(const File& filename, spi:
 		LogLog::debug(msg);
 	}
 
+#if LOG4CXX_ABI_VERSION <= 15
 	m_priv->loggerFactory = std::make_shared<DefaultLoggerFactory>();
+#else
+	m_priv->loggerFactory = std::make_shared<LoggerFactory>();
+#endif
 
 	Pool p;
 	apr_file_t* fd;

--- a/src/main/cpp/domconfigurator.cpp
+++ b/src/main/cpp/domconfigurator.cpp
@@ -33,7 +33,7 @@
 #if LOG4CXX_ABI_VERSION <= 15
 #include <log4cxx/defaultloggerfactory.h>
 #else
-#include <log4cxx/loggerfactory.h>
+#include <log4cxx/spi/loggerfactory.h>
 #endif
 #include <log4cxx/helpers/filewatchdog.h>
 #include <log4cxx/spi/loggerrepository.h>

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -227,7 +227,11 @@ LevelPtr Hierarchy::getThreshold() const
 
 LoggerPtr Hierarchy::getLogger(const LogString& name)
 {
+#if LOG4CXX_ABI_VERSION <= 15
 	static WideLife<spi::LoggerFactoryPtr> defaultFactory = std::make_shared<DefaultLoggerFactory>();
+#else
+	static WideLife<spi::LoggerFactoryPtr> defaultFactory = std::make_shared<LoggerFactory>();
+#endif
 	return getLogger(name, defaultFactory);
 }
 
@@ -246,7 +250,11 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 	}
 	if (!result && factory)
 	{
+#if LOG4CXX_ABI_VERSION <= 15
+		LoggerPtr logger(factory->makeNewLoggerInstance(m_priv->pool, name));
+#else
 		LoggerPtr logger(factory->makeNewLoggerInstance(name));
+#endif
 		logger->setHierarchy(this);
 		m_priv->loggers.insert(LoggerMap::value_type(name, logger));
 
@@ -283,7 +291,7 @@ LoggerPtr Hierarchy::getRootLogger() const
 	std::lock_guard<std::recursive_mutex> lock(m_priv->mutex);
 	if (!m_priv->root)
 	{
-		m_priv->root = std::make_shared<RootLogger>(m_priv->pool, Level::getDebug());
+		m_priv->root = std::make_shared<RootLogger>(Level::getDebug());
 		m_priv->root->setHierarchy(const_cast<Hierarchy*>(this));
 	}
 

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -246,7 +246,11 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 	}
 	if (!result && factory)
 	{
+#if LOG4CXX_ABI_VERSION <= 15
 		LoggerPtr logger(factory->makeNewLoggerInstance(m_priv->pool, name));
+#else
+		LoggerPtr logger(factory->makeNewLoggerInstance(name));
+#endif
 		logger->setHierarchy(this);
 		m_priv->loggers.insert(LoggerMap::value_type(name, logger));
 

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -15,24 +15,18 @@
  * limitations under the License.
  */
 
-#include <log4cxx/logstring.h>
-#include <log4cxx/spi/loggerfactory.h>
 #include <log4cxx/hierarchy.h>
+#if LOG4CXX_ABI_VERSION <= 15
 #include <log4cxx/defaultloggerfactory.h>
-#include <log4cxx/logger.h>
-#include <log4cxx/spi/hierarchyeventlistener.h>
-#include <log4cxx/level.h>
-#include <algorithm>
+#endif
 #include <log4cxx/helpers/loglog.h>
 #include <log4cxx/appender.h>
-#include <log4cxx/logstring.h>
 #include <log4cxx/helpers/stringhelper.h>
-#if !defined(LOG4CXX)
-	#define LOG4CXX 1
-#endif
 #include <log4cxx/spi/rootlogger.h>
+#include <algorithm>
+#include <map>
 #include <mutex>
-#include "assert.h"
+#include <vector>
 
 
 using namespace LOG4CXX_NS;

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -246,11 +246,7 @@ LoggerPtr Hierarchy::getLogger(const LogString& name,
 	}
 	if (!result && factory)
 	{
-#if LOG4CXX_ABI_VERSION <= 15
-		LoggerPtr logger(factory->makeNewLoggerInstance(m_priv->pool, name));
-#else
 		LoggerPtr logger(factory->makeNewLoggerInstance(name));
-#endif
 		logger->setHierarchy(this);
 		m_priv->loggers.insert(LoggerMap::value_type(name, logger));
 

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -93,9 +93,8 @@ Logger::Logger(const LogString& name1)
 }
 
 #if LOG4CXX_ABI_VERSION <= 15
-Logger::Logger(Pool& p, const LogString& name1)
-	: m_priv(std::make_unique<LoggerPrivate>(name1))
-	, m_threshold(0)
+Logger::Logger(Pool& p, const LogString& name)
+	: Logger(name)
 {
 }
 #endif

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -37,16 +37,9 @@ using namespace LOG4CXX_NS::spi;
 
 struct Logger::LoggerPrivate
 {
-	LoggerPrivate(
-#if LOG4CXX_ABI_VERSION <= 15
-		Pool& p,
-#endif
-		const LogString& name1)
+	LoggerPrivate(const LogString& name1)
 		: name(name1)
 		, repositoryRaw(0)
-#if LOG4CXX_ABI_VERSION <= 15
-		, aai(p)
-#endif
 		, additive(true)
 		, levelData(Level::getData())
 		{}
@@ -93,16 +86,19 @@ struct Logger::LoggerPrivate
 
 IMPLEMENT_LOG4CXX_OBJECT(Logger)
 
-#if LOG4CXX_ABI_VERSION <= 15
-Logger::Logger(Pool& p, const LogString& name1)
-	: m_priv(std::make_unique<LoggerPrivate>(p, name1))
-#else
 Logger::Logger(const LogString& name1)
 	: m_priv(std::make_unique<LoggerPrivate>(name1))
-#endif
 	, m_threshold(0)
 {
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+Logger::Logger(Pool& p, const LogString& name1)
+	: m_priv(std::make_unique<LoggerPrivate>(name1))
+	, m_threshold(0)
+{
+}
+#endif
 
 Logger::~Logger()
 {

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -15,14 +15,11 @@
  * limitations under the License.
  */
 
-#include <log4cxx/logstring.h>
 #include <log4cxx/logger.h>
 #include <log4cxx/spi/loggingevent.h>
 #include <log4cxx/logmanager.h>
-#include <log4cxx/spi/loggerfactory.h>
 #include <log4cxx/appender.h>
 #include <log4cxx/level.h>
-#include <log4cxx/helpers/loglog.h>
 #include <log4cxx/hierarchy.h>
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/transcoder.h>
@@ -40,12 +37,19 @@ using namespace LOG4CXX_NS::spi;
 
 struct Logger::LoggerPrivate
 {
-	LoggerPrivate(Pool& p, const LogString& name1):
-		name(name1),
-		repositoryRaw(0),
-		aai(p),
-		additive(true),
-		levelData(Level::getData()) {}
+	LoggerPrivate(
+#if LOG4CXX_ABI_VERSION <= 15
+		Pool& p,
+#endif
+		const LogString& name1)
+		: name(name1)
+		, repositoryRaw(0)
+#if LOG4CXX_ABI_VERSION <= 15
+		, aai(p)
+#endif
+		, additive(true)
+		, levelData(Level::getData())
+		{}
 
 	/**
 	The name of this logger.
@@ -71,7 +75,7 @@ struct Logger::LoggerPrivate
 
 
 	// Loggers need to know what Hierarchy they are in
-	LOG4CXX_NS::spi::LoggerRepository* repositoryRaw;
+	spi::LoggerRepository* repositoryRaw;
 
 	helpers::AppenderAttachableImpl aai;
 
@@ -89,8 +93,13 @@ struct Logger::LoggerPrivate
 
 IMPLEMENT_LOG4CXX_OBJECT(Logger)
 
+#if LOG4CXX_ABI_VERSION <= 15
 Logger::Logger(Pool& p, const LogString& name1)
 	: m_priv(std::make_unique<LoggerPrivate>(p, name1))
+#else
+Logger::Logger(const LogString& name1)
+	: m_priv(std::make_unique<LoggerPrivate>(name1))
+#endif
 	, m_threshold(0)
 {
 }

--- a/src/main/cpp/propertyconfigurator.cpp
+++ b/src/main/cpp/propertyconfigurator.cpp
@@ -17,20 +17,20 @@
 
 #include <log4cxx/logstring.h>
 #include <log4cxx/propertyconfigurator.h>
-#include <log4cxx/spi/loggerfactory.h>
 #include <log4cxx/helpers/properties.h>
 #include <log4cxx/helpers/loglog.h>
 #include <log4cxx/helpers/exception.h>
 #include <log4cxx/logmanager.h>
 #include <log4cxx/helpers/optionconverter.h>
 #include <log4cxx/level.h>
+#if LOG4CXX_ABI_VERSION <= 15
 #include <log4cxx/defaultloggerfactory.h>
+#else
+#include <log4cxx/spi/loggerfactory.h>
+#endif
 #include <log4cxx/helpers/stringhelper.h>
-#include <log4cxx/appender.h>
-#include <log4cxx/logger.h>
 #include <log4cxx/layout.h>
 #include <log4cxx/config/propertysetter.h>
-#include <log4cxx/spi/loggerrepository.h>
 #include <log4cxx/helpers/stringtokenizer.h>
 #include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/helpers/fileinputstream.h>

--- a/src/main/cpp/propertyconfigurator.cpp
+++ b/src/main/cpp/propertyconfigurator.cpp
@@ -75,7 +75,12 @@ PropertyWatchdog* PropertyConfigurator::pdog = NULL;
 IMPLEMENT_LOG4CXX_OBJECT(PropertyConfigurator)
 
 PropertyConfigurator::PropertyConfigurator()
-	: registry(new std::map<LogString, AppenderPtr>()), loggerFactory(new DefaultLoggerFactory())
+	: registry(new std::map<LogString, AppenderPtr>())
+#if LOG4CXX_ABI_VERSION <= 15
+	, loggerFactory(new DefaultLoggerFactory())
+#else
+	, loggerFactory(new LoggerFactory())
+#endif
 {
 }
 

--- a/src/main/cpp/rootlogger.cpp
+++ b/src/main/cpp/rootlogger.cpp
@@ -25,7 +25,11 @@ using namespace LOG4CXX_NS::spi;
 using namespace LOG4CXX_NS::helpers;
 
 RootLogger::RootLogger(Pool& pool, const LevelPtr level1) :
+#if LOG4CXX_ABI_VERSION <= 15
 	Logger(pool, LOG4CXX_STR("root"))
+#else
+	Logger(LOG4CXX_STR("root"))
+#endif
 {
 	setLevel(level1);
 }

--- a/src/main/cpp/rootlogger.cpp
+++ b/src/main/cpp/rootlogger.cpp
@@ -24,15 +24,18 @@ using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::spi;
 using namespace LOG4CXX_NS::helpers;
 
-RootLogger::RootLogger(Pool& pool, const LevelPtr level1) :
-#if LOG4CXX_ABI_VERSION <= 15
-	Logger(pool, LOG4CXX_STR("root"))
-#else
-	Logger(LOG4CXX_STR("root"))
-#endif
+RootLogger::RootLogger(const LevelPtr& level1)
+	: Logger(LOG4CXX_STR("root"))
 {
 	setLevel(level1);
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+RootLogger::RootLogger(Pool&, const LevelPtr level)
+	: RootLogger(level)
+{
+}
+#endif
 
 const LevelPtr& RootLogger::getEffectiveLevel() const
 {

--- a/src/main/include/log4cxx/defaultloggerfactory.h
+++ b/src/main/include/log4cxx/defaultloggerfactory.h
@@ -26,6 +26,7 @@ namespace LOG4CXX_NS
 class Logger;
 typedef std::shared_ptr<Logger> LoggerPtr;
 
+#if LOG4CXX_ABI_VERSION <= 15
 class LOG4CXX_EXPORT DefaultLoggerFactory :
 	public virtual spi::LoggerFactory,
 	public virtual helpers::Object
@@ -36,15 +37,12 @@ class LOG4CXX_EXPORT DefaultLoggerFactory :
 		LOG4CXX_CAST_ENTRY(spi::LoggerFactory)
 		END_LOG4CXX_CAST_MAP()
 
-		LoggerPtr makeNewLoggerInstance(const LogString& name) const override;
-
-#if LOG4CXX_ABI_VERSION <= 15
 		[[ deprecated( "Pool is no longer required" ) ]]
 		LoggerPtr makeNewLoggerInstance(
 			helpers::Pool& pool,
 			const LogString& name) const override;
-#endif
 };
+#endif
 }  // namespace log4cxx
 
 #endif //_LOG4CXX_DEFAULT_LOGGER_FACTORY_H

--- a/src/main/include/log4cxx/defaultloggerfactory.h
+++ b/src/main/include/log4cxx/defaultloggerfactory.h
@@ -36,7 +36,11 @@ class LOG4CXX_EXPORT DefaultLoggerFactory :
 		LOG4CXX_CAST_ENTRY(spi::LoggerFactory)
 		END_LOG4CXX_CAST_MAP()
 
-		LoggerPtr makeNewLoggerInstance(helpers::Pool& pool, const LogString& name) const override;
+		LoggerPtr makeNewLoggerInstance(
+#if LOG4CXX_ABI_VERSION <= 15
+			helpers::Pool& pool,
+#endif
+			const LogString& name) const override;
 };
 }  // namespace log4cxx
 

--- a/src/main/include/log4cxx/defaultloggerfactory.h
+++ b/src/main/include/log4cxx/defaultloggerfactory.h
@@ -38,9 +38,7 @@ class LOG4CXX_EXPORT DefaultLoggerFactory :
 		END_LOG4CXX_CAST_MAP()
 
 		[[ deprecated( "Pool is no longer required" ) ]]
-		LoggerPtr makeNewLoggerInstance(
-			helpers::Pool& pool,
-			const LogString& name) const override;
+		LoggerPtr makeNewLoggerInstance(helpers::Pool& pool, const LogString& name) const override;
 };
 #endif
 }  // namespace log4cxx

--- a/src/main/include/log4cxx/defaultloggerfactory.h
+++ b/src/main/include/log4cxx/defaultloggerfactory.h
@@ -36,11 +36,14 @@ class LOG4CXX_EXPORT DefaultLoggerFactory :
 		LOG4CXX_CAST_ENTRY(spi::LoggerFactory)
 		END_LOG4CXX_CAST_MAP()
 
-		LoggerPtr makeNewLoggerInstance(
+		LoggerPtr makeNewLoggerInstance(const LogString& name) const override;
+
 #if LOG4CXX_ABI_VERSION <= 15
+		[[ deprecated( "Pool is no longer required" ) ]]
+		LoggerPtr makeNewLoggerInstance(
 			helpers::Pool& pool,
-#endif
 			const LogString& name) const override;
+#endif
 };
 }  // namespace log4cxx
 

--- a/src/main/include/log4cxx/helpers/appenderattachableimpl.h
+++ b/src/main/include/log4cxx/helpers/appenderattachableimpl.h
@@ -44,10 +44,10 @@ class LOG4CXX_EXPORT AppenderAttachableImpl :
 		/**
 		 *   Create new instance.
 		 */
-#if LOG4CXX_ABI_VERSION <= 15
-		AppenderAttachableImpl(Pool& pool);
-#else
 		AppenderAttachableImpl();
+#if LOG4CXX_ABI_VERSION <= 15
+		[[ deprecated( "Pool is no longer required" ) ]]
+		AppenderAttachableImpl(Pool& pool);
 #endif
 		~AppenderAttachableImpl();
 

--- a/src/main/include/log4cxx/helpers/appenderattachableimpl.h
+++ b/src/main/include/log4cxx/helpers/appenderattachableimpl.h
@@ -20,10 +20,8 @@
 
 
 #include <log4cxx/spi/appenderattachable.h>
-#include <log4cxx/helpers/object.h>
 #include <log4cxx/helpers/pool.h>
 #include <log4cxx/log4cxx.h>
-#include <mutex>
 
 namespace LOG4CXX_NS
 {
@@ -45,10 +43,12 @@ class LOG4CXX_EXPORT AppenderAttachableImpl :
 	public:
 		/**
 		 *   Create new instance.
-		 *   @param pool pool, must be longer-lived than instance.
 		 */
+#if LOG4CXX_ABI_VERSION <= 15
 		AppenderAttachableImpl(Pool& pool);
-
+#else
+		AppenderAttachableImpl();
+#endif
 		~AppenderAttachableImpl();
 
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(AppenderAttachableImpl)

--- a/src/main/include/log4cxx/hierarchy.h
+++ b/src/main/include/log4cxx/hierarchy.h
@@ -21,12 +21,8 @@
 
 #include <log4cxx/spi/loggerrepository.h>
 #include <log4cxx/spi/loggerfactory.h>
-#include <vector>
-#include <map>
 #include <log4cxx/provisionnode.h>
-#include <log4cxx/helpers/object.h>
 #include <log4cxx/spi/hierarchyeventlistener.h>
-#include <log4cxx/helpers/pool.h>
 
 namespace LOG4CXX_NS
 {

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -18,7 +18,7 @@
 #ifndef _LOG4CXX_LOGGER_H
 #define _LOG4CXX_LOGGER_H
 
-#include <log4cxx/helpers/appenderattachableimpl.h>
+#include <log4cxx/spi/appenderattachable.h>
 #include <log4cxx/level.h>
 #include <log4cxx/helpers/pool.h>
 #include <log4cxx/spi/location/locationinfo.h>
@@ -46,8 +46,8 @@ LOG4CXX_LIST_DEF(LoggerList, LoggerPtr);
 This is the central class in the log4cxx package. Most logging
 operations, except configuration, are done through this class.
 */
-class LOG4CXX_EXPORT Logger :
-	public virtual LOG4CXX_NS::spi::AppenderAttachable
+class LOG4CXX_EXPORT Logger
+	: public virtual spi::AppenderAttachable
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(Logger)
@@ -66,12 +66,12 @@ class LOG4CXX_EXPORT Logger :
 		sets its name.
 
 		<p>It is intended to be only used by factory-classes.
-
-		@param pool lifetime of pool must be longer than logger.
-		@param name The name of the logger.
 		*/
+#if LOG4CXX_ABI_VERSION <= 15
 		Logger(helpers::Pool& pool, const LogString& name);
-
+#else
+		Logger(const LogString& name);
+#endif
 		~Logger();
 
 
@@ -97,7 +97,7 @@ class LOG4CXX_EXPORT Logger :
 		@param event the event to log.
 		@param p memory pool for any allocations needed to process request.
 		*/
-		void callAppenders(const LOG4CXX_NS::spi::LoggingEventPtr& event, LOG4CXX_NS::helpers::Pool& p) const;
+		void callAppenders(const spi::LoggingEventPtr& event, helpers::Pool& p) const;
 
 		/**
 		Close all attached appenders implementing the AppenderAttachable

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -67,10 +67,10 @@ class LOG4CXX_EXPORT Logger
 
 		<p>It is intended to be only used by factory-classes.
 		*/
-#if LOG4CXX_ABI_VERSION <= 15
-		Logger(helpers::Pool& pool, const LogString& name);
-#else
 		Logger(const LogString& name);
+#if LOG4CXX_ABI_VERSION <= 15
+		[[ deprecated( "Pool is no longer required" ) ]]
+		Logger(helpers::Pool& pool, const LogString& name);
 #endif
 		~Logger();
 

--- a/src/main/include/log4cxx/logmanager.h
+++ b/src/main/include/log4cxx/logmanager.h
@@ -98,7 +98,7 @@ class LOG4CXX_EXPORT LogManager
 		static LoggerPtr getLogger(const std::string& name,
 			const spi::LoggerFactoryPtr& factory);
 		/**
-		 A pointer to the logger \c name instance if it exists in the hierarchy.
+		 A pointer to the Logger \c name instance if it exists in the {@link spi::LoggerRepository LoggerRepository}.
 
 		 @returns A null pointer unless the \c name Logger already exists.
 		 */
@@ -124,7 +124,7 @@ class LOG4CXX_EXPORT LogManager
 		static LoggerPtr getLogger(const std::wstring& name,
 			const spi::LoggerFactoryPtr& factory);
 		/**
-		 A pointer to the logger \c name instance if it exists in the hierarchy.
+		 A pointer to the Logger \c name instance if it exists in the {@link spi::LoggerRepository LoggerRepository}.
 
 		 @returns A null pointer unless the \c name Logger already exists.
 		 */
@@ -153,7 +153,7 @@ class LOG4CXX_EXPORT LogManager
 		static LoggerPtr getLogger(const std::basic_string<UniChar>& name,
 			const spi::LoggerFactoryPtr& factory);
 		/**
-		 A pointer to the logger \c name instance if it exists in the hierarchy.
+		 A pointer to the Logger \c name instance if it exists in the {@link spi::LoggerRepository LoggerRepository}.
 
 		 @returns A null pointer unless the \c name Logger already exists.
 		 */
@@ -182,7 +182,7 @@ class LOG4CXX_EXPORT LogManager
 		static LoggerPtr getLogger(const CFStringRef& name,
 			const spi::LoggerFactoryPtr& factory);
 		/**
-		 A pointer to the logger \c name instance if it exists in the hierarchy.
+		 A pointer to the Logger \c name instance if it exists in the {@link spi::LoggerRepository LoggerRepository}.
 
 		 @returns A null pointer unless the \c name Logger already exists.
 		 */
@@ -213,7 +213,7 @@ class LOG4CXX_EXPORT LogManager
 			const spi::LoggerFactoryPtr& factory);
 
 		/**
-		 A pointer to the logger \c name instance if it exists in the hierarchy.
+		 A pointer to the Logger \c name instance if it exists in the {@link spi::LoggerRepository LoggerRepository}.
 
 		 @returns A null pointer unless the \c name Logger already exists.
 		 */
@@ -229,21 +229,21 @@ class LOG4CXX_EXPORT LogManager
 
 		/**
 		Reset all values contained in this current
-		{@link spi::LoggerRepository LoggerRepository}61
+		{@link spi::LoggerRepository LoggerRepository}
 		to their default.
 		*/
 		static void resetConfiguration();
 
 		/**
-		Remove the \c name Logger from the hierarchy.
+		Remove the \c name Logger from the {@link spi::LoggerRepository LoggerRepository}.
 
-		Note: The \c name Logger must be retrieved from the hierarchy
+		Note: The \c name Logger must be retrieved from the {@link spi::LoggerRepository LoggerRepository}
 		\b after any subsequent configuration file change
 		for the newly loaded settings to be used.
 
 		@param name The logger to remove.
 		@param ifNotUsed If true and use_count() indicates there are other references, do not remove the Logger and return false.
-		@returns true if \c name Logger was removed from the hierarchy.
+		@returns true if \c name Logger was removed from the {@link spi::LoggerRepository LoggerRepository}.
 		*/
 		static bool removeLogger(const LogString& name, bool ifNotUsed = true);
 }; // class LogManager

--- a/src/main/include/log4cxx/logmanager.h
+++ b/src/main/include/log4cxx/logmanager.h
@@ -80,7 +80,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using DefaultLoggerFactory to create it if required.
+		using LoggerFactory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured} passing {@link DefaultConfigurator::configure} to ensure
 		the repository is configured.
@@ -105,7 +105,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using DefaultLoggerFactory to create it if required.
+		using LoggerFactory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured} passing {@link DefaultConfigurator::configure} to ensure
 		the repository is configured.
@@ -130,7 +130,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using DefaultLoggerFactory to create it if required.
+		using LoggerFactory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured}
 		passing {@link DefaultConfigurator::configure} to ensure
@@ -157,7 +157,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using DefaultLoggerFactory to create it if required.
+		using LoggerFactory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured}
 		passing {@link DefaultConfigurator::configure} to ensure
@@ -185,7 +185,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using DefaultLoggerFactory to create it if required.
+		using LoggerFactory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured}
 		passing {@link DefaultConfigurator::configure} to ensure

--- a/src/main/include/log4cxx/logmanager.h
+++ b/src/main/include/log4cxx/logmanager.h
@@ -80,7 +80,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using LoggerFactory to create it if required.
+		using the default factory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured} passing {@link DefaultConfigurator::configure} to ensure
 		the repository is configured.
@@ -98,14 +98,16 @@ class LOG4CXX_EXPORT LogManager
 		static LoggerPtr getLogger(const std::string& name,
 			const spi::LoggerFactoryPtr& factory);
 		/**
-		 Does the logger \c name exist in the hierarchy?
+		 A pointer to the logger \c name instance if it exists in the hierarchy.
+
+		 @returns A null pointer unless the \c name Logger already exists.
 		 */
 		static LoggerPtr exists(const std::string& name);
 #if LOG4CXX_WCHAR_T_API
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using LoggerFactory to create it if required.
+		using the default factory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured} passing {@link DefaultConfigurator::configure} to ensure
 		the repository is configured.
@@ -122,7 +124,9 @@ class LOG4CXX_EXPORT LogManager
 		static LoggerPtr getLogger(const std::wstring& name,
 			const spi::LoggerFactoryPtr& factory);
 		/**
-		 Does the logger \c name exist in the hierarchy?
+		 A pointer to the logger \c name instance if it exists in the hierarchy.
+
+		 @returns A null pointer unless the \c name Logger already exists.
 		 */
 		static LoggerPtr exists(const std::wstring& name);
 #endif
@@ -130,7 +134,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using LoggerFactory to create it if required.
+		using the default factory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured}
 		passing {@link DefaultConfigurator::configure} to ensure
@@ -149,7 +153,9 @@ class LOG4CXX_EXPORT LogManager
 		static LoggerPtr getLogger(const std::basic_string<UniChar>& name,
 			const spi::LoggerFactoryPtr& factory);
 		/**
-		 Does the logger \c name exist in the hierarchy?
+		 A pointer to the logger \c name instance if it exists in the hierarchy.
+
+		 @returns A null pointer unless the \c name Logger already exists.
 		 */
 		static LoggerPtr exists(const std::basic_string<UniChar>& name);
 #endif
@@ -157,7 +163,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using LoggerFactory to create it if required.
+		using the default factory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured}
 		passing {@link DefaultConfigurator::configure} to ensure
@@ -176,7 +182,9 @@ class LOG4CXX_EXPORT LogManager
 		static LoggerPtr getLogger(const CFStringRef& name,
 			const spi::LoggerFactoryPtr& factory);
 		/**
-		 Does the logger \c name exist in the hierarchy?
+		 A pointer to the logger \c name instance if it exists in the hierarchy.
+
+		 @returns A null pointer unless the \c name Logger already exists.
 		 */
 		static LoggerPtr exists(const CFStringRef& name);
 #endif
@@ -185,7 +193,7 @@ class LOG4CXX_EXPORT LogManager
 		/**
 		Retrieve the \c name Logger instance from the
 		{@link spi::LoggerRepository LoggerRepository}
-		using LoggerFactory to create it if required.
+		using the default factory to create it if required.
 
 		Calls {@link spi::LoggerRepository::ensureIsConfigured ensureIsConfigured}
 		passing {@link DefaultConfigurator::configure} to ensure
@@ -205,7 +213,9 @@ class LOG4CXX_EXPORT LogManager
 			const spi::LoggerFactoryPtr& factory);
 
 		/**
-		 Does the logger \c name exist in the hierarchy?
+		 A pointer to the logger \c name instance if it exists in the hierarchy.
+
+		 @returns A null pointer unless the \c name Logger already exists.
 		 */
 		static LoggerPtr existsLS(const LogString& name);
 

--- a/src/main/include/log4cxx/spi/appenderattachable.h
+++ b/src/main/include/log4cxx/spi/appenderattachable.h
@@ -19,7 +19,6 @@
 #define _LOG4CXX_SPI_APPENDER_ATTACHABLE_H_
 
 #include <log4cxx/logstring.h>
-#include <vector>
 #include <log4cxx/helpers/object.h>
 #include <log4cxx/appender.h>
 

--- a/src/main/include/log4cxx/spi/loggerfactory.h
+++ b/src/main/include/log4cxx/spi/loggerfactory.h
@@ -32,13 +32,20 @@ a sub-class of Logger.
 class LOG4CXX_EXPORT LoggerFactory : public virtual helpers::Object
 {
 	public:
+#if LOG4CXX_ABI_VERSION <= 15
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(LoggerFactory)
+#else
+		DECLARE_LOG4CXX_OBJECT(LoggerFactory)
+		BEGIN_LOG4CXX_CAST_MAP()
+		LOG4CXX_CAST_ENTRY(LoggerFactory)
+		END_LOG4CXX_CAST_MAP()
+#endif
 		virtual ~LoggerFactory() {}
 
 #if LOG4CXX_ABI_VERSION <= 15
 		LoggerPtr makeNewLoggerInstance(const LogString& name) const;
 #else
-		virtual LoggerPtr makeNewLoggerInstance(const LogString& name) const = 0;
+		virtual LoggerPtr makeNewLoggerInstance(const LogString& name) const;
 #endif
 
 #if LOG4CXX_ABI_VERSION <= 15

--- a/src/main/include/log4cxx/spi/loggerfactory.h
+++ b/src/main/include/log4cxx/spi/loggerfactory.h
@@ -34,7 +34,11 @@ class LOG4CXX_EXPORT LoggerFactory : public virtual helpers::Object
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(LoggerFactory)
 		virtual ~LoggerFactory() {}
-		virtual LoggerPtr makeNewLoggerInstance(helpers::Pool& pool, const LogString& name) const = 0;
+		virtual LoggerPtr makeNewLoggerInstance(
+#if LOG4CXX_ABI_VERSION <= 15
+			helpers::Pool& pool,
+#endif
+			const LogString& name) const = 0;
 };
 
 

--- a/src/main/include/log4cxx/spi/loggerfactory.h
+++ b/src/main/include/log4cxx/spi/loggerfactory.h
@@ -35,7 +35,11 @@ class LOG4CXX_EXPORT LoggerFactory : public virtual helpers::Object
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(LoggerFactory)
 		virtual ~LoggerFactory() {}
 
+#if LOG4CXX_ABI_VERSION <= 15
+		LoggerPtr makeNewLoggerInstance(const LogString& name) const;
+#else
 		virtual LoggerPtr makeNewLoggerInstance(const LogString& name) const = 0;
+#endif
 
 #if LOG4CXX_ABI_VERSION <= 15
 		[[ deprecated( "Pool is no longer required" ) ]]

--- a/src/main/include/log4cxx/spi/loggerfactory.h
+++ b/src/main/include/log4cxx/spi/loggerfactory.h
@@ -34,11 +34,15 @@ class LOG4CXX_EXPORT LoggerFactory : public virtual helpers::Object
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(LoggerFactory)
 		virtual ~LoggerFactory() {}
-		virtual LoggerPtr makeNewLoggerInstance(
+
+		virtual LoggerPtr makeNewLoggerInstance(const LogString& name) const = 0;
+
 #if LOG4CXX_ABI_VERSION <= 15
+		[[ deprecated( "Pool is no longer required" ) ]]
+		virtual LoggerPtr makeNewLoggerInstance(
 			helpers::Pool& pool,
-#endif
 			const LogString& name) const = 0;
+#endif
 };
 
 

--- a/src/main/include/log4cxx/spi/loggerfactory.h
+++ b/src/main/include/log4cxx/spi/loggerfactory.h
@@ -43,16 +43,12 @@ class LOG4CXX_EXPORT LoggerFactory : public virtual helpers::Object
 		virtual ~LoggerFactory() {}
 
 #if LOG4CXX_ABI_VERSION <= 15
+		[[ deprecated( "Pool is no longer required" ) ]]
+		virtual LoggerPtr makeNewLoggerInstance(helpers::Pool& pool, const LogString& name) const = 0;
+
 		LoggerPtr makeNewLoggerInstance(const LogString& name) const;
 #else
 		virtual LoggerPtr makeNewLoggerInstance(const LogString& name) const;
-#endif
-
-#if LOG4CXX_ABI_VERSION <= 15
-		[[ deprecated( "Pool is no longer required" ) ]]
-		virtual LoggerPtr makeNewLoggerInstance(
-			helpers::Pool& pool,
-			const LogString& name) const = 0;
 #endif
 };
 

--- a/src/main/include/log4cxx/spi/rootlogger.h
+++ b/src/main/include/log4cxx/spi/rootlogger.h
@@ -40,7 +40,12 @@ class LOG4CXX_EXPORT RootLogger : public Logger
 		The root logger names itself as "root". However, the root
 		logger cannot be retrieved by name.
 		*/
-		RootLogger(LOG4CXX_NS::helpers::Pool& pool, const LevelPtr level);
+		RootLogger(const LevelPtr& level);
+
+#if LOG4CXX_ABI_VERSION <= 15
+		[[ deprecated( "Pool is no longer required" ) ]]
+		RootLogger(helpers::Pool& pool, const LevelPtr level);
+#endif
 
 		~RootLogger() {}
 

--- a/src/test/cpp/customlogger/xlogger.cpp
+++ b/src/test/cpp/customlogger/xlogger.cpp
@@ -104,14 +104,14 @@ XFactory::XFactory()
 {
 }
 
-#if LOG4CXX_ABI_VERSION <= 15
-LoggerPtr XFactory::makeNewLoggerInstance(log4cxx::helpers::Pool& pool, const LogString& name) const
-{
-	return LoggerPtr(new XLogger(pool, name));
-}
-#else
 LoggerPtr XFactory::makeNewLoggerInstance(const LogString& name) const
 {
 	return LoggerPtr(new XLogger(name));
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+LoggerPtr XFactory::makeNewLoggerInstance(
+	helpers::Pool& pool,
+	const LogString& name) const
+{ return makeNewLoggerInstance(name); }
 #endif

--- a/src/test/cpp/customlogger/xlogger.cpp
+++ b/src/test/cpp/customlogger/xlogger.cpp
@@ -104,8 +104,14 @@ XFactory::XFactory()
 {
 }
 
-LoggerPtr XFactory::makeNewLoggerInstance(log4cxx::helpers::Pool& pool,
-	const LogString& name) const
+#if LOG4CXX_ABI_VERSION <= 15
+LoggerPtr XFactory::makeNewLoggerInstance(log4cxx::helpers::Pool& pool, const LogString& name) const
 {
 	return LoggerPtr(new XLogger(pool, name));
 }
+#else
+LoggerPtr XFactory::makeNewLoggerInstance(const LogString& name) const
+{
+	return LoggerPtr(new XLogger(name));
+}
+#endif

--- a/src/test/cpp/customlogger/xlogger.cpp
+++ b/src/test/cpp/customlogger/xlogger.cpp
@@ -104,14 +104,14 @@ XFactory::XFactory()
 {
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
+LoggerPtr XFactory::makeNewLoggerInstance(helpers::Pool&, const LogString& name) const
+{
+	return LoggerPtr(new XLogger(name));
+}
+#endif
+
 LoggerPtr XFactory::makeNewLoggerInstance(const LogString& name) const
 {
 	return LoggerPtr(new XLogger(name));
 }
-
-#if LOG4CXX_ABI_VERSION <= 15
-LoggerPtr XFactory::makeNewLoggerInstance(
-	helpers::Pool& pool,
-	const LogString& name) const
-{ return makeNewLoggerInstance(name); }
-#endif

--- a/src/test/cpp/customlogger/xlogger.h
+++ b/src/test/cpp/customlogger/xlogger.h
@@ -44,7 +44,9 @@ class XFactory :
 
 		XFactory();
 		LoggerPtr makeNewLoggerInstance(
+#if LOG4CXX_ABI_VERSION <= 15
 			log4cxx::helpers::Pool& pool,
+#endif
 			const LogString& name) const override;
 };
 
@@ -72,9 +74,11 @@ class XLogger : public Logger
 		/**
 		        Just calls the parent constuctor.
 		*/
-		XLogger(log4cxx::helpers::Pool& pool,
-			const LogString& name1) : Logger(pool, name1) {}
-
+#if LOG4CXX_ABI_VERSION <= 15
+		XLogger(log4cxx::helpers::Pool& pool, const LogString& name) : Logger(pool, name) {}
+#else
+		XLogger(const LogString& name) : Logger(name) {}
+#endif
 		/**
 		        Nothing to activate.
 		*/

--- a/src/test/cpp/customlogger/xlogger.h
+++ b/src/test/cpp/customlogger/xlogger.h
@@ -44,7 +44,11 @@ class XFactory :
 
 		XFactory();
 
+#if LOG4CXX_ABI_VERSION <= 15
+		LoggerPtr makeNewLoggerInstance(const LogString& name) const;
+#else
 		LoggerPtr makeNewLoggerInstance(const LogString& name) const override;
+#endif
 
 #if LOG4CXX_ABI_VERSION <= 15
 		LoggerPtr makeNewLoggerInstance(

--- a/src/test/cpp/customlogger/xlogger.h
+++ b/src/test/cpp/customlogger/xlogger.h
@@ -43,11 +43,14 @@ class XFactory :
 		END_LOG4CXX_CAST_MAP()
 
 		XFactory();
-		LoggerPtr makeNewLoggerInstance(
+
+		LoggerPtr makeNewLoggerInstance(const LogString& name) const override;
+
 #if LOG4CXX_ABI_VERSION <= 15
-			log4cxx::helpers::Pool& pool,
-#endif
+		LoggerPtr makeNewLoggerInstance(
+			helpers::Pool& pool,
 			const LogString& name) const override;
+#endif
 };
 
 typedef std::shared_ptr<XFactory> XFactoryPtr;
@@ -74,11 +77,8 @@ class XLogger : public Logger
 		/**
 		        Just calls the parent constuctor.
 		*/
-#if LOG4CXX_ABI_VERSION <= 15
-		XLogger(log4cxx::helpers::Pool& pool, const LogString& name) : Logger(pool, name) {}
-#else
 		XLogger(const LogString& name) : Logger(name) {}
-#endif
+
 		/**
 		        Nothing to activate.
 		*/

--- a/src/test/cpp/customlogger/xlogger.h
+++ b/src/test/cpp/customlogger/xlogger.h
@@ -45,15 +45,13 @@ class XFactory :
 		XFactory();
 
 #if LOG4CXX_ABI_VERSION <= 15
-		LoggerPtr makeNewLoggerInstance(const LogString& name) const;
-#else
-		LoggerPtr makeNewLoggerInstance(const LogString& name) const override;
-#endif
-
-#if LOG4CXX_ABI_VERSION <= 15
 		LoggerPtr makeNewLoggerInstance(
 			helpers::Pool& pool,
 			const LogString& name) const override;
+
+		LoggerPtr makeNewLoggerInstance(const LogString& name) const;
+#else
+		LoggerPtr makeNewLoggerInstance(const LogString& name) const override;
 #endif
 };
 


### PR DESCRIPTION
No memory pool should live as long as a Log4cxx logger.