### PR TITLE
Periodically flush buffered file output

### DIFF
--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -96,7 +96,6 @@ APRInitializer::APRInitializer() :
 
 APRInitializer::~APRInitializer()
 {
-	stopWatchDogs();
 	isDestructed = true;
 #if APR_HAS_THREADS
 	std::lock_guard<std::mutex> lock(m_priv->mutex);

--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -104,7 +104,7 @@ APRInitializer::APRInitializer() :
 
 APRInitializer::~APRInitializer()
 {
-	deleteWatchDogs();
+	stopWatchDogs();
 	isDestructed = true;
 #if APR_HAS_THREADS
 	std::lock_guard<std::mutex> lock(m_priv->mutex);
@@ -112,12 +112,13 @@ APRInitializer::~APRInitializer()
 #endif
 }
 
-void APRInitializer::deleteWatchDogs()
+void APRInitializer::stopWatchDogs()
 {
 	std::lock_guard<std::mutex> lock(m_priv->mutex);
 
 	while (!m_priv->watchdogs.empty())
 	{
+		m_priv->watchdogs.back()->stop();
 		delete m_priv->watchdogs.back();
 		m_priv->watchdogs.pop_back();
 	}
@@ -126,7 +127,7 @@ void APRInitializer::deleteWatchDogs()
 void APRInitializer::unregisterAll()
 {
 	FileWatchdog::stopAll();
-	getInstance().deleteWatchDogs();
+	getInstance().stopWatchDogs();
 }
 
 APRInitializer& APRInitializer::getInstance()

--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -96,6 +96,7 @@ APRInitializer::APRInitializer() :
 
 APRInitializer::~APRInitializer()
 {
+	deleteWatchDogs();
 	isDestructed = true;
 #if APR_HAS_THREADS
 	std::lock_guard<std::mutex> lock(m_priv->mutex);

--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -126,7 +126,6 @@ void APRInitializer::stopWatchDogs()
 
 void APRInitializer::unregisterAll()
 {
-	FileWatchdog::stopAll();
 	getInstance().stopWatchDogs();
 }
 

--- a/src/main/cpp/aprinitializer.cpp
+++ b/src/main/cpp/aprinitializer.cpp
@@ -103,13 +103,12 @@ APRInitializer::~APRInitializer()
 #endif
 }
 
-void APRInitializer::stopWatchDogs()
+void APRInitializer::deleteWatchDogs()
 {
 	std::lock_guard<std::mutex> lock(m_priv->mutex);
 
 	while (!m_priv->watchdogs.empty())
 	{
-		m_priv->watchdogs.back()->stop();
 		delete m_priv->watchdogs.back();
 		m_priv->watchdogs.pop_back();
 	}
@@ -117,7 +116,8 @@ void APRInitializer::stopWatchDogs()
 
 void APRInitializer::unregisterAll()
 {
-	getInstance().stopWatchDogs();
+	FileWatchdog::stopAll();
+	getInstance().deleteWatchDogs();
 }
 
 APRInitializer& APRInitializer::getInstance()

--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -395,9 +395,19 @@ int FileAppender::getBufferSize() const
 	return _priv->bufferSize;
 }
 
-void FileAppender::setBufferSize(int bufferSize1)
+int FileAppender::getBufferedSeconds() const
 {
-	_priv->bufferSize = bufferSize1;
+	return _priv->bufferedSeconds;
+}
+
+void FileAppender::setBufferSize(int newValue)
+{
+	_priv->bufferSize = newValue;
+}
+
+void FileAppender::setBufferedSeconds(int newValue)
+{
+	_priv->bufferedSeconds = newValue;
 }
 
 bool FileAppender::getAppend() const

--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -206,7 +206,8 @@ void FileAppender::activateOptionsInternal(Pool& p)
 		}
 		else if (0 == _priv->bufferedSeconds)
 		{
-			ThreadUtility::instance()->removePeriodicTask(getName());
+			if (auto p = _priv->taskManager.lock())
+				p->value()->removePeriodicTask(getName());
 		}
 	}
 }

