### PR TITLE
Improve diagnostic hints when using zip/gzip to compress log files

### DIFF
--- a/src/main/cpp/aprserversocket.cpp
+++ b/src/main/cpp/aprserversocket.cpp
@@ -111,7 +111,7 @@ SocketPtr APRServerSocket::accept()
 	}
 	if (s == 0)
 	{
-		throw IOException(LOG4CXX_STR("socket is 0"));
+		throw NullPointerException(LOG4CXX_STR("socket"));
 	}
 
 	apr_pollfd_t poll;

--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -185,9 +185,9 @@ LogString IOException::formatMessage(const LogString& type, log4cxx_status_t sta
 	LogString s = type;
 	char err_buff[1024] = {0};
 	apr_strerror(stat, err_buff, sizeof(err_buff));
-	if (!err_buff[0])
+	if (0 == err_buff[0] || 0 == strncmp(err_buff, "APR does not understand", 23))
 	{
-		s.append(LOG4CXX_STR(": APR error code "));
+		s.append(LOG4CXX_STR(": error code "));
 		Pool p;
 		StringHelper::toString(stat, p, s);
 	}

--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -153,6 +153,11 @@ IOException::IOException(log4cxx_status_t stat)
 {
 }
 
+IOException::IOException(const LogString& type, log4cxx_status_t stat)
+	: Exception(formatMessage(type, stat))
+{
+}
+
 
 IOException::IOException(const LogString& msg1)
 	: Exception(msg1)
@@ -172,16 +177,21 @@ IOException& IOException::operator=(const IOException& src)
 
 LogString IOException::formatMessage(log4cxx_status_t stat)
 {
+	return formatMessage(LOG4CXX_STR("IO Exception"), stat);
+}
+
+LogString IOException::formatMessage(const LogString& type, log4cxx_status_t stat)
+{
 	char err_buff[1024];
-	LogString s(LOG4CXX_STR("IO Exception : status code = "));
+	LogString s = type;
+	s.append(LOG4CXX_STR(": error code "));
 	Pool p;
 	StringHelper::toString(stat, p, s);
-	s.append(LOG4CXX_STR("("));
+	s.append(LOG4CXX_STR(": "));
 	apr_strerror(stat, err_buff, sizeof(err_buff));
 	std::string sMsg = err_buff;
 	LOG4CXX_DECODE_CHAR(lsMsg, sMsg);
 	s.append(lsMsg);
-	s.append(LOG4CXX_STR(")"));
 	return s;
 }
 

--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -182,16 +182,22 @@ LogString IOException::formatMessage(log4cxx_status_t stat)
 
 LogString IOException::formatMessage(const LogString& type, log4cxx_status_t stat)
 {
-	char err_buff[1024];
 	LogString s = type;
-	s.append(LOG4CXX_STR(": error code "));
-	Pool p;
-	StringHelper::toString(stat, p, s);
-	s.append(LOG4CXX_STR(": "));
+	char err_buff[1024] = {0};
 	apr_strerror(stat, err_buff, sizeof(err_buff));
-	std::string sMsg = err_buff;
-	LOG4CXX_DECODE_CHAR(lsMsg, sMsg);
-	s.append(lsMsg);
+	if (!err_buff[0])
+	{
+		s.append(LOG4CXX_STR(": APR error code "));
+		Pool p;
+		StringHelper::toString(stat, p, s);
+	}
+	else
+	{
+		s.append(LOG4CXX_STR(" - "));
+		std::string sMsg = err_buff;
+		LOG4CXX_DECODE_CHAR(lsMsg, sMsg);
+		s.append(lsMsg);
+	}
 	return s;
 }
 

--- a/src/main/cpp/fileinputstream.cpp
+++ b/src/main/cpp/fileinputstream.cpp
@@ -61,7 +61,7 @@ void FileInputStream::open(const LogString& filename)
 
 	if (stat != APR_SUCCESS)
 	{
-		throw IOException(stat);
+		throw IOException(filename, stat);
 	}
 }
 
@@ -75,7 +75,7 @@ FileInputStream::FileInputStream(const File& aFile) :
 
 	if (stat != APR_SUCCESS)
 	{
-		throw IOException(stat);
+		throw IOException(aFile.getName(), stat);
 	}
 }
 

