### PR TITLE
Log elapsed time for multiprocessrollingappender unit test

### DIFF
--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -550,3 +550,22 @@ bool TimeBasedRollingPolicy::isLastFileNameUnchanged()
 	}
 	return result;
 }
+
+/**
+ * Load the name (set by some other process) from shared memory
+ */
+void TimeBasedRollingPolicy::loadLastFileName()
+{
+	if( m_priv->multiprocess ){
+#if LOG4CXX_HAS_MULTIPROCESS_ROLLING_FILE_APPENDER
+		if (m_priv->_mmap)
+		{
+			lockMMapFile(APR_FLOCK_SHARED);
+			LogString mapLastFile((char*)m_priv->_mmap->mm);
+			unLockMMapFile();
+			if (!mapLastFile.empty())
+				m_priv->lastFileName = mapLastFile;
+		}
+#endif
+	}
+}

--- a/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
+++ b/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
@@ -214,6 +214,11 @@ class LOG4CXX_EXPORT TimeBasedRollingPolicy : public virtual RollingPolicyBase,
 		 */
 		bool isLastFileNameUnchanged();
 
+		/**
+		 * Load the name (set by some other process) from shared memory
+		 */
+		void loadLastFileName();
+
 	protected:
 		/**
 		 * A map from "d" and "date" to a date conversion formatter.


### PR DESCRIPTION
The timing (on Windows) from the unit test (5 processes) indicates checking shared memory is (approximately) 4% faster than using apr_stat()