--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -207,7 +207,7 @@ void FileAppender::activateOptionsInternal(Pool& p)
 		else if (0 == _priv->bufferedSeconds)
 		{
 			if (auto p = _priv->taskManager.lock())
-				p->value()->removePeriodicTask(getName());
+				p->value().removePeriodicTask(getName());
 		}
 	}
 }

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -35,7 +35,8 @@ long FileWatchdog::DEFAULT_DELAY = 60000;
 struct FileWatchdog::FileWatchdogPrivate{
 	FileWatchdogPrivate(const File& file1) :
 		file(file1), delay(DEFAULT_DELAY), lastModif(0),
-		warnedAlready(false)
+		warnedAlready(false),
+		taskName{LOG4CXX_STR("WatchDog_") + file1.getName()}
 	{ }
 
 
@@ -57,7 +58,7 @@ struct FileWatchdog::FileWatchdogPrivate{
 	std::condition_variable interrupt;
 	std::mutex interrupt_mutex;
 #endif
-	LogString taskName{LOG4CXX_STR("FileWatchdog")};
+	LogString taskName;
 };
 
 FileWatchdog::FileWatchdog(const File& file1)
@@ -67,7 +68,6 @@ FileWatchdog::FileWatchdog(const File& file1)
 
 FileWatchdog::~FileWatchdog()
 {
-	stop();
 }
 
 
@@ -83,6 +83,14 @@ void FileWatchdog::stop()
 		LogLog::debug(LOG4CXX_STR("Stopping file watchdog"));
 		ThreadUtility::instance()->removePeriodicTask(m_priv->taskName);
 	}
