### PR TITLE
Google OSS-Fuzz integration

### DIFF
--- a/.github/workflows/log4cxx-ubuntu.yml
+++ b/.github/workflows/log4cxx-ubuntu.yml
@@ -34,6 +34,7 @@ jobs:
             odbc: OFF
             multithread: OFF
             exitevents: OFF
+            fuzzers: OFF
           - name: ubuntu20-clang
             os: ubuntu-20.04
             cxx: clang++
@@ -42,6 +43,7 @@ jobs:
             odbc: ON
             multithread: OFF
             exitevents: OFF
+            fuzzers: ON
           - name: ubuntu22-gcc
             os: ubuntu-22.04
             cxx: g++
@@ -50,6 +52,7 @@ jobs:
             odbc: OFF
             multithread: ON
             exitevents: ON
+            fuzzers: OFF
           - name: ubuntu22-clang
             os: ubuntu-22.04
             cxx: clang++
@@ -58,6 +61,7 @@ jobs:
             odbc: OFF
             multithread: ON
             exitevents: OFF
+            fuzzers: ON
 
     steps:
     - uses: actions/checkout@v4
@@ -87,7 +91,14 @@ jobs:
         cd main
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DLOG4CXX_ENABLE_ODBC=${{ matrix.odbc }} -DLOG4CXX_QT_SUPPORT=${{ matrix.qt }}  -DENABLE_MULTITHREAD_TEST=${{ matrix.multithread }} -DLOG4CXX_EVENTS_AT_EXIT=${{ matrix.exitevents }} ..
+        cmake \
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+          -DLOG4CXX_ENABLE_ODBC=${{ matrix.odbc }} \
+          -DLOG4CXX_QT_SUPPORT=${{ matrix.qt }} \
+          -DENABLE_MULTITHREAD_TEST=${{ matrix.multithread }} \
+          -DLOG4CXX_EVENTS_AT_EXIT=${{ matrix.exitevents }} \
+          -DBUILD_FUZZERS=${{ matrix.fuzzers }} \
+          ..
         cmake --build .
 
     - name: run unit tests

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pom.xml.releaseBackup
 release.properties
 
 autom4te.cache/
+.idea/
 .vs/
 out/
 src/**/__history/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ find_package(APR-Util REQUIRED)
 
 find_package( Threads REQUIRED )
 
+# Find LibFuzzer
+include("${CMAKE_CURRENT_LIST_DIR}/src/cmake/FindLibFuzzer.cmake")
+
 # Find expat for XML parsing
 find_package(EXPAT REQUIRED)
 if(TARGET EXPAT::EXPAT)
@@ -144,7 +147,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/main/include/log4cxx
 )
 
 install(TARGETS log4cxx EXPORT ${LOG4CXX_LIB_NAME}Targets
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} 
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -180,7 +183,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/liblog4cxx.pc.in"
   "${CMAKE_CURRENT_BINARY_DIR}/lib${LOG4CXX_LIB_NAME}.pc"
 )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${LOG4CXX_LIB_NAME}.pc" 
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${LOG4CXX_LIB_NAME}.pc"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 if(LOG4CXX_QT_SUPPORT)
@@ -299,6 +302,7 @@ message(STATUS "  C++ features requested: ......... : ${CMAKE_CXX_STANDARD}")
 message(STATUS "  Build shared library ............ : ${BUILD_SHARED_LIBS}")
 message(STATUS "  Build tests ..................... : ${BUILD_TESTING}")
 message(STATUS "  Build examples................... : ${BUILD_EXAMPLES}")
