### PR TITLE
Prevent compiler error when using std::experimental::optional

### DIFF
--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -206,7 +206,7 @@ bool LoggingEvent::getNDC(LogString& dest) const
 	// Otherwise use the NDC that is associated with the thread.
 	if (m_priv->dc)
 	{
-		result = m_priv->dc->ctx.has_value();
+		result = bool(m_priv->dc->ctx);
 		if (result)
 			dest.append(NDC::getFullMessage(m_priv->dc->ctx.value()));
 	}

--- a/src/main/include/log4cxx/helpers/optional.h
+++ b/src/main/include/log4cxx/helpers/optional.h
@@ -53,8 +53,9 @@ public:
 		this->second = value;
 		return *this;
 	}
-	bool has_value() const { return this->first; }
-	const T& value() const { return this->second; }
+	constexpr explicit operator bool() const noexcept { return this->first; }
+	constexpr bool has_value() const noexcept { return this->first; }
+	constexpr const T& value() const noexcept { return this->second; }
 };
 } // namespace LOG4CXX_NS
 #endif


### PR DESCRIPTION
This PR add support for the standard library used by gcc 5.4 [std::experimental::optional](https://en.cppreference.com/w/cpp/experimental/optional) which does not define a `has_value` method