### PR TITLE
Reduce MultiprocessRollingFileAppender overhead

### DIFF
--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -158,8 +158,10 @@ void MultiprocessRollingFileAppender::activateOptions(Pool& p)
 bool MultiprocessRollingFileAppender::isRolloverCheckNeeded()
 {
 	bool result = true;
+#ifdef WIN32 // apr_stat is slow on Windows
 	if (auto pTimeBased = LOG4CXX_NS::cast<TimeBasedRollingPolicy>(_priv->rollingPolicy))
 		result = !pTimeBased->isLastFileNameUnchanged();
+#endif
 	return result;
 }
 

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -398,7 +398,7 @@ WriterPtr MultiprocessRollingFileAppender::createWriter(OutputStreamPtr& os)
 		msg += LOG4CXX_STR(" - Rollover synchronization will be degraded.");
 		_priv->errorHandler->error(msg);
 	}
-	return FileAppender::createWriter(os);
+	return RollingFileAppender::createWriter(os);
 }
 
 

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -530,3 +530,23 @@ void TimeBasedRollingPolicy::setOption(const LogString& option,
 		RollingPolicyBase::setOption(option, value);
 	}
 }
+
+/**
+ * Was the name in shared memory set by this process?
+ */
+bool TimeBasedRollingPolicy::isLastFileNameUnchanged()
+{
+	bool result = true;
+	if( m_priv->multiprocess ){
+#if LOG4CXX_HAS_MULTIPROCESS_ROLLING_FILE_APPENDER
+		if (m_priv->_mmap)
+		{
+			lockMMapFile(APR_FLOCK_SHARED);
+			LogString mapCurrent((char*)m_priv->_mmap->mm);
+			unLockMMapFile();
+			result = (mapCurrent == m_priv->lastFileName);
+		}
+#endif
+	}
+	return result;
+}

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -29,7 +29,11 @@ namespace rolling
 
 
 /**
- * A special version of the RollingFileAppender that acts properly with multiple processes
+ * A special version of the RollingFileAppender that acts properly with multiple processes.
+ *
+ * Coordinating with other processes adds significant overhead compared to RollingFileAppender.
+ * Benchmarks show the overhead of this appender is more than 4 and 10 times
+ * the overhead of RollingFileAppender on Linux and Windows respectively.
  *
  * Note: Do *not* set the option <code>Append</code> to <code>false</code>.
  * Rolling over files is only relevant when you are appending.

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -103,11 +103,22 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		void setFileLength(size_t length);
 
 		/**
+		 * Is it possible the current log file was renamed?
+		 */
+		bool isRolloverCheckNeeded();
+
+		/**
 		 *  Was \c fileName renamed?
 		 *  @param pSize if not NULL, receives the log file size
 		 * @return true if the log file must be reopened
 		 */
 		bool isAlreadyRolled(const LogString& fileName, size_t* pSize = 0);
+
+		/**
+		 * Put the current size of the log file into \c pSize.
+		 * @return true if the log file size was put into \c pSize
+		 */
+		bool getCurrentFileSize(size_t* pSize);
 
 		/**
 		 * re-open \c fileName (used after it has been renamed)

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -112,10 +112,7 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		/**
 		 * re-open \c fileName (used after it has been renamed)
 		 */
-		void reopenFile(const LogString& fileName, size_t fileLength);
-
-		friend class MultiprocessOutputStream;
-
+		void reopenFile(const LogString& fileName);
 };
 
 LOG4CXX_PTR_DEF(MultiprocessRollingFileAppender);

--- a/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
+++ b/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
@@ -209,6 +209,11 @@ class LOG4CXX_EXPORT TimeBasedRollingPolicy : public virtual RollingPolicyBase,
 		 */
 		void setOption(const LogString& option, const LogString& value) override;
 
