### PR TITLE
Ensure all logged event are stored when using MultiprocessRollingFileAppender

### DIFF
--- a/src/main/cpp/bufferedwriter.cpp
+++ b/src/main/cpp/bufferedwriter.cpp
@@ -82,3 +82,8 @@ void BufferedWriter::write(const LogString& str, Pool& p)
 	}
 }
 
+WriterPtr BufferedWriter::getWriter() const
+{
+	return m_priv->out;
+}
+

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -350,11 +350,9 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 					);
 				setWriterInternal(createWriter(os));
 
-				bool success = false;
+				bool success = true; // A synchronous action is not required
 				if (auto pAction = rollover1->getSynchronous())
-				{
 					success = pAction->execute(p);
-				}
 
 				if (success)
 				{

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -156,9 +156,6 @@ public: // Support classes
 		{
 			if (!m_parent->lock_file)
 			{
-				if (auto pTimeBased = LOG4CXX_NS::cast<TimeBasedRollingPolicy>(m_parent->rollingPolicy))
-					pTimeBased->setMultiprocess(true);
-
 				LogString filePrefix(fileName);
 				if (auto basePolicy = LOG4CXX_NS::cast<RollingPolicyBase>(m_parent->rollingPolicy))
 				{
@@ -223,6 +220,18 @@ MultiprocessRollingFileAppender::MultiprocessRollingFileAppender()
 	: RollingFileAppender(std::make_unique<MultiprocessRollingFileAppenderPriv>())
 {
 }
+
+/**
+ * Prepare instance of use.
+ */
+void MultiprocessRollingFileAppender::activateOptions(Pool& p)
+{
+	RollingFileAppender::activateOptions(p);
+
+	if (auto pTimeBased = LOG4CXX_NS::cast<TimeBasedRollingPolicy>(_priv->rollingPolicy))
+		pTimeBased->setMultiprocess(true);
+}
+	
 
 bool MultiprocessRollingFileAppender::isAlreadyRolled()
 {

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -290,8 +290,9 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 	{
 		MultiprocessRollingFileAppenderPriv::Lock lk(_priv, getFile());
 		if (!lk.hasLock())
-			;
-		else if (auto rollover1 = _priv->rollingPolicy->rollover(getFile(), getAppend(), p))
+			LogLog::warn(LOG4CXX_STR("Failed to lock ") + getFile());
+
+		if (auto rollover1 = _priv->rollingPolicy->rollover(getFile(), getAppend(), p))
 		{
 			closeWriter();
 			if (rollover1->getActiveFileName() == getFile())

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -291,8 +291,9 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 		MultiprocessRollingFileAppenderPriv::Lock lk(_priv, getFile());
 		if (!lk.hasLock())
 			LogLog::warn(LOG4CXX_STR("Failed to lock ") + getFile());
-
-		if (auto rollover1 = _priv->rollingPolicy->rollover(getFile(), getAppend(), p))
+		else if (!_priv->triggeringPolicy->isTriggeringEvent(this, _priv->_event, getFile(), File().setPath(getFile()).length(p)))
+			;
+		else if (auto rollover1 = _priv->rollingPolicy->rollover(getFile(), getAppend(), p))
 		{
 			closeWriter();
 			if (rollover1->getActiveFileName() == getFile())

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -192,7 +192,6 @@ public: // Support classes
 				else
 					m_ok = true;
 			}
-			;
 		}
 
 		/**
@@ -298,17 +297,13 @@ bool MultiprocessRollingFileAppender::rolloverInternal(Pool& p)
 			if (rollover1->getActiveFileName() == getFile())
 			{
 
-				bool success = false;
-
+				bool success = true; // A synchronous action is not required
 				if (auto pAction = rollover1->getSynchronous())
-				{
 					success = pAction->execute(p);
-				}
 
 				bool appendToExisting = true;
 				if (success)
 				{
-
 					appendToExisting = rollover1->getAppend();
 					if (appendToExisting)
 					{

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -42,8 +42,13 @@ IMPLEMENT_LOG4CXX_OBJECT(RollingFileAppender)
 /**
  * Construct a new instance.
  */
-RollingFileAppender::RollingFileAppender() :
-	FileAppender (std::make_unique<RollingFileAppenderPriv>())
+RollingFileAppender::RollingFileAppender()
+	: FileAppender(std::make_unique<RollingFileAppenderPriv>())
+{
+}
+
+RollingFileAppender::RollingFileAppender( std::unique_ptr<RollingFileAppenderPriv> priv )
+	: FileAppender(std::move(priv))
 {
 }
 

--- a/src/main/include/log4cxx/helpers/bufferedwriter.h
+++ b/src/main/include/log4cxx/helpers/bufferedwriter.h
@@ -50,6 +50,7 @@ class LOG4CXX_EXPORT BufferedWriter : public Writer
 		void flush(Pool& p) override;
 		void write(const LogString& str, Pool& p) override;
 
+		WriterPtr getWriter() const;
 	private:
 		BufferedWriter(const BufferedWriter&);
 		BufferedWriter& operator=(const BufferedWriter&);

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -19,11 +19,8 @@
 #define LOG4CXX_ROLLING_MULTIPROCESS_ROLLING_FILE_APPENDER_H
 
 #include <log4cxx/fileappender.h>
-#include <log4cxx/spi/optionhandler.h>
 #include <log4cxx/rolling/rollingfileappender.h>
 #include <log4cxx/rolling/triggeringpolicy.h>
-#include <log4cxx/rolling/rollingpolicy.h>
-#include <log4cxx/rolling/action.h>
 
 namespace LOG4CXX_NS
 {
@@ -33,6 +30,9 @@ namespace rolling
 
 /**
  * A special version of the RollingFileAppender that acts properly with multiple processes
+ *
+ * Note: Do *not* set the option <code>Append</code> to <code>false</code>.
+ * Rolling over files is only relevant when you are appending.
  */
 class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppender
 {
@@ -90,7 +90,7 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		helpers::WriterPtr createWriter(helpers::OutputStreamPtr& os) override;
 
 	private:
-		bool rolloverInternal(LOG4CXX_NS::helpers::Pool& p, const TriggeringPolicyPtr& trigger = TriggeringPolicyPtr() );
+		bool rolloverInternal(helpers::Pool& p, const TriggeringPolicyPtr& trigger = TriggeringPolicyPtr() );
 
 		/**
 		 * Set byte length of current active log file.
@@ -109,7 +109,7 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		 * re-open the latest file when its own handler has been renamed
 		 * @return void
 		 */
-		void reopenLatestFile(LOG4CXX_NS::helpers::Pool& p);
+		void reopenLatestFile(helpers::Pool& p);
 
 		friend class MultiprocessOutputStream;
 

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -48,6 +48,13 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		MultiprocessRollingFileAppender();
 
 		/**
+		\copybrief FileAppender::activateOptions()
+
+		\sa FileAppender::activateOptions()
+		*/
+		void activateOptions(helpers::Pool& pool ) override;
+
+		/**
 		   Implements the usual roll over behaviour.
 
 		   <p>If <code>MaxBackupIndex</code> is positive, then files

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -90,11 +90,15 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		helpers::WriterPtr createWriter(helpers::OutputStreamPtr& os) override;
 
 	private:
-		bool rolloverInternal(helpers::Pool& p, const TriggeringPolicyPtr& trigger = TriggeringPolicyPtr() );
+		/**
+		 * Coordinate a rollover with other processes
+
+		 * @return true if this process perfomed the rollover.
+		 */
+		bool synchronizedRollover(helpers::Pool& p, const TriggeringPolicyPtr& trigger = TriggeringPolicyPtr() );
 
 		/**
-		 * Set byte length of current active log file.
-		 * @return void
+		 * Set the length of current active log file to \c length bytes.
 		 */
 		void setFileLength(size_t length);
 

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -77,8 +77,6 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		*/
 		void subAppend(const spi::LoggingEventPtr& event, helpers::Pool& p) override;
 
-		bool rolloverInternal(LOG4CXX_NS::helpers::Pool& p);
-
 	protected:
 		/**
 		   Returns an OutputStreamWriter when passed an OutputStream.  The
@@ -92,6 +90,8 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		helpers::WriterPtr createWriter(helpers::OutputStreamPtr& os) override;
 
 	private:
+		bool rolloverInternal(LOG4CXX_NS::helpers::Pool& p, const TriggeringPolicyPtr& trigger = TriggeringPolicyPtr() );
+
 		/**
 		 * Set byte length of current active log file.
 		 * @return void
@@ -100,9 +100,10 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 
 		/**
 		 *  Was the log file changed?
+		 *  @param pSize if not NULL, receives the log file size
 		 * @return true if the log file must be reopened
 		 */
-		bool isAlreadyRolled();
+		bool isAlreadyRolled(size_t* pSize = 0);
 
 		/**
 		 * re-open the latest file when its own handler has been renamed

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -92,10 +92,11 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		void setFileLength(size_t length);
 
 		/**
-		 *  Release the file lock
-		 * @return void
+		 *  Was the log file changed?
+		 * @return true if the log file must be reopened
 		 */
-		void releaseFileLock(apr_file_t* lock_file);
+		bool isAlreadyRolled();
+
 		/**
 		 * re-open the latest file when its own handler has been renamed
 		 * @return void

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -99,17 +99,16 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		void setFileLength(size_t length);
 
 		/**
-		 *  Was the log file changed?
+		 *  Was \c fileName renamed?
 		 *  @param pSize if not NULL, receives the log file size
 		 * @return true if the log file must be reopened
 		 */
-		bool isAlreadyRolled(size_t* pSize = 0);
+		bool isAlreadyRolled(const LogString& fileName, size_t* pSize = 0);
 
 		/**
-		 * re-open the latest file when its own handler has been renamed
-		 * @return void
+		 * re-open \c fileName (used after it has been renamed)
 		 */
-		void reopenLatestFile(helpers::Pool& p);
+		void reopenFile(const LogString& fileName, size_t fileLength);
 
 		friend class MultiprocessOutputStream;
 

--- a/src/main/include/log4cxx/rolling/rollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/rollingfileappender.h
@@ -43,19 +43,16 @@ namespace rolling
  * <code>RollingPolicy</code> and a <code>TriggeringPolicy</code>.
  *
  * <p><code>RollingFileAppender</code> can be configured programattically or
- * using {@link log4cxx::xml::DOMConfigurator}. Here is a sample
- * configration file:
+ * using {@link log4cxx::xml::DOMConfigurator}.
+ * The following is a sample configuration file.
 
 <pre>&lt;?xml version="1.0" encoding="UTF-8" ?>
 &lt;!DOCTYPE log4j:configuration>
-
-&lt;log4j:configuration debug="true">
-
+  &lt;log4j:configuration debug="true">
   &lt;appender name="ROLL" class="org.apache.log4j.rolling.RollingFileAppender">
     <b>&lt;rollingPolicy class="org.apache.log4j.rolling.TimeBasedRollingPolicy">
       &lt;param name="FileNamePattern" value="/wombat/foo.%d{yyyy-MM}.gz"/>
     &lt;/rollingPolicy></b>
-
     &lt;layout class="org.apache.log4j.PatternLayout">
       &lt;param name="ConversionPattern" value="%c{1} - %m%n"/>
     &lt;/layout>
@@ -64,7 +61,6 @@ namespace rolling
   &lt;root>
     &lt;appender-ref ref="ROLL"/>
   &lt;/root>
-
 &lt;/log4j:configuration>
 </pre>
 
@@ -73,9 +69,10 @@ namespace rolling
  * {@link TimeBasedRollingPolicy} for more details.
  *
  *
+ * Note: Do *not* set the option <code>Append</code> to <code>false</code>.
+ * Rolling over files is only relevant when you are appending.
  *
- *
- * */
+ */
 class LOG4CXX_EXPORT RollingFileAppender : public FileAppender
 {
 		DECLARE_LOG4CXX_OBJECT(RollingFileAppender)

--- a/src/main/include/log4cxx/rolling/rollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/rollingfileappender.h
@@ -88,6 +88,7 @@ class LOG4CXX_EXPORT RollingFileAppender : public FileAppender
 
 	public:
 		RollingFileAppender();
+		RollingFileAppender( std::unique_ptr<RollingFileAppenderPriv> priv );
 
 		/** Returns the value of the <b>MaxBackupIndex</b> option. */
 		int getMaxBackupIndex() const;

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -119,7 +119,7 @@ public:
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 3;
 		size_t approxBytesPerLogFile = 1000;
-		if (auto pAppender = LOG4CXX_NS::cast<rolling::RollingFileAppender>(logger->getAppender(LOG4CXX_STR("DATED-UNCOMPRESSED"))))
+		if (auto pAppender = LOG4CXX_NS::cast<rolling::RollingFileAppender>(logger->getAppender(LOG4CXX_STR("DATED"))))
 		{
 			if (auto pPolicy = LOG4CXX_NS::cast<rolling::SizeBasedTriggeringPolicy>(pAppender->getTriggeringPolicy()))
 				approxBytesPerLogFile = pPolicy->getMaxFileSize();

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -212,7 +212,7 @@ public:
 							LogString msg(ex.what());
 							msg += " processing\n";
 							msg += line;
-							helpers::LogLog::debug(msg);
+							helpers::LogLog::warn(msg);
 						}
 					 }
 					 pos = line.find(" [0x");
@@ -228,7 +228,7 @@ public:
 							LogString msg(ex.what());
 							msg += " processing\n";
 							msg += line;
-							helpers::LogLog::debug(msg);
+							helpers::LogLog::warn(msg);
 						}
 					 }
 				}

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -181,7 +181,7 @@ public:
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
 		{
 			LogString filename(dir_entry.path().filename().string());
-			if (expectedPrefix.size() + expectedSuffix.size() < filename.size()
+			if (expectedPrefix.size() + expectedSuffix.size() <= filename.size()
 				&& filename.substr(0, expectedPrefix.size()) == expectedPrefix
 				&& filename.substr(filename.size() - expectedSuffix.size()) == expectedSuffix)
 			{

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -158,6 +158,15 @@ public:
 	 */
 	void test4()
 	{
+		LogString expectedPrefix = LOG4CXX_STR("multiprocess-dated");
+		// remove any previously generated files
+		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
+		{
+			LogString filename(dir_entry.path().filename().string());
+			if (expectedPrefix.size() < filename.size() &&
+				filename.substr(0, expectedPrefix.size()) == expectedPrefix)
+				std::filesystem::remove(dir_entry);
+		}
 		auto thisProgram = GetExecutableFileName();
 		const char* args[] = {thisProgram.c_str(), "test3", 0};
 		helpers::Pool p;
@@ -175,7 +184,6 @@ public:
 		}
 
 		// Check all messages are saved to files
-		LogString expectedPrefix = LOG4CXX_STR("multiprocess-dated");
 		LogString expectedSuffix = LOG4CXX_STR(".log");
 		std::vector<int> messageCount;
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -205,11 +205,21 @@ public:
 							messageCount.resize(msgNumber + 1);
 						++messageCount[msgNumber];
 					 }
-					 pos = line.find("[0x");
+					 pos = line.find(" [0x");
 					 if (line.npos != pos && pos + 4 < line.size())
 					 {
-						auto threadNumber = std::stoi(line.substr(pos + 4), 0, 16);
-						++perThreadMessageCount[threadNumber];
+						try
+						{
+							auto threadNumber = std::stoi(line.substr(pos + 4), 0, 16);
+							++perThreadMessageCount[threadNumber];
+						}
+						catch (std::exception const& ex)
+						{
+							LogString msg(ex.what());
+							msg += " processing\n";
+							msg += line;
+							helpers::LogLog::debug(msg);
+						}
 					 }
 				}
 			}

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -22,7 +22,11 @@
 #include <log4cxx/xml/domconfigurator.h>
 #include <log4cxx/helpers/strftimedateformat.h>
 #include <log4cxx/helpers/date.h>
+#include <log4cxx/helpers/loglog.h>
+#include <log4cxx/helpers/stringhelper.h>
 #include <filesystem>
+#include <fstream>
+#include <apr_thread_proc.h>
 
 using namespace log4cxx;
 
@@ -46,6 +50,7 @@ LOGUNIT_CLASS(MultiprocessRollingTest)
 	LOGUNIT_TEST(test1);
 	LOGUNIT_TEST(test2);
 	LOGUNIT_TEST(test3);
+	LOGUNIT_TEST(test4);
 	LOGUNIT_TEST_SUITE_END();
 
 public:
@@ -137,7 +142,7 @@ public:
 	 */
 	void test3()
 	{
-		auto logger = getLogger("Test2");
+		auto logger = getLogger("Test3");
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 30;
 		auto approxBytesPerLogFile = 1000;
@@ -148,14 +153,125 @@ public:
 		}
 	}
 
-private:
 	/**
-	 *   Common aspects of test1 and test2
+	 * Concurrently use a time based rolling policy with a sized based trigger.
 	 */
-	void common(const LogString & baseName)
+	void test4()
 	{
+		auto thisProgram = GetExecutableFileName();
+		const char* args[] = {thisProgram.c_str(), "test3", 0};
+		helpers::Pool p;
+		apr_procattr_t* attr = NULL;
+		setTestAttributes(&attr, p);
+		apr_proc_t pid[5];
+		for (auto i : {0, 1, 2, 3, 4})
+			startTestInstance(&pid[i], attr, args, p);
+		for (auto i : {0, 1, 2, 3, 4})
+		{
+			int exitCode;
+			apr_exit_why_e reason;
+			apr_proc_wait(&pid[i], &exitCode, &reason, APR_WAIT);
+			LOGUNIT_ASSERT_EQUAL(exitCode, 0);
+		}
 
+		// Check all messages are saved to files
+		LogString expectedPrefix = LOG4CXX_STR("multiprocess-dated-");
+		LogString expectedSuffix = LOG4CXX_STR(".log");
+		std::vector<int> messageCount;
+		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
+		{
+			LogString filename(dir_entry.path().filename().string());
+			if (expectedPrefix.size() + expectedSuffix.size() < filename.size()
+				&& filename.substr(0, expectedPrefix.size()) == expectedPrefix
+				&& filename.substr(filename.size() - expectedSuffix.size()) == expectedSuffix)
+			{
+				std::ifstream input(dir_entry.path());
+				for (std::string line; std::getline(input, line);)
+				{
+					 auto pos = line.rfind(' ');
+					 if (line.npos != pos)
+					 {
+						auto msgNumber = std::stoi(line.substr(pos));
+						if (messageCount.size() <= msgNumber)
+							messageCount.resize(msgNumber + 1);
+						++messageCount[msgNumber];
+					 }
+				}
+			}
+		}
+		if (helpers::LogLog::isDebugEnabled())
+		{
+			LogString msg(LOG4CXX_STR("messageCount "));
+			for (auto item : messageCount)
+			{
+				msg += logchar(' ');
+				helpers::StringHelper::toString(item, p, msg);
+			}
+			helpers::LogLog::debug(msg);
+		}
+		for (auto& count : messageCount)
+			LOGUNIT_ASSERT_EQUAL(count, messageCount.front());
 	}
+
+private:
+
+	void setTestAttributes(apr_procattr_t** attr, helpers::Pool& p)
+	{
+		if (apr_procattr_create(attr, p.getAPRPool()) != APR_SUCCESS)
+		{
+			LOGUNIT_FAIL("apr_procattr_create failed");
+		}
+		if (apr_procattr_io_set(*attr, APR_NO_PIPE, APR_NO_PIPE, APR_NO_PIPE) != APR_SUCCESS)
+		{
+			LOGUNIT_FAIL("apr_procattr_io_set failed");
+		}
+		if (apr_procattr_cmdtype_set(*attr, APR_PROGRAM) != APR_SUCCESS)
+		{
+			LOGUNIT_FAIL("apr_procattr_cmdtype_set failed");
+		}
+	}
+
+	void startTestInstance(apr_proc_t* pid, apr_procattr_t* attr, const char** argv, helpers::Pool& p)
+	{
+		if (apr_proc_create(pid, argv[0], argv, NULL, attr, p.getAPRPool()) == APR_SUCCESS)
+		{
+			apr_sleep(1000);    // 1 millisecond
+		}
+		else
+		{
+			LOGUNIT_FAIL("apr_proc_create failed");
+		}
+	}
+
+	std::string GetExecutableFileName()
+	{
+		static const int bufSize = 4096;
+		char buf[bufSize+1] = {0};
+		uint32_t bufCount = 0;
+#if defined(_WIN32)
+		GetModuleFileName(NULL, buf, bufSize);
+#elif defined(__APPLE__)
+		_NSGetExecutablePath(buf, &bufCount);
+#elif (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 500) || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L)
+		std::ostringstream exeLink;
+		exeLink << "/proc/" << getpid() << "/exe";
+		bufCount = readlink(exeLink.str().c_str(), buf, bufSize);
+		if (0 < bufCount)
+			buf[bufCount] = 0;
+#else
+		strncpy(buf, "multiprocessrollingtest", bufSize);
+#endif
+		return std::string(buf);
+	}
+#ifdef _DEBUG
+	struct Fixture
+	{
+		Fixture() {
+			helpers::LogLog::setInternalDebugging(true);
+		}
+	} suiteFixture;
+#endif
+
 };
 
 LOGUNIT_TEST_SUITE_REGISTRATION(MultiprocessRollingTest);

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -20,6 +20,8 @@
 #include "../insertwide.h"
 #include <log4cxx/logmanager.h>
 #include <log4cxx/xml/domconfigurator.h>
+#include <log4cxx/rolling/multiprocessrollingfileappender.h>
+#include <log4cxx/rolling/sizebasedtriggeringpolicy.h>
 #include <log4cxx/helpers/strftimedateformat.h>
 #include <log4cxx/helpers/date.h>
 #include <log4cxx/helpers/loglog.h>
@@ -28,7 +30,7 @@
 #include <fstream>
 #include <apr_thread_proc.h>
 
-using namespace log4cxx;
+using namespace LOG4CXX_NS;
 
 auto getLogger(const std::string& name) -> LoggerPtr {
 	static struct log4cxx_initializer {
@@ -59,7 +61,7 @@ public:
 	 */
 	void test1()
 	{
-		auto logger = getLogger("Test1");
+		auto logger = getLogger(LOG4CXX_STR("Test1"));
 		for (int i = 0; i < 25; i++)
 		{
 			char msg[10];
@@ -113,10 +115,15 @@ public:
 				filename.substr(0, expectedPrefix.size()) == expectedPrefix)
 				std::filesystem::remove(dir_entry);
 		}
-		auto logger = getLogger("Test2");
+		auto logger = getLogger(LOG4CXX_STR("Test2"));
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 3;
-		auto approxBytesPerLogFile = 1000;
+		size_t approxBytesPerLogFile = 1000;
+		if (auto pAppender = LOG4CXX_NS::cast<rolling::RollingFileAppender>(logger->getAppender(LOG4CXX_STR("DATED-UNCOMPRESSED"))))
+		{
+			if (auto pPolicy = LOG4CXX_NS::cast<rolling::SizeBasedTriggeringPolicy>(pAppender->getTriggeringPolicy()))
+				approxBytesPerLogFile = pPolicy->getMaxFileSize();
+		}
 		auto requiredLogEventCount = (approxBytesPerLogFile * requiredLogFileCount + approxBytesPerLogEvent - 1) / approxBytesPerLogEvent;
 		for ( int x = 0; x < requiredLogEventCount; x++ )
 		{
@@ -142,10 +149,15 @@ public:
 	 */
 	void test3()
 	{
-		auto logger = getLogger("Test3");
+		auto logger = getLogger(LOG4CXX_STR("Test3"));
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 30;
-		auto approxBytesPerLogFile = 1000;
+		size_t approxBytesPerLogFile = 1000;
+		if (auto pAppender = LOG4CXX_NS::cast<rolling::RollingFileAppender>(logger->getAppender(LOG4CXX_STR("DATED-UNCOMPRESSED"))))
+		{
+			if (auto pPolicy = LOG4CXX_NS::cast<rolling::SizeBasedTriggeringPolicy>(pAppender->getTriggeringPolicy()))
+				approxBytesPerLogFile = pPolicy->getMaxFileSize();
+		}
 		auto requiredLogEventCount = (approxBytesPerLogFile * requiredLogFileCount + approxBytesPerLogEvent - 1) / approxBytesPerLogEvent;
 		for ( int x = 0; x < requiredLogEventCount; x++ )
 		{

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -175,7 +175,7 @@ public:
 		}
 
 		// Check all messages are saved to files
-		LogString expectedPrefix = LOG4CXX_STR("multiprocess-dated-");
+		LogString expectedPrefix = LOG4CXX_STR("multiprocess-dated");
 		LogString expectedSuffix = LOG4CXX_STR(".log");
 		std::vector<int> messageCount;
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
@@ -189,7 +189,7 @@ public:
 				for (std::string line; std::getline(input, line);)
 				{
 					 auto pos = line.rfind(' ');
-					 if (line.npos != pos)
+					 if (line.npos != pos && pos + 1 < line.size() && isdigit(line[pos+1]))
 					 {
 						auto msgNumber = std::stoi(line.substr(pos));
 						if (messageCount.size() <= msgNumber)

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -61,7 +61,7 @@ public:
 	 */
 	void test1()
 	{
-		auto logger = getLogger(LOG4CXX_STR("Test1"));
+		auto logger = getLogger("Test1");
 		for (int i = 0; i < 25; i++)
 		{
 			char msg[10];
@@ -106,16 +106,16 @@ public:
 	 */
 	void test2()
 	{
-		LogString expectedPrefix = LOG4CXX_STR("multiprocess-dated-");
+		std::string expectedPrefix = LOG4CXX_STR("multiprocess-dated-");
 		// remove any previously generated files
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
 		{
-			LogString filename(dir_entry.path().filename().string());
+			std::string filename(dir_entry.path().filename().string());
 			if (expectedPrefix.size() < filename.size() &&
 				filename.substr(0, expectedPrefix.size()) == expectedPrefix)
 				std::filesystem::remove(dir_entry);
 		}
-		auto logger = getLogger(LOG4CXX_STR("Test2"));
+		auto logger = getLogger("Test2");
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 3;
 		size_t approxBytesPerLogFile = 1000;
@@ -149,7 +149,7 @@ public:
 	 */
 	void test3()
 	{
-		auto logger = getLogger(LOG4CXX_STR("Test3"));
+		auto logger = getLogger("Test3");
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 30;
 		size_t approxBytesPerLogFile = 1000;
@@ -170,11 +170,11 @@ public:
 	 */
 	void test4()
 	{
-		LogString expectedPrefix = LOG4CXX_STR("multiprocess-dated");
+		std::string expectedPrefix("multiprocess-dated");
 		// remove any previously generated files
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
 		{
-			LogString filename(dir_entry.path().filename().string());
+			std::string filename(dir_entry.path().filename().string());
 			if (expectedPrefix.size() < filename.size() &&
 				filename.substr(0, expectedPrefix.size()) == expectedPrefix)
 				std::filesystem::remove(dir_entry);
@@ -196,12 +196,12 @@ public:
 		}
 
 		// Check all messages are saved to files
-		LogString expectedSuffix = LOG4CXX_STR(".log");
+		std::string expectedSuffix(".log");
 		std::vector<int> messageCount;
 		std::map<long long, int> perThreadMessageCount;
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
 		{
-			LogString filename(dir_entry.path().filename().string());
+			std::string filename(dir_entry.path().filename().string());
 			if (expectedPrefix.size() + expectedSuffix.size() <= filename.size()
 				&& filename.substr(0, expectedPrefix.size()) == expectedPrefix
 				&& filename.substr(filename.size() - expectedSuffix.size()) == expectedSuffix)
@@ -221,9 +221,10 @@ public:
 						}
 						catch (std::exception const& ex)
 						{
-							LogString msg(ex.what());
-							msg += " processing\n";
-							msg += line;
+							LogString msg;
+							helpers::Transcoder::decode(ex.what(), msg);
+							msg += LOG4CXX_STR(" processing\n");
+							helpers::Transcoder::decode(line, msg);
 							helpers::LogLog::warn(msg);
 						}
 					 }
@@ -237,9 +238,10 @@ public:
 						}
 						catch (std::exception const& ex)
 						{
-							LogString msg(ex.what());
-							msg += " processing\n";
-							msg += line;
+							LogString msg;
+							helpers::Transcoder::decode(ex.what(), msg);
+							msg += LOG4CXX_STR(" processing\n");
+							helpers::Transcoder::decode(line, msg);
 							helpers::LogLog::warn(msg);
 						}
 					 }

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -29,6 +29,7 @@
 #include <filesystem>
 #include <fstream>
 #include <apr_thread_proc.h>
+#include <thread>
 
 using namespace LOG4CXX_NS;
 
@@ -150,6 +151,9 @@ public:
 	void test3()
 	{
 		auto logger = getLogger("Test3");
+		LOG4CXX_INFO( logger, "Startup ");
+		using namespace std::chrono_literals;
+		std::this_thread::sleep_for(30ms);
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 30;
 		size_t approxBytesPerLogFile = 1000;

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -186,6 +186,7 @@ public:
 		// Check all messages are saved to files
 		LogString expectedSuffix = LOG4CXX_STR(".log");
 		std::vector<int> messageCount;
+		std::map<int, int> perThreadMessageCount;
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
 		{
 			LogString filename(dir_entry.path().filename().string());
@@ -204,6 +205,12 @@ public:
 							messageCount.resize(msgNumber + 1);
 						++messageCount[msgNumber];
 					 }
+					 pos = line.find("[0x");
+					 if (line.npos != pos && pos + 4 < line.size())
+					 {
+						auto threadNumber = std::stoi(line.substr(pos + 4), 0, 16);
+						++perThreadMessageCount[threadNumber];
+					 }
 				}
 			}
 		}
@@ -214,6 +221,16 @@ public:
 			{
 				msg += logchar(' ');
 				helpers::StringHelper::toString(item, p, msg);
+			}
+			helpers::LogLog::debug(msg);
+		}
+		if (helpers::LogLog::isDebugEnabled())
+		{
+			LogString msg(LOG4CXX_STR("perThreadMessageCount "));
+			for (auto item : perThreadMessageCount)
+			{
+				msg += logchar(' ');
+				helpers::StringHelper::toString(item.second, p, msg);
 			}
 			helpers::LogLog::debug(msg);
 		}

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -107,7 +107,7 @@ public:
 	 */
 	void test2()
 	{
-		std::string expectedPrefix = LOG4CXX_STR("multiprocess-dated-");
+		std::string expectedPrefix = LOG4CXX_STR("multiprocess-2-");
 		// remove any previously generated files
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
 		{
@@ -151,9 +151,6 @@ public:
 	void test3()
 	{
 		auto logger = getLogger("Test3");
-		//LOG4CXX_INFO( logger, "Startup ");
-		using namespace std::chrono_literals;
-		std::this_thread::sleep_for(100ms);
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 30;
 		size_t approxBytesPerLogFile = 1000;
@@ -174,7 +171,7 @@ public:
 	 */
 	void test4()
 	{
-		std::string expectedPrefix("multiprocess-dated");
+		std::string expectedPrefix("multiprocess-3");
 		// remove any previously generated files
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
 		{

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -151,9 +151,9 @@ public:
 	void test3()
 	{
 		auto logger = getLogger("Test3");
-		LOG4CXX_INFO( logger, "Startup ");
+		//LOG4CXX_INFO( logger, "Startup ");
 		using namespace std::chrono_literals;
-		std::this_thread::sleep_for(30ms);
+		std::this_thread::sleep_for(100ms);
 		auto approxBytesPerLogEvent = 40 + 23;
 		auto requiredLogFileCount = 30;
 		size_t approxBytesPerLogFile = 1000;

--- a/src/test/resources/input/rolling/multiprocess.xml
+++ b/src/test/resources/input/rolling/multiprocess.xml
@@ -50,6 +50,20 @@
     </layout>
   </appender>
 
+  <appender name="DATED-UNCOMPRESSED" class="org.apache.log4j.rolling.MultiprocessRollingFileAppender">
+    <param name="file" value="output/rolling/multiprocess-dated.log"/>
+    <param name="append" value="false"/>
+    <rollingPolicy class="org.apache.log4j.rolling.TimeBasedRollingPolicy">
+      <param name="FileNamePattern" value="output/rolling/multiprocess-dated-%d{yyyy-MM-dd-HH-mm-ss-SSS}.log"/>
+    </rollingPolicy>
+    <triggeringPolicy class="org.apache.log4j.rolling.SizeBasedTriggeringPolicy">
+      <param name="MaxFileSize" value="1KB"/>
+    </triggeringPolicy>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] %c %-5p - %m%n"/>
+    </layout>
+  </appender>
+
   <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
     <layout class="org.apache.log4j.PatternLayout">
       <param name="ConversionPattern" value="%m%n"/>
@@ -63,6 +77,11 @@
 
   <logger name="Test2" additivity="false">
     <appender-ref ref="DATED"/>
+    <level value="info"/>
+  </logger>
+
+  <logger name="Test3" additivity="false">
+    <appender-ref ref="DATED-UNCOMPRESSED"/>
     <level value="info"/>
   </logger>
 

--- a/src/test/resources/input/rolling/multiprocess.xml
+++ b/src/test/resources/input/rolling/multiprocess.xml
@@ -37,10 +37,10 @@
   </appender>
 
   <appender name="DATED" class="org.apache.log4j.rolling.MultiprocessRollingFileAppender">
-    <param name="file" value="output/rolling/multiprocess-dated.log"/>
+    <param name="file" value="output/rolling/multiprocess-2.log"/>
     <param name="append" value="false"/>
     <rollingPolicy class="org.apache.log4j.rolling.TimeBasedRollingPolicy">
-      <param name="FileNamePattern" value="output/rolling/multiprocess-dated-%d{yyyy-MM-dd-HH-mm-ss-SSS}.log.gz"/>
+      <param name="FileNamePattern" value="output/rolling/multiprocess-2-%d{yyyy-MM-dd-HH-mm-ss-SSS}.log.gz"/>
     </rollingPolicy>
     <triggeringPolicy class="org.apache.log4j.rolling.SizeBasedTriggeringPolicy">
       <param name="MaxFileSize" value="1KB"/>
@@ -51,10 +51,10 @@
   </appender>
 
   <appender name="DATED-UNCOMPRESSED" class="org.apache.log4j.rolling.MultiprocessRollingFileAppender">
-    <param name="file" value="output/rolling/multiprocess-dated.log"/>
+    <param name="file" value="output/rolling/multiprocess-3.log"/>
     <param name="append" value="true"/>
     <rollingPolicy class="org.apache.log4j.rolling.TimeBasedRollingPolicy">
-      <param name="FileNamePattern" value="output/rolling/multiprocess-dated-%d{yyyy-MM-dd-HH-mm-ss-SSS}.log"/>
+      <param name="FileNamePattern" value="output/rolling/multiprocess-3-%d{yyyy-MM-dd-HH-mm-ss-SSS}.log"/>
     </rollingPolicy>
     <triggeringPolicy class="org.apache.log4j.rolling.SizeBasedTriggeringPolicy">
       <param name="MaxFileSize" value="1KB"/>

--- a/src/test/resources/input/rolling/multiprocess.xml
+++ b/src/test/resources/input/rolling/multiprocess.xml
@@ -60,7 +60,7 @@
       <param name="MaxFileSize" value="1KB"/>
     </triggeringPolicy>
     <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] %c %-5p - %m%n"/>
+      <param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c %-5p - %m%n"/>
     </layout>
   </appender>
 

--- a/src/test/resources/input/rolling/multiprocess.xml
+++ b/src/test/resources/input/rolling/multiprocess.xml
@@ -52,7 +52,7 @@
 
   <appender name="DATED-UNCOMPRESSED" class="org.apache.log4j.rolling.MultiprocessRollingFileAppender">
     <param name="file" value="output/rolling/multiprocess-dated.log"/>
-    <param name="append" value="false"/>
+    <param name="append" value="true"/>
     <rollingPolicy class="org.apache.log4j.rolling.TimeBasedRollingPolicy">
       <param name="FileNamePattern" value="output/rolling/multiprocess-dated-%d{yyyy-MM-dd-HH-mm-ss-SSS}.log"/>
     </rollingPolicy>


### PR DESCRIPTION
This PR adds an (initially failing) test of MultiprocessRollingFileAppender that ensure messages are not lost