--- a/src/main/cpp/fileoutputstream.cpp
+++ b/src/main/cpp/fileoutputstream.cpp
@@ -73,7 +73,7 @@ apr_file_t* FileOutputStream::open(const LogString& filename,
 
 	if (stat != APR_SUCCESS)
 	{
-		throw IOException(stat);
+		throw IOException(filename, stat);
 	}
 
 	return fileptr;
@@ -110,7 +110,7 @@ void FileOutputStream::write(ByteBuffer& buf, Pool& /* p */ )
 {
 	if (m_priv->fileptr == NULL)
 	{
-		throw IOException(-1);
+		throw NullPointerException(LOG4CXX_STR("FileOutputStream"));
 	}
 
 	size_t nbytes = buf.remaining();

--- a/src/main/cpp/gzcompressaction.cpp
+++ b/src/main/cpp/gzcompressaction.cpp
@@ -91,7 +91,7 @@ bool GZCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 
 		if (stat != APR_SUCCESS)
 		{
-			throw IOException(stat);
+			throw IOException(priv->destination.getName(), stat);
 		}
 
 		stat =  apr_procattr_child_out_set(attr, child_out, NULL);

--- a/src/main/cpp/gzcompressaction.cpp
+++ b/src/main/cpp/gzcompressaction.cpp
@@ -130,11 +130,11 @@ bool GZCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 		apr_proc_t pid;
 		stat = apr_proc_create(&pid, "gzip", args, NULL, attr, aprpool);
 
-		if (stat != APR_SUCCESS && priv->throwIOExceptionOnForkFailure)
+		if (stat != APR_SUCCESS)
 		{
-			throw IOException(stat);
-		}else if(stat != APR_SUCCESS && !priv->throwIOExceptionOnForkFailure)
-		{
+			LogLog::warn(LOG4CXX_STR("Failed to fork gzip during log rotation; leaving log file uncompressed"));
+			if (priv->throwIOExceptionOnForkFailure)
+				throw IOException("gzip", stat);
 			/* If we fail here (to create the gzip child process),
 			 * skip the compression and consider the rotation to be
 			 * otherwise successful. The caller has already rotated
@@ -143,12 +143,7 @@ bool GZCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 			 * same path with `.gz` appended). Remove the empty
 			 * destination file and leave source as-is.
 			 */
-			LogLog::warn(LOG4CXX_STR("Failed to fork gzip during log rotation; leaving log file uncompressed"));
 			stat = apr_file_close(child_out);
-			if (stat != APR_SUCCESS)
-			{
-				LogLog::warn(LOG4CXX_STR("Failed to close abandoned .gz file; ignoring"));
-			}
 			return true;
 		}
 

--- a/src/main/cpp/gzcompressaction.cpp
+++ b/src/main/cpp/gzcompressaction.cpp
@@ -134,7 +134,7 @@ bool GZCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 		{
 			LogLog::warn(LOG4CXX_STR("Failed to fork gzip during log rotation; leaving log file uncompressed"));
 			if (priv->throwIOExceptionOnForkFailure)
-				throw IOException("gzip", stat);
+				throw IOException(LOG4CXX_STR("gzip"), stat);
 			/* If we fail here (to create the gzip child process),
 			 * skip the compression and consider the rotation to be
 			 * otherwise successful. The caller has already rotated

--- a/src/main/cpp/inputstreamreader.cpp
+++ b/src/main/cpp/inputstreamreader.cpp
@@ -86,7 +86,7 @@ LogString InputStreamReader::read(Pool& p)
 
 		if (stat != 0)
 		{
-			throw IOException(stat);
+			throw IOException(LOG4CXX_STR("decode"), stat);
 		}
 
 		if (buf.remaining() > 0)

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -206,7 +206,8 @@ bool LoggingEvent::getNDC(LogString& dest) const
 	// Otherwise use the NDC that is associated with the thread.
 	if (m_priv->dc)
 	{
-		if (result = m_priv->dc->ctx.has_value())
+		result = m_priv->dc->ctx.has_value();
+		if (result)
 			dest.append(NDC::getFullMessage(m_priv->dc->ctx.value()));
 	}
 	else

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -346,7 +346,8 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 							bool appendToExisting = true;
 							if (success)
 							{
-								if (appendToExisting = rollover1->getAppend())
+								appendToExisting = rollover1->getAppend();
+								if (appendToExisting)
 								{
 									_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length(p);
 								}

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -336,11 +336,10 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 								}
 								catch (std::exception& ex)
 								{
-									LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-									lsMsg.append(getFile());
-									lsMsg.append(LOG4CXX_STR("]"));
-									_priv->errorHandler->error(lsMsg, ex, 0);
+									LogString msg(LOG4CXX_STR("Rollover of ["));
+									msg.append(getFile());
+									msg.append(LOG4CXX_STR("] failed"));
+									_priv->errorHandler->error(msg, ex, 0);
 								}
 							}
 
@@ -366,11 +365,10 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 									}
 									catch (std::exception& ex)
 									{
-										LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-										lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-										lsMsg.append(getFile());
-										lsMsg.append(LOG4CXX_STR("]"));
-										_priv->errorHandler->error(lsMsg, ex, 0);
+										LogString msg(LOG4CXX_STR("Rollover of ["));
+										msg.append(getFile());
+										msg.append(LOG4CXX_STR("] failed"));
+										_priv->errorHandler->error(msg, ex, 0);
 									}
 								}
 							}
@@ -399,11 +397,10 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 								}
 								catch (std::exception& ex)
 								{
-									LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-									lsMsg.append(getFile());
-									lsMsg.append(LOG4CXX_STR("]"));
-									_priv->errorHandler->error(lsMsg, ex, 0);
+									LogString msg(LOG4CXX_STR("Rollover of ["));
+									msg.append(getFile());
+									msg.append(LOG4CXX_STR("] failed"));
+									_priv->errorHandler->error(msg, ex, 0);
 								}
 							}
 
@@ -438,11 +435,10 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 				}
 				catch (std::exception& ex)
 				{
-					LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-					lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-					lsMsg.append(getFile());
-					lsMsg.append(LOG4CXX_STR("]"));
-					_priv->errorHandler->error(lsMsg, ex, 0);
+					LogString msg(LOG4CXX_STR("Rollover of ["));
+					msg.append(getFile());
+					msg.append(LOG4CXX_STR("] failed"));
+					_priv->errorHandler->error(msg, ex, 0);
 				}
 
 			}
@@ -496,10 +492,10 @@ void MultiprocessRollingFileAppender::subAppend(const LoggingEventPtr& event, Po
 		}
 		catch (std::exception& ex)
 		{
-			LogLog::warn(LOG4CXX_STR("Exception during rollover attempt."));
-			LogString exmsg;
-			LOG4CXX_NS::helpers::Transcoder::decode(ex.what(), exmsg);
-			_priv->errorHandler->error(exmsg);
+			LogString msg(LOG4CXX_STR("Rollover of ["));
+			msg.append(getFile());
+			msg.append(LOG4CXX_STR("] failed"));
+			_priv->errorHandler->error(msg, ex, 0);
 		}
 	}
 

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -336,16 +336,18 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 								}
 								catch (std::exception& ex)
 								{
-									LogLog::warn(LOG4CXX_STR("Exception on rollover"));
-									LogString exmsg;
-									LOG4CXX_NS::helpers::Transcoder::decode(ex.what(), exmsg);
-									_priv->errorHandler->error(exmsg, ex, 0);
+									LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
+									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+									lsMsg.append(getFile());
+									lsMsg.append(LOG4CXX_STR("]"));
+									_priv->errorHandler->error(lsMsg, ex, 0);
 								}
 							}
 
+							bool appendToExisting = true;
 							if (success)
 							{
-								if (rollover1->getAppend())
+								if (appendToExisting = rollover1->getAppend())
 								{
 									_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length(p);
 								}
@@ -354,25 +356,25 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 									_priv->fileLength = 0;
 								}
 
-								//
-								//  async action not yet implemented
-								//
 								ActionPtr asyncAction(rollover1->getAsynchronous());
 
 								if (asyncAction != NULL)
 								{
-									asyncAction->execute(p);
+									try
+									{
+										asyncAction->execute(p);
+									}
+									catch (std::exception& ex)
+									{
+										LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
+										lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+										lsMsg.append(getFile());
+										lsMsg.append(LOG4CXX_STR("]"));
+										_priv->errorHandler->error(lsMsg, ex, 0);
+									}
 								}
-
-								setFileInternal(
-									rollover1->getActiveFileName(), rollover1->getAppend(),
-									_priv->bufferedIO, _priv->bufferSize, p);
 							}
-							else
-							{
-								setFileInternal(
-									rollover1->getActiveFileName(), true, _priv->bufferedIO, _priv->bufferSize, p);
-							}
+							setFileInternal(rollover1->getActiveFileName(), appendToExisting, _priv->bufferedIO, _priv->bufferSize, p);
 						}
 						else
 						{
@@ -397,10 +399,11 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 								}
 								catch (std::exception& ex)
 								{
-									LogLog::warn(LOG4CXX_STR("Exception during rollover"));
-									LogString exmsg;
-									LOG4CXX_NS::helpers::Transcoder::decode(ex.what(), exmsg);
-									_priv->errorHandler->error(exmsg, ex, 0);
+									LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
+									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+									lsMsg.append(getFile());
+									lsMsg.append(LOG4CXX_STR("]"));
+									_priv->errorHandler->error(lsMsg, ex, 0);
 								}
 							}
 
@@ -435,10 +438,11 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 				}
 				catch (std::exception& ex)
 				{
-					LogLog::warn(LOG4CXX_STR("Exception during rollover"));
-					LogString exmsg;
-					LOG4CXX_NS::helpers::Transcoder::decode(ex.what(), exmsg);
-					_priv->errorHandler->error(exmsg, ex, 0);
+					LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
+					lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+					lsMsg.append(getFile());
+					lsMsg.append(LOG4CXX_STR("]"));
+					_priv->errorHandler->error(lsMsg, ex, 0);
 				}
 
 			}

--- a/src/main/cpp/onlyonceerrorhandler.cpp
+++ b/src/main/cpp/onlyonceerrorhandler.cpp
@@ -28,12 +28,12 @@ IMPLEMENT_LOG4CXX_OBJECT(OnlyOnceErrorHandler)
 
 struct OnlyOnceErrorHandler::OnlyOnceErrorHandlerPrivate{
 	OnlyOnceErrorHandlerPrivate() :
-		WARN_PREFIX(LOG4CXX_STR("log4cxx warning: ")),
-		ERROR_PREFIX(LOG4CXX_STR("log4cxx error: ")),
 		firstTime(true){}
 
+#if LOG4CXX_ABI_VERSION <= 15
 	LogString WARN_PREFIX;
 	LogString ERROR_PREFIX;
+#endif
 	mutable bool firstTime;
 };
 

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -344,9 +344,10 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 								}
 							}
 
+							bool appendToExisting = true;
 							if (success)
 							{
-								if (rollover1->getAppend())
+								if (appendToExisting = rollover1->getAppend())
 								{
 									_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length(p);
 								}
@@ -372,16 +373,8 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 										_priv->errorHandler->error(lsMsg, ex, 0);
 									}
 								}
-
-								setFileInternal(
-									rollover1->getActiveFileName(), rollover1->getAppend(),
-									_priv->bufferedIO, _priv->bufferSize, p);
 							}
-							else
-							{
-								setFileInternal(
-									rollover1->getActiveFileName(), true, _priv->bufferedIO, _priv->bufferSize, p);
-							}
+							setFileInternal(rollover1->getActiveFileName(), appendToExisting, _priv->bufferedIO, _priv->bufferSize, p);
 						}
 						else
 						{

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -340,7 +340,6 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
 									lsMsg.append(getFile());
 									lsMsg.append(LOG4CXX_STR("]"));
-									LogLog::error(lsMsg);
 									_priv->errorHandler->error(lsMsg, ex, 0);
 								}
 							}
@@ -356,9 +355,6 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 									_priv->fileLength = 0;
 								}
 
-								//
-								//  async action not yet implemented
-								//
 								ActionPtr asyncAction(rollover1->getAsynchronous());
 
 								if (asyncAction != NULL)

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -336,11 +336,10 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 								}
 								catch (std::exception& ex)
 								{
-									LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-									lsMsg.append(getFile());
-									lsMsg.append(LOG4CXX_STR("]"));
-									_priv->errorHandler->error(lsMsg, ex, 0);
+									LogString msg(LOG4CXX_STR("Rollover of ["));
+									msg.append(getFile());
+									msg.append(LOG4CXX_STR("] failed"));
+									_priv->errorHandler->error(msg, ex, 0);
 								}
 							}
 
@@ -366,11 +365,10 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 									}
 									catch (std::exception& ex)
 									{
-										LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-										lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-										lsMsg.append(getFile());
-										lsMsg.append(LOG4CXX_STR("]"));
-										_priv->errorHandler->error(lsMsg, ex, 0);
+										LogString msg(LOG4CXX_STR("Rollover of ["));
+										msg.append(getFile());
+										msg.append(LOG4CXX_STR("] failed"));
+										_priv->errorHandler->error(msg, ex, 0);
 									}
 								}
 							}
@@ -399,11 +397,10 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 								}
 								catch (std::exception& ex)
 								{
-									LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-									lsMsg.append(getFile());
-									lsMsg.append(LOG4CXX_STR("]"));
-									_priv->errorHandler->error(lsMsg, ex, 0);
+									LogString msg(LOG4CXX_STR("Rollover of ["));
+									msg.append(getFile());
+									msg.append(LOG4CXX_STR("] failed"));
+									_priv->errorHandler->error(msg, ex, 0);
 								}
 							}
 
@@ -433,11 +430,10 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 				}
 				catch (std::exception& ex)
 				{
-					LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-					lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-					lsMsg.append(getFile());
-					lsMsg.append(LOG4CXX_STR("]"));
-					_priv->errorHandler->error(lsMsg, ex, 0);
+					LogString msg(LOG4CXX_STR("Rollover of ["));
+					msg.append(getFile());
+					msg.append(LOG4CXX_STR("] failed"));
+					_priv->errorHandler->error(msg, ex, 0);
 				}
 		}
 	}
@@ -468,11 +464,10 @@ void RollingFileAppender::subAppend(const LoggingEventPtr& event, Pool& p)
 		}
 		catch (std::exception& ex)
 		{
-			LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-			lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-			lsMsg.append(getFile());
-			lsMsg.append(LOG4CXX_STR("]"));
-			_priv->errorHandler->error(lsMsg);
+			LogString msg(LOG4CXX_STR("Rollover of ["));
+			msg.append(getFile());
+			msg.append(LOG4CXX_STR("] failed"));
+			_priv->errorHandler->error(msg, ex, 0);
 		}
 	}
 

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -337,9 +337,10 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 								catch (std::exception& ex)
 								{
 									LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-									LogString errorMsg = LOG4CXX_STR("Exception on rollover: ");
-									errorMsg.append(lsMsg);
-									LogLog::error(errorMsg);
+									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+									lsMsg.append(getFile());
+									lsMsg.append(LOG4CXX_STR("]"));
+									LogLog::error(lsMsg);
 									_priv->errorHandler->error(lsMsg, ex, 0);
 								}
 							}
@@ -362,7 +363,18 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 
 								if (asyncAction != NULL)
 								{
-									asyncAction->execute(p);
+									try
+									{
+										asyncAction->execute(p);
+									}
+									catch (std::exception& ex)
+									{
+										LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
+										lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+										lsMsg.append(getFile());
+										lsMsg.append(LOG4CXX_STR("]"));
+										_priv->errorHandler->error(lsMsg, ex, 0);
+									}
 								}
 
 								setFileInternal(
@@ -399,9 +411,9 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 								catch (std::exception& ex)
 								{
 									LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-									LogString errorMsg = LOG4CXX_STR("Exception during rollover: ");
-									errorMsg.append(lsMsg);
-									LogLog::warn(errorMsg);
+									lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+									lsMsg.append(getFile());
+									lsMsg.append(LOG4CXX_STR("]"));
 									_priv->errorHandler->error(lsMsg, ex, 0);
 								}
 							}
@@ -417,14 +429,22 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 									_priv->fileLength = 0;
 								}
 
-								//
-								//   async action not yet implemented
-								//
 								ActionPtr asyncAction(rollover1->getAsynchronous());
 
 								if (asyncAction != NULL)
 								{
-									asyncAction->execute(p);
+									try
+									{
+										asyncAction->execute(p);
+									}
+									catch (std::exception& ex)
+									{
+										LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
+										lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+										lsMsg.append(getFile());
+										lsMsg.append(LOG4CXX_STR("]"));
+										_priv->errorHandler->error(lsMsg, ex, 0);
+									}
 								}
 							}
 
@@ -436,9 +456,9 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 				catch (std::exception& ex)
 				{
 					LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-					LogString errorMsg = LOG4CXX_STR("Exception during rollover: ");
-					errorMsg.append(lsMsg);
-					LogLog::warn(errorMsg);
+					lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+					lsMsg.append(getFile());
+					lsMsg.append(LOG4CXX_STR("]"));
 					_priv->errorHandler->error(lsMsg, ex, 0);
 				}
 		}
@@ -471,9 +491,9 @@ void RollingFileAppender::subAppend(const LoggingEventPtr& event, Pool& p)
 		catch (std::exception& ex)
 		{
 			LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-			LogString errorMsg = LOG4CXX_STR("Exception during rollover attempt: ");
-			errorMsg.append(lsMsg);
-			LogLog::warn(errorMsg);
+			lsMsg.append(LOG4CXX_STR("- during rollover of ["));
+			lsMsg.append(getFile());
+			lsMsg.append(LOG4CXX_STR("]"));
 			_priv->errorHandler->error(lsMsg);
 		}
 	}

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -346,7 +346,8 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 							bool appendToExisting = true;
 							if (success)
 							{
-								if (appendToExisting = rollover1->getAppend())
+								appendToExisting = rollover1->getAppend();
+								if (appendToExisting)
 								{
 									_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length(p);
 								}

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -433,18 +433,7 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 
 								if (asyncAction != NULL)
 								{
-									try
-									{
-										asyncAction->execute(p);
-									}
-									catch (std::exception& ex)
-									{
-										LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
-										lsMsg.append(LOG4CXX_STR("- during rollover of ["));
-										lsMsg.append(getFile());
-										lsMsg.append(LOG4CXX_STR("]"));
-										_priv->errorHandler->error(lsMsg, ex, 0);
-									}
+									asyncAction->execute(p);
 								}
 							}
 

--- a/src/main/cpp/zipcompressaction.cpp
+++ b/src/main/cpp/zipcompressaction.cpp
@@ -116,11 +116,11 @@ bool ZipCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 	apr_proc_t pid;
 	stat = apr_proc_create(&pid, "zip", args, NULL, attr, aprpool);
 
-	if (stat != APR_SUCCESS && priv->throwIOExceptionOnForkFailure)
+	if (stat != APR_SUCCESS)
 	{
-		throw IOException(stat);
-	}else if(stat != APR_SUCCESS && !priv->throwIOExceptionOnForkFailure)
-	{
+		LogLog::warn(LOG4CXX_STR("Failed to fork zip during log rotation; leaving log file uncompressed"));
+		if (priv->throwIOExceptionOnForkFailure)
+			throw IOException("zip", stat);
 		/* If we fail here (to create the zip child process),
 		 * skip the compression and consider the rotation to be
 		 * otherwise successful. The caller has already rotated
@@ -129,7 +129,6 @@ bool ZipCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 		 * same path with `.zip` appended). Remove the empty
 		 * destination file and leave source as-is.
 		 */
-		LogLog::warn(LOG4CXX_STR("Failed to fork zip during log rotation; leaving log file uncompressed"));
 		return true;
 	}
 

--- a/src/main/cpp/zipcompressaction.cpp
+++ b/src/main/cpp/zipcompressaction.cpp
@@ -120,7 +120,7 @@ bool ZipCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 	{
 		LogLog::warn(LOG4CXX_STR("Failed to fork zip during log rotation; leaving log file uncompressed"));
 		if (priv->throwIOExceptionOnForkFailure)
-			throw IOException("zip", stat);
+			throw IOException(LOG4CXX_STR("zip"), stat);
 		/* If we fail here (to create the zip child process),
 		 * skip the compression and consider the rotation to be
 		 * otherwise successful. The caller has already rotated

--- a/src/main/include/log4cxx/helpers/exception.h
+++ b/src/main/include/log4cxx/helpers/exception.h
@@ -92,10 +92,12 @@ class LOG4CXX_EXPORT IOException : public Exception
 		IOException();
 		IOException(log4cxx_status_t stat);
 		IOException(const LogString& msg);
+		IOException(const LogString& type, log4cxx_status_t stat);
 		IOException(const IOException& src);
 		IOException& operator=(const IOException&);
 	private:
 		static LogString formatMessage(log4cxx_status_t stat);
+		static LogString formatMessage(const LogString& type, log4cxx_status_t stat);
 };
 
 class LOG4CXX_EXPORT MissingResourceException : public Exception


### PR DESCRIPTION
This PR provides a better diagnostic than just `IO Exception: The system cannot find the file specified` for all errors

The new message is (for example):
```
log4cxx: Failed to fork zip during log rotation; leaving log file uncompressed
log4cxx: Rollover of [MyApp.log] failed
log4cxx: zip - The system cannot find the file specified.  
```