### PR TITLE
Remove unused code from cmake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,6 @@ find_package(APR-Util REQUIRED)
 
 find_package( Threads REQUIRED )
 
-# Find LibFuzzer
-include("${CMAKE_CURRENT_LIST_DIR}/src/cmake/FindLibFuzzer.cmake")
-
 # Find expat for XML parsing
 find_package(EXPAT REQUIRED)
 if(TARGET EXPAT::EXPAT)
@@ -214,7 +211,7 @@ install(EXPORT ${LOG4CXX_LIB_NAME}Targets
   FILE        ${LOG4CXX_LIB_NAME}Config.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LOG4CXX_LIB_NAME}
 )
-# Support for find_package(log4cxx 0.11) in consuming CMake projects
+# Support for find_package(log4cxx 1.3) in consuming CMake projects
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${LOG4CXX_LIB_NAME}ConfigVersion.cmake"
   VERSION       ${PROJECT_VERSION}
@@ -241,7 +238,7 @@ if(LOG4CXX_QT_SUPPORT)
 endif(LOG4CXX_QT_SUPPORT)
 
 #
-# Get the varaibles from the subdirectories
+# Get variables used in configuration information messages from subdirectories
 #
 get_directory_property( HAS_LIBESMTP DIRECTORY src/main/include DEFINITION HAS_LIBESMTP )
 get_directory_property( HAS_SYSLOG DIRECTORY src/main/include DEFINITION HAS_SYSLOG )
@@ -249,8 +246,12 @@ get_directory_property( FILESYSTEM_IMPL DIRECTORY src DEFINITION FILESYSTEM_IMPL
 get_directory_property( STD_MAKE_UNIQUE_IMPL DIRECTORY src DEFINITION STD_MAKE_UNIQUE_IMPL )
 get_directory_property( STD_LIB_HAS_UNICODE_STRING DIRECTORY src DEFINITION STD_LIB_HAS_UNICODE_STRING )
 get_directory_property( HAS_THREAD_LOCAL DIRECTORY src DEFINITION HAS_THREAD_LOCAL )
+get_directory_property( BUILD_FUZZERS DIRECTORY src DEFINITION BUILD_FUZZERS )
 
-foreach(varName HAS_STD_LOCALE  HAS_ODBC  HAS_MBSRTOWCS  HAS_WCSTOMBS  HAS_FWIDE  HAS_LIBESMTP  HAS_SYSLOG HAS_FMT)
+#
+# Use ON/OFF in configuration information messages
+#
+foreach(varName HAS_ODBC  HAS_LIBESMTP  HAS_SYSLOG)
   if(${varName} EQUAL 0)
     set(${varName} "OFF" )
   elseif(${varName} EQUAL 1)
@@ -267,40 +268,12 @@ else()
 endif()
 
 #
-# Package and sign if Apache maintainer
-#
-option(APACHE_MAINTAINER "Apache maintainer" OFF)
-if(APACHE_MAINTAINER)
-    set(CPACK_SOURCE_PACKAGE_FILE_NAME "apache-log4cxx-${LOG4CXX_RELEASE_VERSION}")
-    set(CPACK_SOURCE_GENERATOR "TGZ;ZIP")
-    set(CPACK_SOURCE_IGNORE_FILES ".git/;.github/;.gitattributes;.gitignore;.vs/;out/;build/;sonar-project.properties;doap_log4cxx.rdf;CMakeLists.txt.user;src/main/abi-symbols/;src/test/resources/output/")
-    include(CPack)
-    if(CPACK_PACKAGE_DIRECTORY)
-      set(LOG4CXX_PACKAGE_FILEPATH_PREFIX "${CPACK_PACKAGE_DIRECTORY}/${CPACK_SOURCE_PACKAGE_FILE_NAME}")
-    else()
-      set(LOG4CXX_PACKAGE_FILEPATH_PREFIX "${CMAKE_BINARY_DIR}/${CPACK_SOURCE_PACKAGE_FILE_NAME}")
-    endif()
-
-    add_custom_target( dist
-	COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} -- package_source
-	COMMAND ${CMAKE_COMMAND} -E sha512sum "${LOG4CXX_PACKAGE_FILEPATH_PREFIX}.tar.gz" > "${LOG4CXX_PACKAGE_FILEPATH_PREFIX}.tar.gz.sha512"
-	COMMAND ${CMAKE_COMMAND} -E sha512sum "${LOG4CXX_PACKAGE_FILEPATH_PREFIX}.zip" > "${LOG4CXX_PACKAGE_FILEPATH_PREFIX}.zip.sha512"
-	COMMAND gpg --armor --detach-sign --yes --pinentry-mode error "${LOG4CXX_PACKAGE_FILEPATH_PREFIX}.tar.gz" > "${LOG4CXX_PACKAGE_FILEPATH_PREFIX}.tar.gz.asc"
-	COMMAND gpg --armor --detach-sign --yes --pinentry-mode error "${LOG4CXX_PACKAGE_FILEPATH_PREFIX}.zip" > "${LOG4CXX_PACKAGE_FILEPATH_PREFIX}.zip.asc"
-	)
-endif()
-
-#
-# Check for any fatal configuration errors
-#
-
-#
 # Output configuration information
 # Similar to APR CMake configuration
 #
 message(STATUS "")
 message(STATUS "")
-message(STATUS "log4cxx configuration summary:")
+message(STATUS "Log4cxx configuration summary:")
 message(STATUS "")
 
 message(STATUS "  C++ compiler .................... : ${CMAKE_CXX_COMPILER}")