+}
+
+/**
+Stop all tasks that periodically checks for a file change.
+*/
+void FileWatchdog::stopAll()
+{
+	ThreadUtility::instance()->removePeriodicTasksMatching(LOG4CXX_STR("WatchDog_"));
 }
 
 const File& FileWatchdog::file()

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -138,7 +138,7 @@ void FileWatchdog::start()
 {
 	checkAndConfigure();
 	auto taskManager = ThreadUtility::instancePtr();
-	if (taskManager->value().hasPeriodicTask(m_priv->taskName))
+	if (!taskManager->value().hasPeriodicTask(m_priv->taskName))
 	{
 		if (LogLog::isDebugEnabled())
 		{

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -78,11 +78,7 @@ bool FileWatchdog::is_active()
 
 void FileWatchdog::stop()
 {
-	if (is_active())
-	{
-		LogLog::debug(LOG4CXX_STR("Stopping file watchdog"));
-		ThreadUtility::instance()->removePeriodicTask(m_priv->taskName);
-	}
+	ThreadUtility::instance()->removePeriodicTask(m_priv->taskName);
 }
 
 /**
@@ -134,8 +130,8 @@ void FileWatchdog::checkAndConfigure()
 
 void FileWatchdog::start()
 {
-	checkAndConfigure();
 	auto p = ThreadUtility::instance();
+	checkAndConfigure();
 	if (!p->hasPeriodicTask(m_priv->taskName))
 	{
 		if (LogLog::isDebugEnabled())

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -24,6 +24,8 @@
 #include <log4cxx/helpers/stringhelper.h>
 #include <functional>
 #include <chrono>
+#include <thread>
+#include <condition_variable>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -136,8 +136,8 @@ void FileWatchdog::checkAndConfigure()
 
 void FileWatchdog::start()
 {
-	checkAndConfigure();
 	auto taskManager = ThreadUtility::instancePtr();
+	checkAndConfigure();
 	if (!taskManager->value().hasPeriodicTask(m_priv->taskName))
 	{
 		if (LogLog::isDebugEnabled())

--- a/src/main/cpp/logmanager.cpp
+++ b/src/main/cpp/logmanager.cpp
@@ -27,6 +27,7 @@
 #include <log4cxx/helpers/exception.h>
 #include <log4cxx/helpers/optionconverter.h>
 #include <log4cxx/helpers/loglog.h>
+#include <log4cxx/helpers/threadutility.h>
 
 #include <log4cxx/spi/loggingevent.h>
 #include <log4cxx/file.h>
@@ -203,6 +204,7 @@ LoggerList LogManager::getCurrentLoggers()
 void LogManager::shutdown()
 {
 	APRInitializer::unregisterAll();
+	ThreadUtility::instance()->removeAllPeriodicTasks();
 	getLoggerRepository()->shutdown();
 }
 

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -354,7 +354,7 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 			for (auto& item : this->jobs)
 			{
 				if (this->terminated)
-					break;
+					return;
 				if (item.nextRun <= currentTime)
 				{
 					try

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -37,6 +37,10 @@
 #if LOG4CXX_EVENTS_AT_EXIT
 #include <log4cxx/private/atexitregistry.h>
 #endif
+#if !defined(LOG4CXX)
+	#define LOG4CXX 1
+#endif
+#include <log4cxx/helpers/aprinitializer.h>
 
 namespace LOG4CXX_NS
 {
@@ -117,8 +121,12 @@ ThreadUtility::~ThreadUtility() {}
 
 ThreadUtility* ThreadUtility::instance()
 {
-	static WideLife<ThreadUtility> instance;
-	return &instance.value();
+	using ThreadUtilityHolder = SingletonHolder<ThreadUtility>;
+	auto result = APRInitializer::getOrAddUnique<ThreadUtilityHolder>
+		( []() -> ObjectPtr
+			{ return std::make_shared<ThreadUtilityHolder>(); }
+		);
+	return &result->value();
 }
 
 void ThreadUtility::configure( ThreadConfigurationType type )

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -119,14 +119,18 @@ ThreadUtility::ThreadUtility()
 
 ThreadUtility::~ThreadUtility() {}
 
+auto ThreadUtility::instancePtr() -> ManagerPtr
+{
+	auto result = APRInitializer::getOrAddUnique<Manager>
+		( []() -> ObjectPtr
+			{ return std::make_shared<Manager>(); }
+		);
+	return result;
+}
+
 ThreadUtility* ThreadUtility::instance()
 {
-	using ThreadUtilityHolder = SingletonHolder<ThreadUtility>;
-	auto result = APRInitializer::getOrAddUnique<ThreadUtilityHolder>
-		( []() -> ObjectPtr
-			{ return std::make_shared<ThreadUtilityHolder>(); }
-		);
-	return &result->value();
+	return &instancePtr()->value();
 }
 
 void ThreadUtility::configure( ThreadConfigurationType type )

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -25,6 +25,7 @@
 
 #include <signal.h>
 #include <mutex>
+#include <list>
 
 #ifdef _WIN32
 	#include <windows.h>
@@ -304,8 +305,6 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 					break;
 				if (item.nextRun <= currentTime)
 				{
-					if (LogLog::isDebugEnabled())
-						LogLog::debug(LOG4CXX_STR("running ") + item.name);
 					try
 					{
 						item.f();

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -270,7 +270,10 @@ void ThreadUtility::addPeriodicTask(const LogString& name, std::function<void()>
 	auto currentTime = std::chrono::system_clock::now();
 	m_priv->jobs.push_back( priv_data::NamedPeriodicFunction{name, delay, currentTime + delay, 0, f} );
 	if (!m_priv->thread.joinable())
+	{
+		m_priv->terminated = false;
 		m_priv->thread = createThread(LOG4CXX_STR("log4cxx"), std::bind(&priv_data::doPeriodicTasks, m_priv.get()));
+	}
 	else
 		m_priv->interrupt.notify_one();
 }

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -79,8 +79,8 @@ struct ThreadUtility::priv_data
 	std::condition_variable   interrupt;
 	std::mutex                interrupt_mutex;
 	bool                      terminated{false};
-	int                       retryCount{2};
-	Period                    maxDelay;
+	int                       retryCount{ 2 };
+	Period                    maxDelay{ 0 };
 
 	void doPeriodicTasks();
 

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -345,12 +345,12 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 {
 	while (!this->terminated)
 	{
-		if (this->jobs.empty())
-			break;
 		auto currentTime = std::chrono::system_clock::now();
 		TimePoint nextOperationTime = currentTime + this->maxDelay;
 		{
 			std::lock_guard<std::mutex> lock(this->job_mutex);
+			if (this->jobs.empty())
+				break;
 			for (auto& item : this->jobs)
 			{
 				if (this->terminated)

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -26,6 +26,7 @@
 #include <signal.h>
 #include <mutex>
 #include <list>
+#include <condition_variable>
 
 #ifdef _WIN32
 	#include <windows.h>
@@ -253,8 +254,8 @@ void ThreadUtility::addPeriodicTask(const LogString& name, std::function<void()>
 	std::lock_guard<std::mutex> lock(m_priv->job_mutex);
 	if (m_priv->maxDelay < delay)
 		m_priv->maxDelay = delay;
-	priv_data::TimePoint currentTime = std::chrono::system_clock::now();
-	m_priv->jobs.emplace_back(name, delay, currentTime + delay, 0, f);
+	auto currentTime = std::chrono::system_clock::now();
+	m_priv->jobs.push_back( priv_data::NamedPeriodicFunction{name, delay, currentTime + delay, 0, f} );
 	if (!m_priv->thread.joinable())
 		m_priv->thread = createThread(LOG4CXX_STR("log4cxx"), std::bind(&priv_data::doPeriodicTasks, m_priv.get()));
 	else

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <list>
 #include <condition_variable>
+#include <algorithm>
 
 #ifdef _WIN32
 	#include <windows.h>

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -56,8 +56,10 @@ struct ThreadUtility::priv_data
 	{
 	}
 
+#ifdef MSYS_UCRT_DOES_NOT_HANG_HERE
 	~priv_data()
 	{ stopThread(); }
+#endif
 
 	ThreadStartPre  start_pre{nullptr};
 	ThreadStarted   started{nullptr};

--- a/src/main/include/log4cxx/fileappender.h
+++ b/src/main/include/log4cxx/fileappender.h
@@ -130,6 +130,7 @@ class LOG4CXX_EXPORT FileAppender : public WriterAppender
 		FileName | {any} | -
 		Append | True,False | True
 		BufferedIO | True,False | False
+		BufferedSeconds | {any} | 5
 		ImmediateFlush | True,False | False
 		BufferSize | (\ref fileSz1 "1") | 8 KB
 

--- a/src/main/include/log4cxx/fileappender.h
+++ b/src/main/include/log4cxx/fileappender.h
@@ -34,9 +34,12 @@ class Pool;
 /**
 *  FileAppender appends log events to a file.
 *
-*  <p>Support for <code>java.io.Writer</code> and console appending
-*  has been deprecated and then removed. See the replacement
-*  solutions: WriterAppender and ConsoleAppender.
+*  Uses a background thread to periodically flush the output buffer
+*  when <code>BufferedIO</code> option is set <code>true</code>.
+*  Use the <code>BufferedSeconds</code> option to control the frequency,
+*  using <code>0</code> to disable the background output buffer flush.
+*  Refer to FileAppender::setOption() for more information.
+*
 */
 class LOG4CXX_EXPORT FileAppender : public WriterAppender
 {
@@ -158,32 +161,54 @@ class LOG4CXX_EXPORT FileAppender : public WriterAppender
 		int getBufferSize() const;
 
 		/**
+		Get the number of seconds between file writes
+		when the <code>BufferedIO</code> option is <code>true</code>.
+		*/
+		int getBufferedSeconds() const;
+
+		/**
+		Set file open mode to \c newValue.
+
 		The <b>Append</b> option takes a boolean value. It is set to
 		<code>true</code> by default. If true, then <code>File</code>
 		will be opened in append mode by #setFile (see
 		above). Otherwise, setFile will open
 		<code>File</code> in truncate mode.
 
-		<p>Note: Actual opening of the file is made when
+		<p>Note: The file is opened when
 		#activateOptions is called, not when the options are set.
 		*/
-		void setAppend(bool fileAppend1);
+		void setAppend(bool newValue);
 
 		/**
-		The <b>BufferedIO</b> option takes a boolean value. It is set to
-		<code>false</code> by default. If true, then <code>File</code>
-		will be opened in buffered mode.
+		Set buffered output behavior to \c newValue.
 
-		BufferedIO will significantly increase performance on heavily
-		loaded systems.
+		By default buffered output is disabled and
+		this appender writes each log message directly to the file.
+		When buffered output is enabled,
+		log messages are stored into a memory buffer
+		and written to the file periodically or when the buffer is full.
 
+		Using buffered output will significantly reduce logging overhead.
+
+		Note: Behavior change occurs when
+		#activateOptions is called, not when the options are set.
 		*/
-		void setBufferedIO(bool bufferedIO);
+		void setBufferedIO(bool newValue);
 
 		/**
-		Set the size of the IO buffer.
+		Use \c newValue as the size of the output buffer.
 		*/
-		void setBufferSize(int bufferSize1);
+		void setBufferSize(int newValue);
+
+		/**
+		Flush the output buffer every \c newValue seconds.
+		The default period is 5 seconds.
+
+		Note: #activateOptions must be called after an option is changed
+		to activate the new frequency.
+		*/
+		void setBufferedSeconds(int newValue);
 
 		/**
 		 *   Replaces double backslashes with single backslashes

--- a/src/main/include/log4cxx/helpers/aprinitializer.h
+++ b/src/main/include/log4cxx/helpers/aprinitializer.h
@@ -84,7 +84,7 @@ class APRInitializer
 	private: // Modifiers
 		void addObject(size_t key, const ObjectPtr& pObject);
 		const ObjectPtr& findOrAddObject(size_t key, std::function<ObjectPtr()> creator);
-		void stopWatchDogs();
+		void deleteWatchDogs();
 	private: // Attributes
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(APRInitializerPrivate, m_priv)
 	private: // Class methods

--- a/src/main/include/log4cxx/helpers/aprinitializer.h
+++ b/src/main/include/log4cxx/helpers/aprinitializer.h
@@ -84,7 +84,7 @@ class APRInitializer
 	private: // Modifiers
 		void addObject(size_t key, const ObjectPtr& pObject);
 		const ObjectPtr& findOrAddObject(size_t key, std::function<ObjectPtr()> creator);
-		void deleteWatchDogs();
+		void stopWatchDogs();
 	private: // Attributes
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(APRInitializerPrivate, m_priv)
 	private: // Class methods

--- a/src/main/include/log4cxx/helpers/filewatchdog.h
+++ b/src/main/include/log4cxx/helpers/filewatchdog.h
@@ -22,9 +22,6 @@
 #include <time.h>
 #include <log4cxx/helpers/pool.h>
 #include <log4cxx/file.h>
-#include <atomic>
-#include <thread>
-#include <condition_variable>
 
 namespace LOG4CXX_NS
 {

--- a/src/main/include/log4cxx/helpers/filewatchdog.h
+++ b/src/main/include/log4cxx/helpers/filewatchdog.h
@@ -72,9 +72,6 @@ class LOG4CXX_EXPORT FileWatchdog
 		bool is_active();
 
 	private:
-		void run();
-		bool is_interrupted();
-
 
 		FileWatchdog(const FileWatchdog&);
 		FileWatchdog& operator=(const FileWatchdog&);

--- a/src/main/include/log4cxx/helpers/filewatchdog.h
+++ b/src/main/include/log4cxx/helpers/filewatchdog.h
@@ -54,20 +54,24 @@ class LOG4CXX_EXPORT FileWatchdog
 		void setDelay(long delay);
 
 		/**
-		Create a thread that periodically checks for a file change after first calling doOnChange() on the current thread.
+		Create an asynchronous task that periodically checks for a file change after first calling doOnChange().
 		*/
 		void start();
 
 		/**
-		Stop the thread that periodically checks for a file change.
+		Stop the task that periodically checks for a file change.
 		*/
 		void stop();
 
 		/**
-		Is the thread that periodically checks for a file change running?
+		Is the task that periodically checks for a file change running?
 		*/
 		bool is_active();
 
+		/**
+		Stop all tasks that periodically check for a file change.
+		*/
+		static void stopAll();
 	private:
 
 		FileWatchdog(const FileWatchdog&);

--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LOG4CXX_SINGLETON_HOLDER_H
+#define LOG4CXX_SINGLETON_HOLDER_H
+
+#include <log4cxx/helpers/object.h>
+
+namespace LOG4CXX_NS
+{
+namespace helpers
+{
+
+/** Wraps any singleton object so it can be added to APRInitializer
+ */
+template <class T>
+class SingletonHolder : public Object
+{
+	using ThisType = SingletonHolder<T>;
+	T m_data;
+	struct Unused : public helpers::Class
+	{
+		LogString getName() const override { return LOG4CXX_STR("SingletonHolder"); }
+	};
+public: // Object method stubs
+	const helpers::Class& getClass() const override { static Unused notUsed; return notUsed; }
+	BEGIN_LOG4CXX_CAST_MAP()
+	LOG4CXX_CAST_ENTRY(ThisType)
+	END_LOG4CXX_CAST_MAP()
+
+public: // Accessors
+	T& value() { return m_data; }
+};
+
+} // namespace helpers
+} // namespace LOG4CXX_NS
+
+#endif //LOG4CXX_SINGLETON_HOLDER_H

--- a/src/main/include/log4cxx/helpers/threadutility.h
+++ b/src/main/include/log4cxx/helpers/threadutility.h
@@ -165,6 +165,11 @@ class LOG4CXX_EXPORT ThreadUtility
 		bool hasPeriodicTask(const LogString& taskName);
 
 		/**
+		 * Remove all periodic tasks and stop the processing thread
+		 */
+		void removeAllPeriodicTasks();
+
+		/**
 		 * Remove the \c taskName periodic task
 		 */
 		void removePeriodicTask(const LogString& taskName);

--- a/src/main/include/log4cxx/helpers/threadutility.h
+++ b/src/main/include/log4cxx/helpers/threadutility.h
@@ -21,6 +21,7 @@
 #include <thread>
 #include <functional>
 #include <memory>
+#include <chrono>
 
 #include "log4cxx/logstring.h"
 #include "widelife.h"
@@ -153,6 +154,23 @@ class LOG4CXX_EXPORT ThreadUtility
 
 			return t;
 		}
+
+		using Period = std::chrono::milliseconds;
+
+		/**
+		 * Add a periodic task
+		 */
+		void addPeriodicTask(const LogString& name, std::function<void()> f, const Period& delay);
+
+		/**
+		 * Has a \c taskName periodic task already been added?
+		 */
+		bool hasPeriodicTask(const LogString& name);
+
+		/**
+		 * Remove the \c taskName periodic task
+		 */
+		void removePeriodicTask(const LogString& name);
 };
 
 } /* namespace helpers */

--- a/src/main/include/log4cxx/helpers/threadutility.h
+++ b/src/main/include/log4cxx/helpers/threadutility.h
@@ -24,7 +24,7 @@
 #include <chrono>
 
 #include "log4cxx/logstring.h"
-#include "widelife.h"
+#include "singletonholder.h"
 
 namespace LOG4CXX_NS
 {
@@ -72,6 +72,7 @@ class LOG4CXX_EXPORT ThreadUtility
 {
 	private:
 		friend class LOG4CXX_NS::helpers::WideLife<ThreadUtility>;
+		friend class LOG4CXX_NS::helpers::SingletonHolder<ThreadUtility>;
 		ThreadUtility();
 
 		LOG4CXX_NS::helpers::ThreadStartPre preStartFunction();

--- a/src/main/include/log4cxx/helpers/threadutility.h
+++ b/src/main/include/log4cxx/helpers/threadutility.h
@@ -65,13 +65,10 @@ enum class ThreadConfigurationType
 	BlockSignalsAndNameThread,
 };
 
-class ThreadUtility;
-LOG4CXX_PTR_DEF(ThreadUtility);
-
 class LOG4CXX_EXPORT ThreadUtility
 {
 	private:
-		friend class LOG4CXX_NS::helpers::SingletonHolder<ThreadUtility>;
+		friend class SingletonHolder<ThreadUtility>;
 		ThreadUtility();
 
 		LOG4CXX_NS::helpers::ThreadStartPre preStartFunction();
@@ -176,6 +173,11 @@ class LOG4CXX_EXPORT ThreadUtility
 		 * Remove any periodic task matching \c namePrefix
 		 */
 		void removePeriodicTasksMatching(const LogString& namePrefix);
+
+		using Manager = SingletonHolder<ThreadUtility>;
+		LOG4CXX_PTR_DEF(Manager);
+
+		static ManagerPtr instancePtr();
 };
 
 } /* namespace helpers */

--- a/src/main/include/log4cxx/helpers/threadutility.h
+++ b/src/main/include/log4cxx/helpers/threadutility.h
@@ -159,19 +159,24 @@ class LOG4CXX_EXPORT ThreadUtility
 		using Period = std::chrono::milliseconds;
 
 		/**
-		 * Add a periodic task
+		 * Add the \c taskName periodic task
 		 */
-		void addPeriodicTask(const LogString& name, std::function<void()> f, const Period& delay);
+		void addPeriodicTask(const LogString& taskName, std::function<void()> f, const Period& delay);
 
 		/**
 		 * Has a \c taskName periodic task already been added?
 		 */
-		bool hasPeriodicTask(const LogString& name);
+		bool hasPeriodicTask(const LogString& taskName);
 
 		/**
 		 * Remove the \c taskName periodic task
 		 */
-		void removePeriodicTask(const LogString& name);
+		void removePeriodicTask(const LogString& taskName);
+
+		/**
+		 * Remove any periodic task matching \c namePrefix
+		 */
+		void removePeriodicTasksMatching(const LogString& namePrefix);
 };
 
 } /* namespace helpers */