+message(STATUS "  Build fuzzers.................... : ${BUILD_FUZZERS}")
 message(STATUS "  Build site ...................... : ${BUILD_SITE}")
 message(STATUS "  Install prefix .................. : ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "  log4cxx library name ............ : ${LOG4CXX_LIB_NAME}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,4 +40,13 @@ if(BUILD_EXAMPLES)
   add_subdirectory(examples/cpp)
 endif()
 
+option(BUILD_FUZZERS "Build log4cxx fuzzers" ${BUILD_TESTING})
+if(BUILD_FUZZERS)
+  if(NOT LIBFUZZER_FOUND)
+    message(SEND_ERROR "libfuzzer, required by the requested fuzzer build, is not found")
+  else()
+    add_subdirectory(fuzzers/cpp)
+  endif()
+endif()
+
 add_subdirectory(site)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,15 @@ if(BUILD_EXAMPLES)
   add_subdirectory(examples/cpp)
 endif()
 
-option(BUILD_FUZZERS "Build log4cxx fuzzers" ${BUILD_TESTING})
+# Define `BUILD_FUZZERS_DEFAULT`
+if(BUILD_TESTING AND LIBFUZZER_FOUND)
+  set(BUILD_FUZZERS_DEFAULT ON)
+else()
+  set(BUILD_FUZZERS_DEFAULT OFF)
+endif()
+
+# Define `BUILD_FUZZERS`
+option(BUILD_FUZZERS "Build log4cxx fuzzers" ${BUILD_FUZZERS_DEFAULT})
 if(BUILD_FUZZERS)
   if(NOT LIBFUZZER_FOUND)
     message(SEND_ERROR "libfuzzer, required by the requested fuzzer build, is not found")

--- a/src/cmake/FindLibFuzzer.cmake
+++ b/src/cmake/FindLibFuzzer.cmake
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This module sets `LIBFUZZER_FOUND` to `1` if libFuzzer[1] is found.
+#
+# [1] https://llvm.org/docs/LibFuzzer.html
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  try_compile(LIBFUZZER_FOUND
+  	"${CMAKE_BINARY_DIR}/LibFuzzerTest"
+  	"${CMAKE_CURRENT_LIST_DIR}/LibFuzzerTest.cpp"
+  	CMAKE_FLAGS -DCOMPILE_DEFINITIONS=-fsanitize=fuzzer)
+else()
+  set(LIBFUZZER_FOUND 0)
+endif()

--- a/src/cmake/LibFuzzerTest.cpp
+++ b/src/cmake/LibFuzzerTest.cpp
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fuzzer/FuzzedDataProvider.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, const size_t size) {
+	FuzzedDataProvider dataProvider(data, size);
+	dataProvider.ConsumeBool();
+	return 0;
+}

--- a/src/fuzzers/bash/oss-fuzz-build.sh
+++ b/src/fuzzers/bash/oss-fuzz-build.sh
@@ -46,7 +46,7 @@ cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && cd ../../..
 
 # Build the project
 mkdir build && cd $_
-cmake -DBUILD_SHARED_LIBS=off ..
+cmake -DBUILD_SHARED_LIBS=OFF -DBUILD_FUZZERS=ON ..
 make -j
 
 # Copy executables & resources

--- a/src/fuzzers/bash/oss-fuzz-build.sh
+++ b/src/fuzzers/bash/oss-fuzz-build.sh
@@ -27,12 +27,6 @@ Usage: $0 <outputDir>
   outputDir
 
     The output directory to dump runner scripts and their dependencies.
-
-Environment variables:
-
-  BUILD (optional)
-
-    If "false", Maven installation will be skipped.
 EOF
   exit 1
 fi
@@ -45,7 +39,7 @@ mkdir -p "$outputDir"
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && cd ../../..
 
 # Build the project
-mkdir build && cd $_
+mkdir -p build && cd $_
 cmake -DBUILD_SHARED_LIBS=OFF -DBUILD_FUZZERS=ON ..
 make -j
 

--- a/src/fuzzers/bash/oss-fuzz-build.sh
+++ b/src/fuzzers/bash/oss-fuzz-build.sh
@@ -46,7 +46,7 @@ cmake \
   -DBUILD_EXAMPLES=OFF \
   -DBUILD_FUZZERS=ON \
   ..
-cmake --build .
+cmake --build . -j
 
 # Copy executables & resources
 find src/fuzzers/cpp -maxdepth 1 -executable -type f -exec cp -v {} "$outputDir/" \;

--- a/src/fuzzers/bash/oss-fuzz-build.sh
+++ b/src/fuzzers/bash/oss-fuzz-build.sh
@@ -20,7 +20,7 @@
 if [[ "$#" -ne 1 ]]; then
   cat >&2 <<EOF
 Generates fuzzer runner scripts to be employed by Google OSS-Fuzz.