@@ -348,7 +321,6 @@ message(STATUS "  ODBC Appender ................... : ${HAS_ODBC}")
 message(STATUS "  DB Appender ..................... : ON")
 message(STATUS "  SMTP Appender ................... : ${HAS_LIBESMTP}")
 message(STATUS "  XMLSocketAppender ............... : ${LOG4CXX_NETWORKING_SUPPORT}")
-message(STATUS "  SocketHubAppender ............... : ${LOG4CXX_NETWORKING_SUPPORT}")
 message(STATUS "  SyslogAppender .................. : ${LOG4CXX_NETWORKING_SUPPORT}")
 if(LOG4CXX_NETWORKING_SUPPORT)
 message(STATUS "  Using syslog.h .................. : ${HAS_SYSLOG}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,9 @@ if(BUILD_EXAMPLES)
   add_subdirectory(examples/cpp)
 endif()
 
+# Find LibFuzzer
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/FindLibFuzzer.cmake")
+
 # Define `BUILD_FUZZERS_DEFAULT`
 if(BUILD_TESTING AND LIBFUZZER_FOUND)
   set(BUILD_FUZZERS_DEFAULT ON)
@@ -57,4 +60,8 @@ if(BUILD_FUZZERS)
   endif()
 endif()
 
-add_subdirectory(site)
+option(BUILD_SITE "Build log4cxx website" OFF)
+if(BUILD_SITE)
+  add_subdirectory(site)
+endif()
+

--- a/src/site/CMakeLists.txt
+++ b/src/site/CMakeLists.txt
@@ -15,29 +15,26 @@
 # limitations under the License.
 #
 
-option(BUILD_SITE "Build log4cxx website" OFF)
-if(BUILD_SITE)
-    file(RELATIVE_PATH LOG4CXX_REL_BIN_TO_SRC_DIR "${LOG4CXX_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+file(RELATIVE_PATH LOG4CXX_REL_BIN_TO_SRC_DIR "${LOG4CXX_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
 
-    find_package( Doxygen REQUIRED dot )
+find_package( Doxygen REQUIRED dot )
 
-    set(LOG4CXX_SOURCE_PACKAGE_FILE_NAME "apache-log4cxx-${LOG4CXX_RELEASE_VERSION}")
-    set(LOG4CXX_SOURCE_MIRROR_URL "https://www.apache.org/dyn/closer.cgi/logging/log4cxx/${LOG4CXX_RELEASE_VERSION}/${LOG4CXX_SOURCE_PACKAGE_FILE_NAME}")
-    set(APACHE_LOGGING_DISTRIBUTION_URL "https://www.apache.org/dist/logging")
-    set(LOG4CXX_DOCUMENTATION_URL "https://logging.apache.org/log4cxx")
-    set(LOG4CXX_DISTRIBUTION_URL "${APACHE_LOGGING_DISTRIBUTION_URL}/log4cxx/${LOG4CXX_RELEASE_VERSION}/${LOG4CXX_SOURCE_PACKAGE_FILE_NAME}")
-    set(LOG4CXX_RELEASE_MANAGER "Stephen Webb")
-    set(LOG4CXX_RELEASE_MANAGER_KEY "C6FC425C96722EFC4E2D02D5D4305EBC16B4A78D")
+set(LOG4CXX_SOURCE_PACKAGE_FILE_NAME "apache-log4cxx-${LOG4CXX_RELEASE_VERSION}")
+set(LOG4CXX_SOURCE_MIRROR_URL "https://www.apache.org/dyn/closer.cgi/logging/log4cxx/${LOG4CXX_RELEASE_VERSION}/${LOG4CXX_SOURCE_PACKAGE_FILE_NAME}")
+set(APACHE_LOGGING_DISTRIBUTION_URL "https://www.apache.org/dist/logging")
+set(LOG4CXX_DOCUMENTATION_URL "https://logging.apache.org/log4cxx")
+set(LOG4CXX_DISTRIBUTION_URL "${APACHE_LOGGING_DISTRIBUTION_URL}/log4cxx/${LOG4CXX_RELEASE_VERSION}/${LOG4CXX_SOURCE_PACKAGE_FILE_NAME}")
+set(LOG4CXX_RELEASE_MANAGER "Stephen Webb")
+set(LOG4CXX_RELEASE_MANAGER_KEY "C6FC425C96722EFC4E2D02D5D4305EBC16B4A78D")
 
-    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/doxy/Doxyfile.in
-        ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile )
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/doxy/Doxyfile.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile )
 
-    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/markdown/download.md.in
-        ${CMAKE_CURRENT_BINARY_DIR}/markdown/download.md )
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/markdown/download.md.in
+    ${CMAKE_CURRENT_BINARY_DIR}/markdown/download.md )
 
-    add_custom_target( doc_doxygen ALL
-        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-        WORKING_DIRECTORY ${LOG4CXX_SOURCE_DIR}
-        COMMENT "Generate site with Doxygen"
-        VERBATIM )
-endif()
+add_custom_target( doc_doxygen ALL
+    COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY ${LOG4CXX_SOURCE_DIR}
+    COMMENT "Generate site with Doxygen"
+    VERBATIM )


### PR DESCRIPTION
This PR removes unused parts of build scripts.

As the release review process relies on Github action to package source (to prevent a XY utils type security problem), the packaging process activated by APACHE_MAINTAINER is no longer required.