--- a/src/main/include/log4cxx/helpers/threadutility.h
+++ b/src/main/include/log4cxx/helpers/threadutility.h
@@ -71,7 +71,6 @@ LOG4CXX_PTR_DEF(ThreadUtility);
 class LOG4CXX_EXPORT ThreadUtility
 {
 	private:
-		friend class LOG4CXX_NS::helpers::WideLife<ThreadUtility>;
 		friend class LOG4CXX_NS::helpers::SingletonHolder<ThreadUtility>;
 		ThreadUtility();
 

--- a/src/main/include/log4cxx/private/fileappender_priv.h
+++ b/src/main/include/log4cxx/private/fileappender_priv.h
@@ -60,6 +60,12 @@ struct FileAppender::FileAppenderPriv : public WriterAppender::WriterAppenderPri
 	/**
 	How big should the IO buffer be? Default is 8K. */
 	int bufferSize;
+
+	/**
+	The number of seconds between each asynchronous output buffer flush.
+	Only active when <code>bufferedIO == true</code>.
+	*/
+	int bufferedSeconds{ 5 };
 };
 
 }

--- a/src/main/include/log4cxx/private/fileappender_priv.h
+++ b/src/main/include/log4cxx/private/fileappender_priv.h
@@ -20,6 +20,7 @@
 
 #include <log4cxx/private/writerappender_priv.h>
 #include <log4cxx/fileappender.h>