-See "FUZZING.adoc" for details.
+For details, see: http://logging.apache.org/log4cxx/fuzzing.html
 
 Usage: $0 <outputDir>
 

--- a/src/fuzzers/bash/oss-fuzz-build.sh
+++ b/src/fuzzers/bash/oss-fuzz-build.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -eu
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Read command line arguments
+if [[ "$#" -ne 1 ]]; then
+  cat >&2 <<EOF
+Generates fuzzer runner scripts to be employed by Google OSS-Fuzz.
+See "FUZZING.adoc" for details.
+
+Usage: $0 <outputDir>
+
+  outputDir
+
+    The output directory to dump runner scripts and their dependencies.
+
+Environment variables:
+
+  BUILD (optional)
+
+    If "false", Maven installation will be skipped.
+EOF
+  exit 1
+fi
+outputDir=$(readlink -f "$1")
+
+# Ensure output directory exists
+mkdir -p "$outputDir"
+
+# Switch to the project directory (by referencing from the script directory)
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && cd ../../..
+
+# Build the project
+mkdir build && cd $_
+cmake -DBUILD_SHARED_LIBS=off ..
+make -j
+
+# Copy executables & resources
+find src/fuzzers/cpp -maxdepth 1 -executable -type f -exec cp -v {} "$outputDir/" \;
+cp -v ../src/fuzzers/resources/* "$outputDir/"

--- a/src/fuzzers/bash/oss-fuzz-build.sh
+++ b/src/fuzzers/bash/oss-fuzz-build.sh
@@ -40,8 +40,13 @@ cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && cd ../../..
 
 # Build the project
 mkdir -p build && cd $_
-cmake -DBUILD_SHARED_LIBS=OFF -DBUILD_FUZZERS=ON ..
-make -j
+cmake \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DBUILD_TESTING=OFF \
+  -DBUILD_EXAMPLES=OFF \
+  -DBUILD_FUZZERS=ON \
+  ..
+cmake --build .
 
 # Copy executables & resources
 find src/fuzzers/cpp -maxdepth 1 -executable -type f -exec cp -v {} "$outputDir/" \;

--- a/src/fuzzers/cpp/CMakeLists.txt
+++ b/src/fuzzers/cpp/CMakeLists.txt
@@ -17,8 +17,15 @@
 
 set(ALL_LOG4CXX_FUZZERS PatternLayoutFuzzer)
 
+# Get the most recent Git commit ID
+execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_ID
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 set(FUZZER_SANITIZE_FLAGS "-fsanitize=fuzzer,address,signed-integer-overflow")
-set(FUZZER_COMPILE_DEFINITIONS "-DCOMPILE_DEFINITIONS=${FUZZER_SANITIZE_FLAGS}")
+set(FUZZER_COMPILE_DEFINITIONS "-DCOMPILE_DEFINITIONS=${FUZZER_SANITIZE_FLAGS}" "-DGIT_COMMIT_ID=\"${GIT_COMMIT_ID}\"")
 
 if(WIN32)
   include(win32_target_environment_path)

--- a/src/fuzzers/cpp/CMakeLists.txt
+++ b/src/fuzzers/cpp/CMakeLists.txt
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set(ALL_LOG4CXX_FUZZERS PatternLayoutFuzzer)
+
+set(FUZZER_SANITIZE_FLAGS "-fsanitize=fuzzer,address,signed-integer-overflow")
+set(FUZZER_COMPILE_DEFINITIONS "-DCOMPILE_DEFINITIONS=${FUZZER_SANITIZE_FLAGS}")
+
+if(WIN32)
+  include(win32_target_environment_path)
+  get_target_environment_path(ESCAPED_PATH)
+elseif(CMAKE_BUILD_TYPE)
+  string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_BUILD_TYPE)
+  if (UPPER_BUILD_TYPE STREQUAL "DEBUG")
+    list(APPEND FUZZER_COMPILE_DEFINITIONS _DEBUG)
+  endif()
+else()
+  list(APPEND FUZZER_COMPILE_DEFINITIONS _DEBUG)
+endif()
+
+foreach(fuzzerName IN LISTS ALL_LOG4CXX_FUZZERS)
+  set(PROGRAM_NAME "${fuzzerName}")
+  add_executable(${PROGRAM_NAME} ${fuzzerName}.cpp)
+  target_compile_definitions(${PROGRAM_NAME}
+    PRIVATE
+      ${FUZZER_COMPILE_DEFINITIONS}
+      ${LOG4CXX_COMPILE_DEFINITIONS}
+      ${APR_COMPILE_DEFINITIONS}
+      ${APR_UTIL_COMPILE_DEFINITIONS})
+  target_include_directories(${PROGRAM_NAME}
+    PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}
+      $<TARGET_PROPERTY:log4cxx,INCLUDE_DIRECTORIES>)
+  target_link_libraries(${PROGRAM_NAME}
+    PRIVATE
+      ${FUZZER_SANITIZE_FLAGS}
+      log4cxx
+      ${APR_UTIL_LIBRARIES}
+      ${EXPAT_LIBRARIES}
+      ${APR_LIBRARIES}
+      ${APR_SYSTEM_LIBS})
+  if(WIN32)
+      set_target_properties(${PROGRAM_NAME}
+        PROPERTIES
+          VS_DEBUGGER_ENVIRONMENT "PATH=${ESCAPED_PATH}"
+          VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+          FOLDER Fuzzers)
+  endif()
+endforeach()

--- a/src/fuzzers/cpp/PatternLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/PatternLayoutFuzzer.cpp
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fuzzer/FuzzedDataProvider.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/appenderskeleton.h>
+
+using namespace LOG4CXX_NS;
+
+namespace LOG4CXX_NS::fuzzer {
+
+/**
+ * Appender encoding incoming log events using the provided layout.
+ * It is intended for appender-agnostic fuzzing.
+ */
+class EncodingAppender : public AppenderSkeleton {
+
+public:
+	DECLARE_LOG4CXX_OBJECT(EncodingAppender)
+	BEGIN_LOG4CXX_CAST_MAP()
+	LOG4CXX_CAST_ENTRY(EncodingAppender)
+	LOG4CXX_CAST_ENTRY_CHAIN(AppenderSkeleton)
+	END_LOG4CXX_CAST_MAP()
+
+	EncodingAppender() : AppenderSkeleton() {}
+
+	EncodingAppender(const LayoutPtr& layout) : AppenderSkeleton(layout) {}
+
+	void close() override {}
+
+	bool requiresLayout() const override {
+		return true;
+	}
+
+	void append(const spi::LoggingEventPtr& event, helpers::Pool& pool) override {
+		LogString msg;
+		getLayout()->format(msg, event, pool);
+	}
+
+	void activateOptions(helpers::Pool& pool) override {}
+
+	void setOption(const LogString& option, const LogString& value) override {}
+
+}; // class
+
+IMPLEMENT_LOG4CXX_OBJECT(EncodingAppender)
+
+LOG4CXX_PTR_DEF(EncodingAppender);
+
+} // namespace
+
+#define MAX_STRING_LENGTH 30
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	PropertyConfigurator::configure("PatternLayoutFuzzer.properties");
+	LoggerPtr logger = Logger::getRootLogger();
+  	FuzzedDataProvider dataProvider(data, size);
+  	while (dataProvider.remaining_bytes() > 0) {
+  		std::string message = dataProvider.ConsumeRandomLengthString(MAX_STRING_LENGTH);
+    	LOG4CXX_INFO(logger, message);
+    }
+  	return 0;
+}

