### PR TITLE
Prevent a possible 'use after free' fault when using AsyncAppender

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -271,12 +271,8 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 		priv->appenders.appendLoopOnAppenders(event, p);
 	}
 
-	// Set the NDC and MDC for the calling thread as these
-	// LoggingEvent fields were not set at event creation time.
-	LogString ndcVal;
-	event->getNDC(ndcVal);
-	// Get a copy of this thread's MDC.
-	event->getMDCCopy();
+	// Get a copy of this thread's diagnostic context
+	event->LoadDC();
 
 	if (!priv->dispatcher.joinable())
 	{

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -135,7 +135,7 @@ struct LoggingEvent::LoggingEventPrivate
 	log4cxx_time_t timeStamp;
 
 	/** The is the location where this log statement was written. */
-	const LOG4CXX_NS::spi::LocationInfo locationInfo;
+	const spi::LocationInfo locationInfo;
 
 
 	/** The identifier of thread in which this logging event
@@ -152,8 +152,16 @@ struct LoggingEvent::LoggingEventPrivate
 
 	std::chrono::time_point<std::chrono::system_clock> chronoTimeStamp;
 
+	/**
+	 *  This ensures the above string references remain valid
+	 *  for the lifetime of this LoggingEvent (i.e. even after thread termination).
+	 */
 	ThreadSpecificData::OtherDataPtr pNames = ThreadSpecificData::getCurrentData()->getOtherData();
 
+	/**
+	 *  Used to hold the diagnostic context when the lifetime
+	 *  of this LoggingEvent exceeds the duration of the logging request.
+	 */
 	struct DiagnosticContext
 	{
 		Optional<NDC::DiagnosticContext> ctx;

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -47,17 +47,7 @@ using namespace LOG4CXX_NS::helpers;
 struct LoggingEvent::LoggingEventPrivate
 {
 	LoggingEventPrivate() :
-#if LOG4CXX_ABI_VERSION <= 15
-		ndc(0),
-		mdcCopy(0),
-#endif
-		properties(0),
-#if LOG4CXX_ABI_VERSION <= 15
-		ndcLookupRequired(true),
-		mdcCopyLookupRequired(true),
-#endif
 		timeStamp(0),
-		locationInfo(),
 		threadName(getCurrentThreadName()),
 		threadUserName(getCurrentThreadUserName())
 	{
@@ -71,15 +61,6 @@ struct LoggingEvent::LoggingEventPrivate
 		) :
 		logger(logger1),
 		level(level1),
-#if LOG4CXX_ABI_VERSION <= 15
-		ndc(0),
-		mdcCopy(0),
-#endif
-		properties(0),
-#if LOG4CXX_ABI_VERSION <= 15
-		ndcLookupRequired(true),
-		mdcCopyLookupRequired(true),
-#endif
 		message(std::move(message1)),
 		timeStamp(Date::currentTime()),
 		locationInfo(locationInfo1),
@@ -94,15 +75,6 @@ struct LoggingEvent::LoggingEventPrivate
 		const LogString& message1, const LocationInfo& locationInfo1) :
 		logger(logger1),
 		level(level1),
-#if LOG4CXX_ABI_VERSION <= 15
-		ndc(0),
-		mdcCopy(0),
-#endif
-		properties(0),
-#if LOG4CXX_ABI_VERSION <= 15
-		ndcLookupRequired(true),
-		mdcCopyLookupRequired(true),
-#endif
 		message(message1),
 		timeStamp(Date::currentTime()),
 		locationInfo(locationInfo1),
@@ -127,16 +99,16 @@ struct LoggingEvent::LoggingEventPrivate
 
 #if LOG4CXX_ABI_VERSION <= 15
 	/** The nested diagnostic context (NDC) of logging event. */
-	mutable LogString* ndc;
+	mutable LogString* ndc{NULL};
 
 	/** The mapped diagnostic context (MDC) of logging event. */
-	mutable MDC::Map* mdcCopy;
+	mutable MDC::Map* mdcCopy{NULL};
 #endif
 
 	/**
 	* A map of String keys and String values.
 	*/
-	std::map<LogString, LogString>* properties;
+	std::map<LogString, LogString>* properties{NULL};
 
 #if LOG4CXX_ABI_VERSION <= 15
 	/** Have we tried to do an NDC lookup? If we did, there is no need
@@ -144,14 +116,14 @@ struct LoggingEvent::LoggingEventPrivate
 	*  serialized. Thus, a receiving SocketNode will never use it's own
 	*  (incorrect) NDC. See also writeObject method.
 	*/
-	mutable bool ndcLookupRequired;
+	mutable bool ndcLookupRequired{false};
 
 	/**
 	* Have we tried to do an MDC lookup? If we did, there is no need to do it
 	* again.  Note that its value is always false when serialized. See also
 	* the getMDC and getMDCCopy methods.
 	*/
-	mutable bool mdcCopyLookupRequired;
+	mutable bool mdcCopyLookupRequired{false};
 #endif
 
 	/** The application supplied message of logging event. */

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -94,18 +94,16 @@ struct LoggingEvent::LoggingEventPrivate
 	}
 
 	/**
-	* The logger of the logging event.
+	* The name of the logger used to make the logging request
 	**/
 	LogString logger;
 
-	/** level of logging event. */
+	/** severity level of logging event. */
 	LevelPtr level;
 
 #if LOG4CXX_ABI_VERSION <= 15
-	/** The nested diagnostic context (NDC) of logging event. */
 	mutable LogString* ndc{NULL};
 
-	/** The mapped diagnostic context (MDC) of logging event. */
 	mutable MDC::Map* mdcCopy{NULL};
 #endif
 
@@ -115,52 +113,35 @@ struct LoggingEvent::LoggingEventPrivate
 	std::map<LogString, LogString>* properties{NULL};
 
 #if LOG4CXX_ABI_VERSION <= 15
-	/** Have we tried to do an NDC lookup? If we did, there is no need
-	*  to do it again.  Note that its value is always false when
-	*  serialized. Thus, a receiving SocketNode will never use it's own
-	*  (incorrect) NDC. See also writeObject method.
-	*/
 	mutable bool ndcLookupRequired{false};
 
-	/**
-	* Have we tried to do an MDC lookup? If we did, there is no need to do it
-	* again.  Note that its value is always false when serialized. See also
-	* the getMDC and getMDCCopy methods.
-	*/
 	mutable bool mdcCopyLookupRequired{false};
 #endif
 
-	/** The application supplied message of logging event. */
+	/** The application supplied message. */
 	LogString message;
 
 
-	/** The number of microseconds elapsed from 01.01.1970 until logging event
-	 was created. */
+	/** The number of microseconds elapsed since 1970-01-01
+	 *  at the time this logging event was created.
+	 */
 	log4cxx_time_t timeStamp;
 
-	/** The is the location where this log statement was written. */
+	/** The source code location where the logging request was made. */
 	const spi::LocationInfo locationInfo;
 
 
 #if LOG4CXX_ABI_VERSION <= 15
-	/** The identifier of thread in which this logging event
-	was generated.
-	*/
 	const LogString& threadName;
 
-	/**
-	 * The user-specified name of the thread(on a per-platform basis).
-	 * This is set using a method such as pthread_setname_np on POSIX
-	 * systems or SetThreadDescription on Windows.
-	 */
 	const LogString& threadUserName;
 #endif
 
 	std::chrono::time_point<std::chrono::system_clock> chronoTimeStamp;
 
 	/**
-	 *  This ensures the above string references remain valid
-	 *  for the lifetime of this LoggingEvent (i.e. even after thread termination).
+	 *  Thread names that remain valid for the lifetime of this LoggingEvent
+	 *  (i.e. even after thread termination).
 	 */
 	ThreadSpecificData::NamePairPtr pNames;
 

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -152,7 +152,7 @@ struct LoggingEvent::LoggingEventPrivate
 
 	std::chrono::time_point<std::chrono::system_clock> chronoTimeStamp;
 
-	ThreadSpecificData::NameDataPtr pNames = ThreadSpecificData::getCurrentData()->getThreadNames();
+	ThreadSpecificData::OtherDataPtr pNames = ThreadSpecificData::getCurrentData()->getOtherData();
 
 	struct DiagnosticContext
 	{

--- a/src/main/cpp/ndc.cpp
+++ b/src/main/cpp/ndc.cpp
@@ -33,12 +33,12 @@ NDC::~NDC()
 }
 
 
-LogString& NDC::getMessage(NDC::DiagnosticContext& ctx)
+const LogString& NDC::getMessage(const DiagnosticContext& ctx)
 {
 	return ctx.first;
 }
 
-LogString& NDC::getFullMessage(NDC::DiagnosticContext& ctx)
+const LogString& NDC::getFullMessage(const DiagnosticContext& ctx)
 {
 	return ctx.second;
 }

--- a/src/main/cpp/smtpappender.cpp
+++ b/src/main/cpp/smtpappender.cpp
@@ -644,11 +644,8 @@ void SMTPAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 		return;
 	}
 