+#include <log4cxx/helpers/threadutility.h>
 
 namespace LOG4CXX_NS
 {
@@ -63,9 +64,15 @@ struct FileAppender::FileAppenderPriv : public WriterAppender::WriterAppenderPri
 
 	/**
 	The number of seconds between each asynchronous output buffer flush.
-	Only active when <code>bufferedIO == true</code>.
+	Only used when <code>bufferedIO == true</code>.
 	*/
 	int bufferedSeconds{ 5 };
+
+	/**
+	Manages asynchronous output buffer flush.
+	Only used when <code>bufferedIO == true</code>.
+	*/
+	helpers::ThreadUtility::ManagerWeakPtr taskManager;
 };
 
 }

--- a/src/main/include/log4cxx/private/writerappender_priv.h
+++ b/src/main/include/log4cxx/private/writerappender_priv.h
@@ -48,7 +48,7 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 		immediateFlush(true),
 		writer(writer1)
 #if LOG4CXX_EVENTS_AT_EXIT
-		, atExitRegistryRaii([this]{atExitActivated();})
+		, atExitRegistryRaii{ [this]{flush();} }
 #endif
 	{
 	}
@@ -57,7 +57,7 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 		AppenderSkeletonPrivate(layout1),
 		immediateFlush(true)
 #if LOG4CXX_EVENTS_AT_EXIT