--- a/src/fuzzers/cpp/PatternLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/PatternLayoutFuzzer.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <iostream>
 #include <fuzzer/FuzzedDataProvider.h>
 #include <log4cxx/propertyconfigurator.h>
 #include <log4cxx/appenderskeleton.h>
@@ -66,6 +67,10 @@ LOG4CXX_PTR_DEF(EncodingAppender);
 #define MAX_STRING_LENGTH 30
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+
+	// Report the effective Git commit ID
+	std::cout << "INFO: Produced using the Git commit ID: " << GIT_COMMIT_ID << std::endl;
+
 	PropertyConfigurator::configure("PatternLayoutFuzzer.properties");
 	LoggerPtr logger = Logger::getRootLogger();
   	FuzzedDataProvider dataProvider(data, size);

--- a/src/fuzzers/cpp/PatternLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/PatternLayoutFuzzer.cpp
@@ -20,6 +20,8 @@
 #include <unistd.h>		// for `readlink`, `chdir`
 #include <libgen.h> 	// for `dirname`
 #include <limits.h>		// for `PATH_MAX`
+#include <iomanip>		// for `put_time()`
+#include <ctime>		// for `time()`
 #include <fuzzer/FuzzedDataProvider.h>
 #include <log4cxx/propertyconfigurator.h>
 #include <log4cxx/appenderskeleton.h>
