### PR TITLE
Reduce SocketAppender overhead

### DIFF
--- a/src/main/cpp/aprsocket.cpp
+++ b/src/main/cpp/aprsocket.cpp
@@ -159,5 +159,10 @@ void APRSocket::close()
 	}
 }
 
+apr_socket_t* APRSocket::getSocketPtr() const
+{
+	return _priv->socket;
+}
+
 } //namespace helpers
 } //namespace log4cxx

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -392,9 +392,9 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 			if (this->jobs.end() == pItem)
 				break;
 			this->jobs.erase(pItem);
+			if (this->jobs.empty())
+				return;
 		}
-		if (this->jobs.empty())
-			break;
 
 		std::unique_lock<std::mutex> lock(this->interrupt_mutex);
 		this->interrupt.wait_until(lock, nextOperationTime);

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -70,8 +70,8 @@ struct ThreadUtility::priv_data
 		Period                delay;
 		TimePoint             nextRun;
 		std::function<void()> f;
-		int                   errorCount{ 0 };
-		bool                  removed{ false };
+		int                   errorCount;
+		bool                  removed;
 	};
 	using JobStore = std::list<NamedPeriodicFunction>;
 	JobStore                  jobs;
@@ -269,7 +269,7 @@ void ThreadUtility::addPeriodicTask(const LogString& name, std::function<void()>
 	if (m_priv->maxDelay < delay)
 		m_priv->maxDelay = delay;
 	auto currentTime = std::chrono::system_clock::now();
-	m_priv->jobs.push_back( priv_data::NamedPeriodicFunction{name, delay, currentTime + delay, f} );
+	m_priv->jobs.push_back( priv_data::NamedPeriodicFunction{name, delay, currentTime + delay, f, 0, false} );
 	if (!m_priv->thread.joinable())
 	{
 		m_priv->terminated = false;

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -69,16 +69,17 @@ struct ThreadUtility::priv_data
 		LogString             name;
 		Period                delay;
 		TimePoint             nextRun;
-		int                   errorCount;
 		std::function<void()> f;
+		int                   errorCount{ 0 };
+		bool                  removed{ false };
 	};
 	using JobStore = std::list<NamedPeriodicFunction>;
 	JobStore                  jobs;
-	std::mutex                job_mutex;
+	std::recursive_mutex      job_mutex;
 	std::thread               thread;
 	std::condition_variable   interrupt;
 	std::mutex                interrupt_mutex;
-	bool                      terminated{false};
+	bool                      terminated{ false };
 	int                       retryCount{ 2 };
 	Period                    maxDelay{ 0 };
 
@@ -264,11 +265,11 @@ ThreadStartPost ThreadUtility::postStartFunction()
  */
 void ThreadUtility::addPeriodicTask(const LogString& name, std::function<void()> f, const Period& delay)
 {
-	std::lock_guard<std::mutex> lock(m_priv->job_mutex);
+	std::lock_guard<std::recursive_mutex> lock(m_priv->job_mutex);
 	if (m_priv->maxDelay < delay)
 		m_priv->maxDelay = delay;
 	auto currentTime = std::chrono::system_clock::now();
-	m_priv->jobs.push_back( priv_data::NamedPeriodicFunction{name, delay, currentTime + delay, 0, f} );
+	m_priv->jobs.push_back( priv_data::NamedPeriodicFunction{name, delay, currentTime + delay, f} );
 	if (!m_priv->thread.joinable())
 	{
 		m_priv->terminated = false;
@@ -283,10 +284,10 @@ void ThreadUtility::addPeriodicTask(const LogString& name, std::function<void()>
  */
 bool ThreadUtility::hasPeriodicTask(const LogString& name)
 {
-	std::lock_guard<std::mutex> lock(m_priv->job_mutex);
+	std::lock_guard<std::recursive_mutex> lock(m_priv->job_mutex);
 	auto pItem = std::find_if(m_priv->jobs.begin(), m_priv->jobs.end()
 		, [&name](const priv_data::NamedPeriodicFunction& item)
-		{ return name == item.name; }
+		{ return !item.removed && name == item.name; }
 		);
 	return m_priv->jobs.end() != pItem;
 }
@@ -297,7 +298,7 @@ bool ThreadUtility::hasPeriodicTask(const LogString& name)
 void ThreadUtility::removeAllPeriodicTasks()
 {
 	{
-		std::lock_guard<std::mutex> lock(m_priv->job_mutex);
+		std::lock_guard<std::recursive_mutex> lock(m_priv->job_mutex);
 		while (!m_priv->jobs.empty())
 			m_priv->jobs.pop_back();
 	}
@@ -309,14 +310,14 @@ void ThreadUtility::removeAllPeriodicTasks()
  */
 void ThreadUtility::removePeriodicTask(const LogString& name)
 {
-	std::lock_guard<std::mutex> lock(m_priv->job_mutex);
+	std::lock_guard<std::recursive_mutex> lock(m_priv->job_mutex);
 	auto pItem = std::find_if(m_priv->jobs.begin(), m_priv->jobs.end()
 		, [&name](const priv_data::NamedPeriodicFunction& item)
-		{ return name == item.name; }
+		{ return !item.removed && name == item.name; }
 		);
 	if (m_priv->jobs.end() != pItem)
 	{
-		m_priv->jobs.erase(pItem);
+		pItem->removed = true;
 		m_priv->interrupt.notify_one();
 	}
 }
@@ -328,14 +329,14 @@ void ThreadUtility::removePeriodicTasksMatching(const LogString& namePrefix)
 {
 	while (1)
 	{
-		std::lock_guard<std::mutex> lock(m_priv->job_mutex);
+		std::lock_guard<std::recursive_mutex> lock(m_priv->job_mutex);
 		auto pItem = std::find_if(m_priv->jobs.begin(), m_priv->jobs.end()
 			, [&namePrefix](const priv_data::NamedPeriodicFunction& item)
-			{ return namePrefix.size() <= item.name.size() && item.name.substr(0, namePrefix.size()) == namePrefix; }
+			{ return !item.removed && namePrefix.size() <= item.name.size() && item.name.substr(0, namePrefix.size()) == namePrefix; }
 			);
 		if (m_priv->jobs.end() == pItem)
 			break;
-		m_priv->jobs.erase(pItem);
+		pItem->removed = true;
 	}
 	m_priv->interrupt.notify_one();
 }
@@ -348,14 +349,16 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 		auto currentTime = std::chrono::system_clock::now();
 		TimePoint nextOperationTime = currentTime + this->maxDelay;
 		{
-			std::lock_guard<std::mutex> lock(this->job_mutex);
+			std::lock_guard<std::recursive_mutex> lock(this->job_mutex);
 			if (this->jobs.empty())
 				break;
 			for (auto& item : this->jobs)
 			{
 				if (this->terminated)
 					return;
-				if (item.nextRun <= currentTime)
+				if (item.removed)
+					;
+				else if (item.nextRun <= currentTime)
 				{
 					try
 					{
@@ -380,13 +383,13 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 					nextOperationTime = item.nextRun;
 			}
 		}
-		// Remove faulty tasks
+		// Delete removed and faulty tasks
 		while (1)
 		{
-			std::lock_guard<std::mutex> lock(this->job_mutex);
+			std::lock_guard<std::recursive_mutex> lock(this->job_mutex);
 			auto pItem = std::find_if(this->jobs.begin(), this->jobs.end()
 				, [this](const NamedPeriodicFunction& item)
-				{ return this->retryCount < item.errorCount; }
+				{ return item.removed || this->retryCount < item.errorCount; }
 				);
 			if (this->jobs.end() == pItem)
 				break;

--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -350,8 +350,6 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 		TimePoint nextOperationTime = currentTime + this->maxDelay;
 		{
 			std::lock_guard<std::recursive_mutex> lock(this->job_mutex);
-			if (this->jobs.empty())
-				break;
 			for (auto& item : this->jobs)
 			{
 				if (this->terminated)
@@ -395,6 +393,8 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 				break;
 			this->jobs.erase(pItem);
 		}
+		if (this->jobs.empty())
+			break;
 
 		std::unique_lock<std::mutex> lock(this->interrupt_mutex);
 		this->interrupt.wait_until(lock, nextOperationTime);

--- a/src/main/include/log4cxx/net/socketappenderskeleton.h
+++ b/src/main/include/log4cxx/net/socketappenderskeleton.h
@@ -164,7 +164,7 @@ class LOG4CXX_EXPORT SocketAppenderSkeleton : public AppenderSkeleton
 		     connection is droppped.
 		     */
 
-		void monitor();
+		void retryConnect();
 		bool is_closed();
 		SocketAppenderSkeleton(const SocketAppenderSkeleton&);
 		SocketAppenderSkeleton& operator=(const SocketAppenderSkeleton&);

--- a/src/main/include/log4cxx/private/aprsocket.h
+++ b/src/main/include/log4cxx/private/aprsocket.h
@@ -41,6 +41,8 @@ class LOG4CXX_EXPORT APRSocket : public helpers::Socket
 		/** Closes this socket. */
 		virtual void close();
 
+		apr_socket_t* getSocketPtr() const;
+
 	private:
 		struct APRSocketPriv;
 };

--- a/src/test/cpp/net/CMakeLists.txt
+++ b/src/test/cpp/net/CMakeLists.txt
@@ -20,6 +20,7 @@ if(LOG4CXX_NETWORKING_SUPPORT)
     set(NET_TESTS
 	syslogappendertestcase
 	telnetappendertestcase
+	socketappendertestcase
 	xmlsocketappendertestcase
     )
 else()

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -120,7 +120,7 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 			LOGUNIT_ASSERT(aprSocket);
 			auto pSocket = aprSocket->getSocketPtr();
 			LOGUNIT_ASSERT(pSocket);
-			apr_socket_timeout_set(pSocket, 100000);    // 100 millisecond
+			apr_socket_timeout_set(pSocket, 200000);    // 200 millisecond
 			std::vector<int> messageCount;
 			char buffer[8*1024];
 			apr_size_t len = sizeof(buffer);

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -91,7 +91,7 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 			{
 				LOGUNIT_FAIL("accept failed");
 			}
-			auto aprSocket = dynamic_pointer_cast<helpers::APRSocket>(incomingSocket);
+			auto aprSocket = std::dynamic_pointer_cast<helpers::APRSocket>(incomingSocket);
 			LOGUNIT_ASSERT(aprSocket);
 			auto pSocket = aprSocket->getSocketPtr();
 			LOGUNIT_ASSERT(pSocket);

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -117,7 +117,7 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 			while (APR_SUCCESS == apr_socket_recv(pSocket, buffer, &len))
 			{
 				auto pStart = &buffer[0];
-				auto pEnd = buffer + len;
+				auto pEnd = pStart + len;
 				for (auto pChar = pStart; pChar < pEnd; ++pChar)
 				{
 					if ('\n' == *pChar)

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -47,6 +47,15 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 
 		LOGUNIT_TEST_SUITE_END();
 
+#ifdef _DEBUG
+	struct Fixture
+	{
+		Fixture() {
+			helpers::LogLog::setInternalDebugging(true);
+		}
+	} suiteFixture;
+#endif
+
 
 	public:
 

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -22,6 +22,7 @@
 #include <log4cxx/helpers/serversocket.h>
 #include <log4cxx/helpers/loglog.h>
 #include <log4cxx/helpers/stringhelper.h>
+#include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/private/aprsocket.h>
 #include <apr_network_io.h>
 

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -60,7 +60,7 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 			auto appender = std::make_shared<net::SocketAppender>();
 			appender->setLayout(std::make_shared<log4cxx::PatternLayout>(LOG4CXX_STR("%d [%T] %m%n")));
 			appender->setRemoteHost(LOG4CXX_STR("localhost"));
-			appender->setReconnectionDelay(100); // milliseconds
+			appender->setReconnectionDelay(50); // milliseconds
 			appender->setPort(tcpPort);
 			helpers::Pool pool;
 			appender->activateOptions(pool);

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -16,10 +16,20 @@
  */
 
 #include "../appenderskeletontestcase.h"
-#include "apr.h"
+#include <log4cxx/patternlayout.h>
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/net/xmlsocketappender.h>
+#include <log4cxx/helpers/serversocket.h>
+#include <log4cxx/helpers/loglog.h>
+#include <log4cxx/helpers/stringhelper.h>
+#include <log4cxx/private/aprsocket.h>
+#include <apr_network_io.h>
 
-using namespace log4cxx;
-using namespace log4cxx::helpers;
+namespace LOG4CXX_NS { namespace net {
+	using SocketAppender = XMLSocketAppender;
+} }
+
+using namespace LOG4CXX_NS;
 
 /**
    Unit tests of log4cxx::SocketAppender
@@ -32,61 +42,111 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 		//
 		LOGUNIT_TEST(testDefaultThreshold);
 		LOGUNIT_TEST(testSetOptionThreshold);
-		LOGUNIT_TEST(testInvalidHost);
+		LOGUNIT_TEST(testRetryConnect);
 
 		LOGUNIT_TEST_SUITE_END();
 
 
 	public:
 
-		void setUp()
-		{
-		}
-
-		void tearDown()
-		{
-			BasicConfigurator::resetConfiguration();
-		}
-
 		AppenderSkeleton* createAppenderSkeleton() const
 		{
 			return new log4cxx::net::SocketAppender();
 		}
 
-		void testInvalidHost(){
-//			log4cxx::net::SocketAppenderPtr appender = std::make_shared<log4cxx::net::SocketAppender>();
-//			log4cxx::PatternLayoutPtr layout = std::make_shared<log4cxx::PatternLayout>(LOG4CXX_STR("%m%n"));
+		void testRetryConnect()
+		{
+			int tcpPort = 44445;
+			auto appender = std::make_shared<net::SocketAppender>();
+			appender->setLayout(std::make_shared<log4cxx::PatternLayout>(LOG4CXX_STR("%d [%T] %m%n")));
+			appender->setRemoteHost(LOG4CXX_STR("localhost"));
+			appender->setReconnectionDelay(100); // milliseconds
+			appender->setPort(tcpPort);
+			helpers::Pool pool;
+			appender->activateOptions(pool);
 
-//			log4cxx::helpers::ServerSocket serverSocket(4445);
+			BasicConfigurator::configure(appender);
+			auto logger = Logger::getLogger("test");
+			int logEventCount = 3000;
+			auto doLogging = [logger, logEventCount]()
+			{
+				apr_sleep(50000);    // 50 millisecond
+				for( int x = 0; x < logEventCount; x++ ){
+					LOG4CXX_INFO(logger, "Message " << x);
+				}
+			};
+			std::vector<std::thread> loggingThread;
+			for (auto i: {0, 1})
+				loggingThread.emplace_back(doLogging);
 
-//			appender->setLayout(layout);
-//			appender->setRemoteHost(LOG4CXX_STR("localhost"));
-//			appender->setReconnectionDelay(1);
-//			appender->setPort(4445);
-//			log4cxx::helpers::Pool pool;
-//			appender->activateOptions(pool);
+			auto serverSocket = helpers::ServerSocket::create(tcpPort);
+			serverSocket->setSoTimeout(1000); // milliseconds
+			helpers::SocketPtr incomingSocket;
+			try
+			{
+				incomingSocket = serverSocket->accept();
+			}
+			catch (std::exception& )
+			{
+				LOGUNIT_FAIL("accept failed");
+			}
+			auto aprSocket = dynamic_pointer_cast<helpers::APRSocket>(incomingSocket);
+			LOGUNIT_ASSERT(aprSocket);
+			auto pSocket = aprSocket->getSocketPtr();
+			LOGUNIT_ASSERT(pSocket);
+			apr_socket_timeout_set(pSocket, 100000);    // 100 millisecond
+			std::vector<int> messageCount;
+			char buffer[8*1024];
+			apr_size_t len = sizeof(buffer);
+			while (APR_SUCCESS == apr_socket_recv(pSocket, buffer, &len))
+			{
+				auto pStart = &buffer[0];
+				auto pEnd = buffer + len;
+				for (auto pChar = pStart; pChar < pEnd; ++pChar)
+				{
+					if ('\n' == *pChar)
+					{
+						std::string line(pStart, pChar);
+						auto pos = line.rfind(' ');
+						if (line.npos != pos && pos + 1 < line.size())
+						{
+							try
+							{
+								auto msgNumber = std::stoi(line.substr(pos));
+								if (messageCount.size() <= msgNumber)
+									messageCount.resize(msgNumber + 1);
+								++messageCount[msgNumber];
+							}
+							catch (std::exception const& ex)
+							{
+								LogString msg;
+								helpers::Transcoder::decode(ex.what(), msg);
+								msg += LOG4CXX_STR(" processing\n");
+								helpers::Transcoder::decode(line, msg);
+								helpers::LogLog::warn(msg);
+							}
+						}
+						pStart = pChar + 1;
+					}
+				}
+				len = sizeof(buffer);
+			}
+			incomingSocket->close();
+			for (auto& t : loggingThread)
+				t.join();
 
-//			BasicConfigurator::configure(appender);
-
-//			log4cxx::Logger::getRootLogger()->setLevel(log4cxx::Level::getAll());
-
-//			std::thread th1( [](){
-//				for( int x = 0; x < 3000; x++ ){
-//					LOG4CXX_INFO(Logger::getLogger(LOG4CXX_STR("test")), "Some message" );
-//				}
-//			});
-//			std::thread th2( [](){
-//				for( int x = 0; x < 3000; x++ ){
-//					LOG4CXX_INFO(Logger::getLogger(LOG4CXX_STR("test")), "Some message" );
-//				}
-//			});
-
-//			SocketPtr incomingSocket = serverSocket.accept();
-//			incomingSocket->close();
-
-//			// If we do not get here, we have deadlocked
-//			th1.join();
-//			th2.join();
+			if (helpers::LogLog::isDebugEnabled())
+			{
+				helpers::Pool p;
+				LogString msg(LOG4CXX_STR("messageCount "));
+				for (auto item : messageCount)
+				{
+					msg += logchar(' ');
+					helpers::StringHelper::toString(item, p, msg);
+				}
+				helpers::LogLog::debug(msg);
+			}
+			LOGUNIT_ASSERT_EQUAL(logEventCount, (int)messageCount.size());
 		}
 };
 

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -84,9 +84,10 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 			int logEventCount = 3000;
 			auto doLogging = [logger, logEventCount]()
 			{
-				apr_sleep(50000);    // 50 millisecond
 				for( int x = 0; x < logEventCount; x++ ){
 					LOG4CXX_INFO(logger, "Message " << x);
+					if (0 == x % 1000)
+						apr_sleep(50000);    // 50 millisecond
 				}
 			};
 			std::vector<std::thread> loggingThread;


### PR DESCRIPTION
Instead of creating a dedicated thread to periodically attempt reconnection to the remote server, SocketAppender will now add a periodic task to ThreadUtility generic periodic task processor.

Also adds a reconnection test.