### PR TITLE
Improve compliance with C++ Core Guidelines

### DIFF
--- a/src/main/cpp/dbappender.cpp
+++ b/src/main/cpp/dbappender.cpp
@@ -62,7 +62,7 @@ struct DBAppender::DBAppenderPriv : public AppenderSkeleton::AppenderSkeletonPri
 		}
 	}
 
-    apr_dbd_driver_t* m_driver = nullptr;
+    const apr_dbd_driver_t* m_driver = nullptr;
     apr_dbd_t* m_databaseHandle = nullptr;
     apr_dbd_prepared_t* preparedStmt = nullptr;
     std::vector<LogString> mappedName;
@@ -147,7 +147,7 @@ void DBAppender::setOption(const LogString& option, const LogString& value){
 void DBAppender::activateOptions(helpers::Pool& p){
     apr_status_t stat = apr_dbd_get_driver(_priv->m_pool.getAPRPool(),
                                            _priv->driverName.c_str(),
-                                           const_cast<const apr_dbd_driver_t**>(&_priv->m_driver));
+                                           &_priv->m_driver);
 
     if(stat != APR_SUCCESS){
         LogString errMsg = LOG4CXX_STR("Unable to get driver named ");

--- a/src/main/cpp/dbappender.cpp
+++ b/src/main/cpp/dbappender.cpp
@@ -62,7 +62,11 @@ struct DBAppender::DBAppenderPriv : public AppenderSkeleton::AppenderSkeletonPri
 		}
 	}
 
+#if 15 < LOG4CXX_ABI_VERSION
     const apr_dbd_driver_t* m_driver = nullptr;
+#else
+    apr_dbd_driver_t* m_driver = nullptr;
+#endif
     apr_dbd_t* m_databaseHandle = nullptr;
     apr_dbd_prepared_t* preparedStmt = nullptr;
     std::vector<LogString> mappedName;
@@ -147,7 +151,11 @@ void DBAppender::setOption(const LogString& option, const LogString& value){
 void DBAppender::activateOptions(helpers::Pool& p){
     apr_status_t stat = apr_dbd_get_driver(_priv->m_pool.getAPRPool(),
                                            _priv->driverName.c_str(),
+#if 15 < LOG4CXX_ABI_VERSION
                                            &_priv->m_driver);
+#else
+                                           const_cast<const apr_dbd_driver_t**>(&_priv->m_driver));
+#endif
 
     if(stat != APR_SUCCESS){
         LogString errMsg = LOG4CXX_STR("Unable to get driver named ");

--- a/src/main/cpp/fallbackerrorhandler.cpp
+++ b/src/main/cpp/fallbackerrorhandler.cpp
@@ -128,9 +128,9 @@ void FallbackErrorHandler::setBackupAppender(const AppenderPtr& backup1)
 
 	// Make sure that we keep a reference to the appender around, since otherwise
 	// the appender would be lost if it has no loggers that use it.
-	LoggerRepository* repository = LogManager::getRootLogger()->getLoggerRepository();
-	Hierarchy* hierarchy = dynamic_cast<Hierarchy*>(repository);
-	if(hierarchy){
+	auto repository = LogManager::getLoggerRepository();
+	if (auto hierarchy = dynamic_cast<Hierarchy*>(repository.get()))
+	{
 		hierarchy->addAppender(backup1);
 	}
 

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -149,7 +149,7 @@ void Logger::callAppenders(const spi::LoggingEventPtr& event, Pool& p) const
 
 	if (writes == 0 && rep)
 	{
-		rep->emitNoAppenderWarning(const_cast<Logger*>(this));
+		rep->emitNoAppenderWarning(this);
 	}
 }
 

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -495,10 +495,8 @@ bool TimeBasedRollingPolicy::isTriggeringEvent(
 
 			if (!mapCurrentBase.empty() && mapCurrentBase != filename)
 			{
-				const FileAppender* fappend = reinterpret_cast<const FileAppender*>(appender->cast(FileAppender::getStaticClass()));
-				if( fappend ){
-					const_cast<FileAppender*>(fappend)->setFile(mapCurrentBase);
-				}
+				if (auto fappend = dynamic_cast<FileAppender*>(appender))
+					fappend->setFile(mapCurrentBase);
 			}
 		}
 


### PR DESCRIPTION
This PR removes unnecessary casts in line with [C++ Core Guildlines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es48-avoid-casts)