@@ -68,10 +70,17 @@ LOG4CXX_PTR_DEF(EncodingAppender);
 
 } // namespace
 
+static std::time_t logTime;
+static std::tm* logTimeBuffer;
+#define LOG(stream) \
+	logTime = std::time(nullptr); \
+	logTimeBuffer = std::localtime(&logTime); \
+	stream << std::put_time(logTimeBuffer, "%Y-%m-%d %H:%M:%S") << " [" << __FILE_NAME__ << ":" << __LINE__ << "] "
+
 static void findExecutablePath(char* buffer) {
     ssize_t length = readlink("/proc/self/exe", buffer, PATH_MAX);
     if (length == -1) {
-		std::cerr << "ERROR: Failed to find the executable path" << std::endl;
+    	LOG(std::cerr) << "ERROR: Failed to find the executable path" << std::endl;
 		exit(EXIT_FAILURE);
 	}
 	buffer[length] = '\0';
@@ -82,33 +91,22 @@ static void chdirExecutableHome() {
     findExecutablePath(executablePath);
     char* executableHome = dirname(executablePath);
 	if (chdir(executableHome) != 0) {
-		std::cerr << "DEBUG: Executable path: " << executablePath << std::endl;
-		std::cerr << "DEBUG: Executable home: " << executableHome << std::endl;
-		std::cerr << "ERROR: Failed to `chdir()` the executable path" << std::endl;
+		LOG(std::cerr) << "DEBUG: Executable path: " << executablePath << std::endl;
+		LOG(std::cerr) << "DEBUG: Executable home: " << executableHome << std::endl;
+		LOG(std::cerr) << "ERROR: Failed to `chdir()` the executable path" << std::endl;
 	}
 }
 
 static int INITIALIZED = 0;
 
 static void init() {
-
-	// Initialize only once
 	if (INITIALIZED != 0) {
 		return;
 	}
-	std::cout << "DEBUG: Initializing" << std::endl;
-
-	// Report the effective Git commit ID
-	std::cout << "INFO: Produced using the Git commit ID: " << GIT_COMMIT_ID << std::endl;
-
-	// Load the configuration
+	LOG(std::cout) << "INFO: Produced using the Git commit ID: " << GIT_COMMIT_ID << std::endl;
 	chdirExecutableHome();
 	PropertyConfigurator::configure("PatternLayoutFuzzer.properties");
-
-	// Toggle initialization flag
-		std::cout << "DEBUG: Initialized" << std::endl;
 	INITIALIZED = 1;
-
 }
 
 #define MAX_STRING_LENGTH 30

--- a/src/fuzzers/cpp/PatternLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/PatternLayoutFuzzer.cpp
@@ -109,7 +109,7 @@ static void init() {
 	INITIALIZED = 1;
 }
 
-#define MAX_STRING_LENGTH 30
+#define MAX_STRING_LENGTH 512
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	init();

--- a/src/fuzzers/resources/PatternLayoutFuzzer.properties
+++ b/src/fuzzers/resources/PatternLayoutFuzzer.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=ALL, encoding
+
+log4j.appender.encoding=org.apache.log4j.fuzzer.EncodingAppender
+log4j.appender.encoding.layout=org.apache.log4j.PatternLayout
+log4j.appender.encoding.layout.ConversionPattern=%5p [%t] (%f:%L) - %m%n

--- a/src/site/markdown/6-development.md
+++ b/src/site/markdown/6-development.md
@@ -25,3 +25,4 @@ See the following pages for development information:
 
 * @subpage source-repository
 * @subpage library-design
+* @subpage fuzzing

--- a/src/site/markdown/change-report-gh.md
+++ b/src/site/markdown/change-report-gh.md
@@ -52,10 +52,11 @@ Release 1.3.0 includes the following new features:
 
 * Overhead reduction of upto 60% sending logging events to an appender
 * Statistics on the AsyncAppender's queue length (in Log4cxx debug output)
+* [Fuzz tests](@ref fuzzing) along with [Google OSS-Fuzz](https://github.com/google/oss-fuzz) integration
 
 The following issues have been addressed:
 
-* MSYS2/MINGW build errors \[[#389](https://github.com/apache/logging-log4cxx/pull/389)\] 
+* MSYS2/MINGW build errors \[[#389](https://github.com/apache/logging-log4cxx/pull/389)\]
 * `thread_local` problems in MSYS2/MINGW \[[#394](https://github.com/apache/logging-log4cxx/pull/394)\]
 * A potential 'use after free' fault when using AsyncAppender \[[#397](https://github.com/apache/logging-log4cxx/pull/397)\]
 

--- a/src/site/markdown/development/fuzzing.md
+++ b/src/site/markdown/development/fuzzing.md
@@ -1,0 +1,61 @@
+Fuzzing {#fuzzing}
+===
+<!--
+ Note: License header cannot be first, as doxygen does not generate
+ cleanly if it before the '==='
+-->
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+[TOC]
+
+Log4cxx contains fuzz tests implemented using [LibFuzzer](https://llvm.org/docs/LibFuzzer.html#dictionaries).
+These tests are located in the `src/fuzzers` directory.
+
+## Google OSS-Fuzz {#oss-fuzz}
+
+[OSS-Fuzz](https://github.com/google/oss-fuzz) is a Google service that continuously runs fuzz tests of critical F/OSS projects on a beefy cluster and reports its findings (bugs, vulnerabilities, etc.) privately to project maintainers.
+Log4cxx provides OSS-Fuzz integration with following helpers:
+
+- [Dockerfile](https://github.com/google/oss-fuzz/tree/master/projects/log4cxx/Dockerfile) to create a container image for running tests
+- `oss-fuzz-build.sh` to generate fuzz test runner scripts along with all necessary dependencies
+
+## Running tests locally {#running}
+
+1. Clone the OSS-Fuzz repository:
+   ~~~~
+   git clone --depth 1 https://github.com/google/oss-fuzz
+   cd oss-fuzz/projects/apache-logging-log4cxx
+   ~~~~
+1. Build the container image:
+   ~~~~
+   docker build -t oss-fuzz-log4cxx .
+   ~~~~
+1. Run the container image to build the Log4cxx project and generate runner scripts along with dependencies:
+   ~~~~
+   # Set the directory where the generated runner scripts will be dumped to
+   export LOG4CXX_FUZZ_DIR="/path/to/store/generated/fuzzers"
+
+   docker run -it -e FUZZING_LANGUAGE=c++ -v "$LOG4CXX_FUZZ_DIR":/out --network host oss-fuzz-log4cxx
+   ~~~~
+1. List generated runner scripts:
+   ~~~~
+   ls -al "$LOG4CXX_FUZZ_DIR"
+   ~~~~
+1. Execute one of the generated runner scripts:
+   ~~~~
+   docker run -it -e FUZZING_LANGUAGE=c++ -v "$LOG4CXX_FUZZ_DIR":/out oss-fuzz-log4cxx /out/PatternLayoutFuzzer
+   ~~~~


### PR DESCRIPTION
As a deliverable of apache/logging-log4j2#2891 and apache/logging-log4j2#2892, this PR implements fuzz tests along with Google OSS-Fuzz integration. See the added `fuzzing.md` for details.

**Note:** Review request has been submitted in [this `dev@` post](https://lists.apache.org/thread/0yqh7ffr5gk031hszlp29oxzr3l57y1d).