### PR TITLE
Improve asyncappender's handling of extremely rare contention

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -306,7 +306,7 @@ void AsyncAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 			auto index = oldEventCount % priv->buffer.size();
 			// Wait for a free slot
 			while (priv->bufferSize <= oldEventCount - priv->dispatchedCount)
-				;
+				std::this_thread::yield(); // Allow the dispatch thread to free a slot
 			// Write to the ring buffer
 			priv->buffer[index] = AsyncAppenderPriv::EventData{event, pendingCount};
 			// Notify the dispatch thread that an event has been added


### PR DESCRIPTION
This PR addresses a very unlikely race condition when multiple threads hit the appender when the buffer is full.