### PR TITLE
Prevent asyncappender test timeout

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -310,10 +310,13 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 			// Write to the ring buffer
 			priv->buffer[index] = AsyncAppenderPriv::EventData{event, pendingCount};
 			// Notify the dispatch thread that an event has been added
+			auto failureCount = 0;
 			auto savedEventCount = oldEventCount;
 			while (!priv->commitCount.compare_exchange_weak(oldEventCount, oldEventCount + 1, std::memory_order_release))
 			{
-				 oldEventCount = savedEventCount;
+				oldEventCount = savedEventCount;
+				if (2 < ++failureCount) // Did the scheduler suspend a thread between claiming a slot and advancing commitCount?
+					std::this_thread::yield(); // Wait a bit
 			}
 			priv->bufferNotEmpty.notify_all();
 			break;

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -235,7 +235,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 		void testMultiThread()
 		{
 			int LEN = 2000; // Larger than default buffer size (128)
-			int threadCount = 6;
+			int threadCount = max(std::thread::hardware_concurrency(), 2);
 			auto root = Logger::getRootLogger();
 			auto vectorAppender = std::make_shared<VectorAppender>();
 			auto asyncAppender = std::make_shared<AsyncAppender>();

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#define NOMINMAX
 #include "logunit.h"
 
 #include <log4cxx/logger.h>
@@ -235,7 +236,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 		void testMultiThread()
 		{
 			int LEN = 2000; // Larger than default buffer size (128)
-			int threadCount = max(std::thread::hardware_concurrency(), 2);
+			int threadCount = std::max(std::thread::hardware_concurrency(), static_cast<unsigned int>(2));
 			auto root = Logger::getRootLogger();
 			auto vectorAppender = std::make_shared<VectorAppender>();
 			auto asyncAppender = std::make_shared<AsyncAppender>();

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -236,7 +236,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 		void testMultiThread()
 		{
 			int LEN = 2000; // Larger than default buffer size (128)
-			int threadCount = std::max(std::thread::hardware_concurrency(), static_cast<unsigned int>(2));
+			auto threadCount = std::max(static_cast<int>(std::thread::hardware_concurrency() - 1), 2);
 			auto root = Logger::getRootLogger();
 			auto vectorAppender = std::make_shared<VectorAppender>();
 			auto asyncAppender = std::make_shared<AsyncAppender>();

--- a/src/test/cpp/terminationtestcase.cpp
+++ b/src/test/cpp/terminationtestcase.cpp
@@ -63,7 +63,7 @@ public:
 	{
 		auto root = getLogger();
 		LOG4CXX_INFO(root, "Message");
-		std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+		std::this_thread::sleep_for( std::chrono::milliseconds( 30 ) );
 		const std::vector<spi::LoggingEventPtr>& v = vectorAppender->getVector();
 		LOGUNIT_ASSERT_EQUAL((size_t) 1, v.size());
 	}


### PR DESCRIPTION
This PR fixes #402 which is caused when more threads than cores (A Github runnuer is limited to only 2 cores) result in multiple thread in a std::atomic::compare_exchange_weak busy loop.

The scheduler then occasionally runs the thread where the compare_exchange succeeds, which make the test run extremely slowly.