-	LogString ndc;
-	event->getNDC(ndc);
-	event->getThreadName();
-	// Get a copy of this thread's MDC.
-	event->getMDCCopy();
+	// Get a copy of this thread's diagnostic context
+	event->LoadDC();
 
 	_priv->cb.add(event);
 

--- a/src/main/cpp/threadspecificdata.cpp
+++ b/src/main/cpp/threadspecificdata.cpp
@@ -61,6 +61,8 @@ struct ThreadSpecificData::ThreadSpecificDataPrivate{
 	void setThreadUserName();
 };
 
+/* Generate an identifier for the current thread
+*/
 void ThreadSpecificData::ThreadSpecificDataPrivate::setThreadIdName()
 {
 #if LOG4CXX_HAS_PTHREAD_SELF && !(defined(_WIN32) && defined(_LIBCPP_VERSION))
@@ -81,6 +83,11 @@ void ThreadSpecificData::ThreadSpecificDataPrivate::setThreadIdName()
 #endif
 }
 
+/*
+ * Get the user-specified name of the current thread (on a per-platform basis).
+ * This is set using a method such as pthread_setname_np on POSIX
+ * systems or SetThreadDescription on Windows.
+ */
 void ThreadSpecificData::ThreadSpecificDataPrivate::setThreadUserName()
 {
 #if LOG4CXX_HAS_PTHREAD_GETNAME && !(defined(_WIN32) && defined(_LIBCPP_VERSION))

--- a/src/main/cpp/threadspecificdata.cpp
+++ b/src/main/cpp/threadspecificdata.cpp
@@ -154,16 +154,6 @@ MDC::Map& ThreadSpecificData::getMap()
 	return m_priv->mdcMap;
 }
 
