### PR TITLE
Simplify the Class interface in the next ABI

### DIFF
--- a/src/main/cpp/class.cpp
+++ b/src/main/cpp/class.cpp
@@ -98,10 +98,12 @@ Class::~Class()
 {
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
 LogString Class::toString() const
 {
 	return getName();
 }
+#endif
 
 Object* Class::newInstance() const
 {

--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -429,7 +429,7 @@ void OptionConverter::selectAndConfigure(const File& configFileName,
 			filename.substr(filename.length() - 4),
 			LOG4CXX_STR(".XML"), LOG4CXX_STR(".xml")))
 	{
-		clazz = LOG4CXX_NS::xml::DOMConfigurator::getStaticClass().toString();
+		clazz = LOG4CXX_NS::xml::DOMConfigurator::getStaticClass().getName();
 	}
 #endif
 

--- a/src/main/include/log4cxx/helpers/class.h
+++ b/src/main/include/log4cxx/helpers/class.h
@@ -33,7 +33,9 @@ class LOG4CXX_EXPORT Class
 	public:
 		virtual ~Class();
 		virtual Object* newInstance() const;
+#if LOG4CXX_ABI_VERSION <= 15
 		LogString toString() const;
+#endif
 		virtual LogString getName() const = 0;
 		static const Class& forName(const LogString& className);
 		static bool registerClass(const Class& newClass);


### PR DESCRIPTION
This Pr remove the internal (unused) Class::toString() method in the next ABI version 