-		, atExitRegistryRaii([this]{atExitActivated();})
+		, atExitRegistryRaii{ [this]{flush();} }
 #endif
 	{
 	}

--- a/src/main/include/log4cxx/private/writerappender_priv.h
+++ b/src/main/include/log4cxx/private/writerappender_priv.h
@@ -37,7 +37,7 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 		AppenderSkeletonPrivate(),
 		immediateFlush(true)
 #if LOG4CXX_EVENTS_AT_EXIT
-		, atExitRegistryRaii([this]{atExitActivated();})
+		, atExitRegistryRaii{ [this]{ flush(); } }
 #endif
 	{
 	}
@@ -62,14 +62,12 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 	{
 	}
 
-#if LOG4CXX_EVENTS_AT_EXIT
-	void atExitActivated()
+	void flush()
 	{
 		std::lock_guard<std::recursive_mutex> lock(mutex);
 		if (writer)
 			writer->flush(pool);
 	}
-#endif
 
 	/**
 	Immediate flush means that the underlying writer or output stream


### PR DESCRIPTION
This PR changes the FileWatchDog thread into a generic periodic task execution thread so that buffered output can be used more often.

The current FileAppender option `BufferedIO` significantly reduces logging overhead, but is not often used because the most recent log entries need to be accessable. This change delivers both the overhead reduction provided by `BufferedIO=true` and access to recent log entries. 

The new FileAppender option `BufferedSeconds` (default value 5) provides user configuration control for this new behaviour.