-LogString& ThreadSpecificData::getThreadIdString()
-{
-	return getCurrentData()->m_priv->pNamePair->idString;
-}
-
-LogString& ThreadSpecificData::getThreadName()
-{
-	return getCurrentData()->m_priv->pNamePair->threadName;
-}
-
 auto ThreadSpecificData::getNames() -> NamePairPtr
 {
 	return getCurrentData()->m_priv->pNamePair;

--- a/src/main/cpp/threadspecificdata.cpp
+++ b/src/main/cpp/threadspecificdata.cpp
@@ -32,14 +32,18 @@
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
 
+struct ThreadSpecificData::OtherData : public std::pair<LogString, LogString>
+{
+};
+
 struct ThreadSpecificData::ThreadSpecificDataPrivate{
 	ThreadSpecificDataPrivate()
-		: pNames(std::make_shared<NameData>())
+		: pOtherData(std::make_shared<OtherData>())
 		{}
 	NDC::Stack ndcStack;
 	MDC::Map mdcMap;
 
-	std::shared_ptr<NameData> pNames;
+	std::shared_ptr<OtherData> pOtherData;
 
 #if !LOG4CXX_LOGCHAR_IS_UNICHAR && !LOG4CXX_LOGCHAR_IS_WCHAR
 	std::basic_ostringstream<logchar> logchar_stringstream;
@@ -78,17 +82,17 @@ MDC::Map& ThreadSpecificData::getMap()
 
 LogString& ThreadSpecificData::getThreadIdString()
 {
-	return getCurrentData()->m_priv->pNames->first;
+	return getCurrentData()->m_priv->pOtherData->first;
 }
 
 LogString& ThreadSpecificData::getThreadName()
 {
-	return getCurrentData()->m_priv->pNames->second;
+	return getCurrentData()->m_priv->pOtherData->second;
 }
 
-auto ThreadSpecificData::getThreadNames() -> NameDataPtr
+auto ThreadSpecificData::getOtherData() -> OtherDataPtr
 {
-	return getCurrentData()->m_priv->pNames;
+	return getCurrentData()->m_priv->pOtherData;
 }
 
 #if !LOG4CXX_LOGCHAR_IS_UNICHAR && !LOG4CXX_LOGCHAR_IS_WCHAR

--- a/src/main/cpp/threadspecificdata.cpp
+++ b/src/main/cpp/threadspecificdata.cpp
@@ -23,6 +23,7 @@
 #if !defined(LOG4CXX)
 	#define LOG4CXX 1
 #endif
+#include <log4cxx/private/log4cxx_private.h>
 #include <log4cxx/helpers/aprinitializer.h>
 #include <sstream>
 #include <algorithm>
@@ -147,7 +148,7 @@ ThreadSpecificData* ThreadSpecificData::getCurrentData()
 
 void ThreadSpecificData::recycle()
 {
-#if APR_HAS_THREADS
+#if !LOG4CXX_HAS_THREAD_LOCAL && APR_HAS_THREADS
 	if (m_priv->ndcStack.empty() && m_priv->mdcMap.empty())
 	{
 		void* pData = NULL;

--- a/src/main/include/log4cxx/helpers/optional.h
+++ b/src/main/include/log4cxx/helpers/optional.h
@@ -1,14 +1,40 @@
 #ifdef __has_include                           // Check if __has_include is present
-#  if __has_include(<optional>)                // Check for a standard library
+#  if __has_include(<optional>)                // Check for a standard version
 #    include <optional>
+#    if defined(__cpp_lib_optional)            // C++ >= 17
 namespace LOG4CXX_NS { template< class T > using Optional = std::optional<T>; }
+#define LOG4CXX_HAS_STD_OPTIONAL 1
+#endif
 #  elif __has_include(<experimental/optional>) // Check for an experimental version
 #    include <experimental/optional>
 namespace LOG4CXX_NS { template< class T > using Optional = std::experimental::optional<T>; }
+#define LOG4CXX_HAS_STD_OPTIONAL 1
 #  elif __has_include(<boost/optional.hpp>)    // Try with an external library
 #    include <boost/optional.hpp>
 namespace LOG4CXX_NS { template< class T > using Optional = boost::optional<T>; }
+#define LOG4CXX_HAS_STD_OPTIONAL 1
 #  else                                        // Not found at all
-#     error "Missing <optional>"
+#define LOG4CXX_HAS_STD_OPTIONAL 0
 #  endif
+#endif
+
+#if !LOG4CXX_HAS_STD_OPTIONAL // Implement a minimal Optional?
+namespace LOG4CXX_NS
+{
+	template< class T >
+class Optional : private std::pair<bool, T>
+{
+	using BaseType = std::pair<bool, T>;
+public:
+	Optional() : BaseType(false, T()) {}
+	Optional& operator=(const T& value)
+	{
+		this->first = true;
+		this->second = value;
+		return *this;
+	}
+	bool has_value() const { return this->first; }
+	const T& value() const { return this->second; }
+};
+} // namespace LOG4CXX_NS
 #endif

--- a/src/main/include/log4cxx/helpers/optional.h
+++ b/src/main/include/log4cxx/helpers/optional.h
@@ -1,10 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LOG4CXX_OPTIONAL_HDR_
+#define LOG4CXX_OPTIONAL_HDR_
+
 #ifdef __has_include                           // Check if __has_include is present
 #  if __has_include(<optional>)                // Check for a standard version
 #    include <optional>
 #    if defined(__cpp_lib_optional)            // C++ >= 17
 namespace LOG4CXX_NS { template< class T > using Optional = std::optional<T>; }
 #define LOG4CXX_HAS_STD_OPTIONAL 1
-#endif
+#    endif
 #  elif __has_include(<experimental/optional>) // Check for an experimental version
 #    include <experimental/optional>
 namespace LOG4CXX_NS { template< class T > using Optional = std::experimental::optional<T>; }
@@ -38,3 +58,5 @@ public:
 };
 } // namespace LOG4CXX_NS
 #endif
+
+#endif // LOG4CXX_OPTIONAL_HDR_

--- a/src/main/include/log4cxx/helpers/optional.h
+++ b/src/main/include/log4cxx/helpers/optional.h
@@ -1,0 +1,14 @@
+#ifdef __has_include                           // Check if __has_include is present
+#  if __has_include(<optional>)                // Check for a standard library
+#    include <optional>
+namespace LOG4CXX_NS { template< class T > using Optional = std::optional<T>; }
+#  elif __has_include(<experimental/optional>) // Check for an experimental version
+#    include <experimental/optional>
+namespace LOG4CXX_NS { template< class T > using Optional = std::experimental::optional<T>; }
+#  elif __has_include(<boost/optional.hpp>)    // Try with an external library
+#    include <boost/optional.hpp>
+namespace LOG4CXX_NS { template< class T > using Optional = boost::optional<T>; }
+#  else                                        // Not found at all
+#     error "Missing <optional>"
+#  endif
+#endif

--- a/src/main/include/log4cxx/helpers/threadspecificdata.h
+++ b/src/main/include/log4cxx/helpers/threadspecificdata.h
@@ -41,26 +41,49 @@ class LOG4CXX_EXPORT ThreadSpecificData
 		 *  @return a pointer that is never null.
 		 */
 		static ThreadSpecificData* getCurrentData();
+
 		/**
-		 *  Release this ThreadSpecficData if empty.
+		 *  Remove current thread data from APR if the diagnostic context is empty.
 		 */
 		void recycle();
 
+		/**
+		 *  Add the \c key \c val pair to the mapped diagnostic context of the current thread
+		 */
 		static void put(const LogString& key, const LogString& val);
+
+		/**
+		 *  Add \c val to the nested diagnostic context of the current thread
+		 */
 		static void push(const LogString& val);
+
+		/**
+		 *  Use \c stack as the nested diagnostic context of the current thread
+		 */
 		static void inherit(const NDC::Stack& stack);
 
+		/**
+		 *  The nested diagnostic context of the current thread
+		 */
 		NDC::Stack& getStack();
+
+		/**
+		 *  The mapped diagnostic context of the current thread
+		 */
 		MDC::Map& getMap();
 
+		/**
+		 *  A character outpur stream only assessable to the current thread
+		 */
 		template <typename T>
 		static std::basic_ostringstream<T>& getStringStream()
 		{
 			return getStream(T());
 		}
-		static LogString& getThreadIdString();
-		static LogString& getThreadName();
 
+		/**
+		 *  The names assigned to the current thread
+		 */
 		struct NamePair
 		{
 			LogString idString;
@@ -68,7 +91,7 @@ class LOG4CXX_EXPORT ThreadSpecificData
 		};
 		using NamePairPtr = std::shared_ptr<NamePair>;
 		/**
-		 *  A reference counted pointer to thread specific strings.
+		 *  A reference counted pointer to the names of the current thread.
 		 *
 		 *  String references will remain valid
 		 *  for the lifetime of this pointer (i.e. even after thread termination).

--- a/src/main/include/log4cxx/helpers/threadspecificdata.h
+++ b/src/main/include/log4cxx/helpers/threadspecificdata.h
@@ -61,15 +61,19 @@ class LOG4CXX_EXPORT ThreadSpecificData
 		static LogString& getThreadIdString();
 		static LogString& getThreadName();
 
+		struct NamePair
+		{
+			LogString idString;
+			LogString threadName;
+		};
+		using NamePairPtr = std::shared_ptr<NamePair>;
 		/**
 		 *  A reference counted pointer to thread specific strings.
 		 *
 		 *  String references will remain valid
 		 *  for the lifetime of this pointer (i.e. even after thread termination).
 		 */
-		struct OtherData;
-		using OtherDataPtr = std::shared_ptr<OtherData>;
-		static OtherDataPtr getOtherData();
+		static NamePairPtr getNames();
 	private:
 #if !LOG4CXX_LOGCHAR_IS_UNICHAR && !LOG4CXX_LOGCHAR_IS_WCHAR
 		static std::basic_ostringstream<logchar>& getStream(const logchar&);

--- a/src/main/include/log4cxx/helpers/threadspecificdata.h
+++ b/src/main/include/log4cxx/helpers/threadspecificdata.h
@@ -61,6 +61,9 @@ class LOG4CXX_EXPORT ThreadSpecificData
 		static LogString& getThreadIdString();
 		static LogString& getThreadName();
 
+		using NameData = std::pair<LogString, LogString>;
+		using NameDataPtr = std::shared_ptr<NameData>;
+		static NameDataPtr getThreadNames();
 	private:
 #if !LOG4CXX_LOGCHAR_IS_UNICHAR && !LOG4CXX_LOGCHAR_IS_WCHAR
 		static std::basic_ostringstream<logchar>& getStream(const logchar&);

--- a/src/main/include/log4cxx/helpers/threadspecificdata.h
+++ b/src/main/include/log4cxx/helpers/threadspecificdata.h
@@ -38,7 +38,7 @@ class LOG4CXX_EXPORT ThreadSpecificData
 
 		/**
 		 *  Gets current thread specific data.
-		 *  @return thread specific data, may be null.
+		 *  @return a pointer that is never null.
 		 */
 		static ThreadSpecificData* getCurrentData();
 		/**
@@ -48,7 +48,7 @@ class LOG4CXX_EXPORT ThreadSpecificData
 
 		static void put(const LogString& key, const LogString& val);
 		static void push(const LogString& val);
-		static void inherit(const LOG4CXX_NS::NDC::Stack& stack);
+		static void inherit(const NDC::Stack& stack);
 
 		NDC::Stack& getStack();
 		MDC::Map& getMap();
@@ -61,9 +61,15 @@ class LOG4CXX_EXPORT ThreadSpecificData
 		static LogString& getThreadIdString();
 		static LogString& getThreadName();
 
-		using NameData = std::pair<LogString, LogString>;
-		using NameDataPtr = std::shared_ptr<NameData>;
-		static NameDataPtr getThreadNames();
+		/**
+		 *  A reference counted pointer to thread specific strings.
+		 *
+		 *  String references will remain valid
+		 *  for the lifetime of this pointer (i.e. even after thread termination).
+		 */
+		struct OtherData;
+		using OtherDataPtr = std::shared_ptr<OtherData>;
+		static OtherDataPtr getOtherData();
 	private:
 #if !LOG4CXX_LOGCHAR_IS_UNICHAR && !LOG4CXX_LOGCHAR_IS_WCHAR
 		static std::basic_ostringstream<logchar>& getStream(const logchar&);

--- a/src/main/include/log4cxx/ndc.h
+++ b/src/main/include/log4cxx/ndc.h
@@ -286,11 +286,11 @@ class LOG4CXX_EXPORT NDC
 		static bool pop(CFStringRef& dst);
 #endif
 
+		static const LogString& getMessage(const DiagnosticContext& ctx);
+		static const LogString& getFullMessage(const DiagnosticContext& ctx);
 	private:
 		NDC(const NDC&);
 		NDC& operator=(const NDC&);
-		static LogString& getMessage(DiagnosticContext& ctx);
-		static LogString& getFullMessage(DiagnosticContext& ctx);
 }; // class NDC;
 }  // namespace log4cxx
 

