### PR TITLE
Use latest version of Github actions for CI

### DIFF
--- a/.github/workflows/abi-compatibility.yml
+++ b/.github/workflows/abi-compatibility.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # do not persist auth token in the local git config
         path: main
@@ -58,7 +58,7 @@ jobs:
         cp $(find . -name compat_report.html) .
         cp $(find . -name new-abi.dump) .
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: abi_info

--- a/.github/workflows/log4cxx-cpp11.yml
+++ b/.github/workflows/log4cxx-cpp11.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 38
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # do not persist auth token in the local git config
         path: main
@@ -45,5 +45,5 @@ jobs:
       run: |
         cd main
         cd build
-        ctest -C Debug --output-on-failure -V
+        ctest -C Debug --output-on-failure
 

--- a/.github/workflows/log4cxx-macos.yml
+++ b/.github/workflows/log4cxx-macos.yml
@@ -38,7 +38,7 @@ jobs:
             qt: OFF
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # do not persist auth token in the local git config
         path: main

--- a/.github/workflows/log4cxx-ubuntu.yml
+++ b/.github/workflows/log4cxx-ubuntu.yml
@@ -60,7 +60,7 @@ jobs:
             exitevents: OFF
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # do not persist auth token in the local git config
         path: main
@@ -95,4 +95,4 @@ jobs:
       run: |
         cd main
         cd build
-        ctest -C Debug --output-on-failure -V
+        ctest -C Debug --output-on-failure

--- a/.github/workflows/log4cxx-windows-static.yml
+++ b/.github/workflows/log4cxx-windows-static.yml
@@ -32,7 +32,7 @@ jobs:
             os: windows-2022
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # do not persist auth token in the local git config
         path: main
@@ -46,7 +46,7 @@ jobs:
 
     - name: 'Checkout VCPKG'
       if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: microsoft/vcpkg
         path: vcpkg
@@ -83,6 +83,6 @@ jobs:
       run: |
         cd main
         cd build
-        ctest -C Debug --output-on-failure -V
+        ctest -C Debug --output-on-failure
 
 

--- a/.github/workflows/log4cxx-windows.yml
+++ b/.github/workflows/log4cxx-windows.yml
@@ -32,21 +32,21 @@ jobs:
             os: windows-2022
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # do not persist auth token in the local git config
         path: main
 
     - name: 'Restore Prebuilt Dependencies'
       id: restore-vcpkg-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vcpkg
         key: ${{ runner.os }}-${{ matrix.name }}-cache-x64
 
     - name: 'Checkout VCPKG'
       if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: microsoft/vcpkg
         path: vcpkg
@@ -83,5 +83,4 @@ jobs:
       run: |
         cd main
         cd build
-        ctest -C Debug --output-on-failure -V
-
+        ctest -C Debug --output-on-failure

--- a/.github/workflows/package_code.yml
+++ b/.github/workflows/package_code.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # do not persist auth token in the local git config
         path: clean-checkout
@@ -60,7 +60,7 @@ jobs:
         sha512sum "apache-log4cxx-$VERSION.zip" > "apache-log4cxx-$VERSION.zip.sha512"
         sha256sum "apache-log4cxx-$VERSION.zip" > "apache-log4cxx-$VERSION.zip.sha256"
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: 'Upload release files'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,7 +32,7 @@ jobs:
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false # do not persist auth token in the local git config
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
@@ -44,7 +44,7 @@ jobs:
           java-version: 17
 
       - name: Set up Python 3.8 for gcovr
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 


### PR DESCRIPTION
According to [this link](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024.

Also, reduce the volume of unit test output.