+		/**
+		 * Was the name in shared memory set by this process?
+		 */
+		bool isLastFileNameUnchanged();
+
 	protected:
 		/**
 		 * A map from "d" and "date" to a date conversion formatter.

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -173,7 +173,10 @@ public:
 	{
 		std::string expectedPrefix("multiprocess-3");
 		// remove any previously generated files
-		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
+		std::filesystem::path outputDir("output/rolling");
+		if (!exists(outputDir))
+			;
+		else for (auto const& dir_entry : std::filesystem::directory_iterator{outputDir})
 		{
 			std::string filename(dir_entry.path().filename().string());
 			if (expectedPrefix.size() < filename.size() &&
@@ -207,6 +210,7 @@ public:
 				&& filename.substr(0, expectedPrefix.size()) == expectedPrefix
 				&& filename.substr(filename.size() - expectedSuffix.size()) == expectedSuffix)
 			{
+				auto initialPerThreadMessageCount = perThreadMessageCount;
 				std::ifstream input(dir_entry.path());
 				for (std::string line; std::getline(input, line);)
 				{
@@ -246,6 +250,18 @@ public:
 							helpers::LogLog::warn(msg);
 						}
 					 }
+				}
+				if (helpers::LogLog::isDebugEnabled())
+				{
+					LogString msg;
+					helpers::Transcoder::decode(dir_entry.path().filename().string(), msg);
+					msg += LOG4CXX_STR(": perThreadMessageCount ");
+					for (auto item : perThreadMessageCount)
+					{
+						msg += logchar(' ');
+						helpers::StringHelper::toString(item.second - initialPerThreadMessageCount[item.first], p, msg);
+					}
+					helpers::LogLog::debug(msg);
 				}
 			}
 		}


### PR DESCRIPTION
The benchmark on Ubuntu 22.04 gcc 11.4 are

 | Benchmark | Time | CPU | Iterations | 
 | ------------ | ------ | ---- | --------- |  
 | Testing disabled logging request | 0.474 ns | 0.474 ns |  1000000000 | 
 | Testing disabled logging request/threads:6 | 0.139 ns | 0.835 ns  |  819039978 | 
 | Appending 5 char string using MessageBuffer, pattern: %m%n | 342 ns | 342 ns | 2045248 | 
 | Appending 5 char string using MessageBuffer, pattern: %m%n/threads:6 | 418 ns | 2350 ns | 293568 | 
 | Appending 49 char string using MessageBuffer, pattern: %m%n | 387 ns | 387 ns | 1803925 | 
 | Appending 49 char string using MessageBuffer, pattern: %m%n/threads:6 | 496 ns | 2717 ns | 229734 | 
 | Appending int value using MessageBuffer, pattern: %m%n | 530 ns | 530 ns | 1340650 | 
 | Appending int value using MessageBuffer, pattern: %m%n/threads:6 | 504 ns | 2809 ns | 250008 | 
 | Appending int+float using MessageBuffer, pattern: %m%n | 1041 ns | 1041 ns | 669224 | 
 | Appending int+float using MessageBuffer, pattern: %m%n/threads:6 | 625 ns | 3597 ns | 190068 | 
 | Appending int value using MessageBuffer, pattern: [%d] %m%n | 569 ns | 569 ns | 1229368 | 
 | Appending int value using MessageBuffer, pattern: [%d] [%c] [%p] %m%n | 629 ns | 629 ns | 1117287 | 
 | Appending 49 char string using FMT, pattern: %m%n | 358 ns | 358 ns | 1941068 | 
 | Appending 49 char string using FMT, pattern: %m%n/threads:6 | 481 ns | 2638 ns | 265746 | 
 | Appending int value using FMT, pattern: %m%n | 407 ns | 407 ns | 1760876 | 
 | Appending int value using FMT, pattern: %m%n/threads:6 | 482 ns | 2669 ns | 256482 | 
 | Appending int+float using FMT, pattern: %m%n | 536 ns | 536 ns | 1320202 | 
 | Appending int+float using FMT, pattern: %m%n/threads:6 | 509 ns | 2883 ns | 236166 | 
 | Async, Sending int+float using MessageBuffer | 1221 ns | 1221 ns | 573362 | 
 | Async, Sending int+float using MessageBuffer/threads:6 | 579 ns | 3458 ns | 202482 | 
 | Logging int+float using MessageBuffer, pattern: %d %m%n | 1203 ns | 1203 ns | 584099 | 
 | Logging int+float using MessageBuffer, pattern: %d %m%n/threads:6 | 982 ns | 4584 ns | 150492 | 
 | Multiprocess logging int+float using MessageBuffer, pattern: %d %m%n | 3496 ns | 3496 ns | 198909 | 