--- a/src/main/include/log4cxx/spi/loggingevent.h
+++ b/src/main/include/log4cxx/spi/loggingevent.h
@@ -212,8 +212,6 @@ class LOG4CXX_EXPORT LoggingEvent :
 		//
 		LoggingEvent(const LoggingEvent&);
 		LoggingEvent& operator=(const LoggingEvent&);
-		static const LogString& getCurrentThreadName();
-		static const LogString& getCurrentThreadUserName();
 
 };
 

--- a/src/main/include/log4cxx/spi/loggingevent.h
+++ b/src/main/include/log4cxx/spi/loggingevent.h
@@ -169,11 +169,20 @@ class LOG4CXX_EXPORT LoggingEvent :
 		*/
 		KeySet getMDCKeySet() const;
 
+#if LOG4CXX_ABI_VERSION <= 15
 		/**
 		Obtain a copy of this thread's MDC prior to serialization
 		or asynchronous logging.
 		*/
+		[[ deprecated( "Use LoadDC instead" ) ]]
 		void getMDCCopy() const;
+#endif
+
+		/**
+		Obtain a copy of this thread's diagnostic context prior to serialization
+		or asynchronous logging.
+		*/
+		void LoadDC() const;
 
 		/**
 		* Return a previously set property.

--- a/src/site/markdown/change-report-gh.md
+++ b/src/site/markdown/change-report-gh.md
@@ -57,6 +57,7 @@ The following issues have been addressed:
 
 * MSYS2/MINGW build errors \[[#389](https://github.com/apache/logging-log4cxx/pull/389)\] 
 * `thread_local` problems in MSYS2/MINGW \[[#394](https://github.com/apache/logging-log4cxx/pull/394)\]
+* A potential 'use after free' fault when using AsyncAppender \[[#397](https://github.com/apache/logging-log4cxx/pull/397)\]
 
 ## Release 1.2.0 - 2024-01-01 {#rel_1_2_0}
 

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -234,7 +234,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 		// this test checks all messages are delivered from multiple threads
 		void testMultiThread()
 		{
-			size_t LEN = 2000; // Larger than default buffer size (128)
+			int LEN = 2000; // Larger than default buffer size (128)
 			int threadCount = 6;
 			auto root = Logger::getRootLogger();
 			auto vectorAppender = std::make_shared<VectorAppender>();
@@ -248,7 +248,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			{
 				threads.emplace_back([root, LEN]()
 				{
-					for (size_t i = 0; i < LEN; i++)
+					for (int i = 0; i < LEN; i++)
 					{
 						LOG4CXX_DEBUG(root, "message" << i);
 					}
@@ -265,18 +265,19 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			asyncAppender->close();
 
 			const std::vector<spi::LoggingEventPtr>& v = vectorAppender->getVector();
-			LOGUNIT_ASSERT_EQUAL(LEN*threadCount, v.size());
-			std::vector<int> count(LEN, 0);
+			LOGUNIT_ASSERT_EQUAL(LEN*threadCount, (int)v.size());
+			std::map<LogString, int> perThreadCount;
 			for (auto m : v)
 			{
 				auto i = StringHelper::toInt(m->getMessage().substr(7));
 				LOGUNIT_ASSERT(0 <= i);
 				LOGUNIT_ASSERT(i < LEN);
-				++count[i];
+				++perThreadCount[m->getThreadName()];
 			}
-			for (size_t i = 0; i < LEN; i++)
+			LOGUNIT_ASSERT_EQUAL(threadCount, (int)perThreadCount.size());
+			for (auto& item : perThreadCount)
 			{
-				LOGUNIT_ASSERT_EQUAL(count[i], threadCount);
+				LOGUNIT_ASSERT_EQUAL(item.second, LEN);
 			}
 		}
 

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -267,11 +267,13 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			const std::vector<spi::LoggingEventPtr>& v = vectorAppender->getVector();
 			LOGUNIT_ASSERT_EQUAL(LEN*threadCount, (int)v.size());
 			std::map<LogString, int> perThreadCount;
+			std::vector<int> msgCount(LEN, 0);
 			for (auto m : v)
 			{
 				auto i = StringHelper::toInt(m->getMessage().substr(7));
 				LOGUNIT_ASSERT(0 <= i);
 				LOGUNIT_ASSERT(i < LEN);
+				++msgCount[i];
 				++perThreadCount[m->getThreadName()];
 			}
 			LOGUNIT_ASSERT_EQUAL(threadCount, (int)perThreadCount.size());
@@ -279,6 +281,8 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			{
 				LOGUNIT_ASSERT_EQUAL(item.second, LEN);
 			}
+			for (size_t i = 0; i < LEN; i++)
+				LOGUNIT_ASSERT_EQUAL(msgCount[i], threadCount);
 		}
 
 		/**

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -309,7 +309,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			asyncAppender->setErrorHandler(errorHandler);
 
 			LOG4CXX_INFO(root, "Message");
-			std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+			std::this_thread::sleep_for( std::chrono::milliseconds( 30 ) );
 			LOGUNIT_ASSERT(errorHandler->errorReported());
 			LOG4CXX_INFO(root, "Message");
 			auto& v = vectorAppender->getVector();


### PR DESCRIPTION
The reference to the thread name (a thread_local) in LoggingEvent may become invalid if the logging thread terminates before the AsyncAppender::dispatch thread has formatted the log message.