### PR TITLE
Support wchar_t logchar in MultiprocessRollingFileAppender

### DIFF
--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -154,7 +154,7 @@ IOException::IOException(log4cxx_status_t stat)
 }
 
 IOException::IOException(const LogString& type, log4cxx_status_t stat)
-	: Exception(formatMessage(type, stat))
+	: Exception(makeMessage(type, stat))
 {
 }
 
@@ -177,10 +177,10 @@ IOException& IOException::operator=(const IOException& src)
 
 LogString IOException::formatMessage(log4cxx_status_t stat)
 {
-	return formatMessage(LOG4CXX_STR("IO Exception"), stat);
+	return makeMessage(LOG4CXX_STR("IO Exception"), stat);
 }
 
-LogString IOException::formatMessage(const LogString& type, log4cxx_status_t stat)
+LogString Exception::makeMessage(const LogString& type, log4cxx_status_t stat)
 {
 	LogString s = type;
 	char err_buff[1024] = {0};
@@ -243,9 +243,9 @@ PoolException& PoolException::operator=(const PoolException& src)
 	return *this;
 }
 
-LogString PoolException::formatMessage(log4cxx_status_t)
+LogString PoolException::formatMessage(log4cxx_status_t stat)
 {
-	return LOG4CXX_STR("Pool exception");
+	return makeMessage(LOG4CXX_STR("Pool exception"), stat);
 }
 
 
@@ -322,10 +322,7 @@ ThreadException& ThreadException::operator=(const ThreadException& src)
 
 LogString ThreadException::formatMessage(log4cxx_status_t stat)
 {
-	LogString s(LOG4CXX_STR("Thread exception: stat = "));
-	Pool p;
-	StringHelper::toString(stat, p, s);
-	return s;
+	return makeMessage(LOG4CXX_STR("Thread exception"), stat);
 }
 
 IllegalMonitorStateException::IllegalMonitorStateException(const LogString& msg1)

--- a/src/main/include/log4cxx/helpers/exception.h
+++ b/src/main/include/log4cxx/helpers/exception.h
@@ -42,6 +42,7 @@ class LOG4CXX_EXPORT Exception : public ::std::exception
 		Exception(const Exception& src);
 		Exception& operator=(const Exception& src);
 		const char* what() const throw();
+		static LogString makeMessage(const LogString& type, log4cxx_status_t stat);
 	private:
 		enum { MSG_SIZE = 128 };
 		char msg[MSG_SIZE + 1];
@@ -97,7 +98,6 @@ class LOG4CXX_EXPORT IOException : public Exception
 		IOException& operator=(const IOException&);
 	private:
 		static LogString formatMessage(log4cxx_status_t stat);
-		static LogString formatMessage(const LogString& type, log4cxx_status_t stat);
 };
 
 class LOG4CXX_EXPORT MissingResourceException : public Exception

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -160,23 +160,7 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 			}
 			if (helpers::LogLog::isDebugEnabled())
 			{
-				LogString msg = LOG4CXX_STR("apr_socket_recv terminated");
-				char err_buff[1024] = {0};
-				apr_strerror(status, err_buff, sizeof(err_buff));
-				if (0 == err_buff[0] || 0 == strncmp(err_buff, "APR does not understand", 23))
-				{
-					msg.append(LOG4CXX_STR(": error code "));
-					helpers::Pool p;
-					helpers::StringHelper::toString(status, p, msg);
-				}
-				else
-				{
-					msg.append(LOG4CXX_STR(" - "));
-					std::string sMsg = err_buff;
-					LOG4CXX_DECODE_CHAR(lsMsg, sMsg);
-					msg.append(lsMsg);
-				}
-				helpers::LogLog::debug(msg);
+				helpers::LogLog::debug(helpers::Exception::makeMessage(LOG4CXX_STR("apr_socket_recv terminated"), status));
 			}
 			incomingSocket->close();
 			serverSocket->close();

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -23,6 +23,7 @@
 #include <log4cxx/rolling/multiprocessrollingfileappender.h>
 #include <log4cxx/rolling/sizebasedtriggeringpolicy.h>
 #include <log4cxx/helpers/strftimedateformat.h>
+#include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/helpers/date.h>
 #include <log4cxx/helpers/fileoutputstream.h>
 #include <log4cxx/helpers/loglog.h>
@@ -108,7 +109,7 @@ public:
 	 */
 	void test2()
 	{
-		std::string expectedPrefix = LOG4CXX_STR("multiprocess-2-");
+		std::string expectedPrefix{ "multiprocess-2-" };
 		// remove any previously generated files
 		std::filesystem::path outputDir("output/rolling");
 		if (!exists(outputDir))
@@ -136,14 +137,16 @@ public:
 		}
 
 		// Count rolled files
+		LOG4CXX_DECODE_CHAR(expectedPrefixLS, expectedPrefix);
 		helpers::Pool p;
-		helpers::StrftimeDateFormat("%Y-%m-%d").format(expectedPrefix, helpers::Date::currentTime(), p);
+		helpers::StrftimeDateFormat(LOG4CXX_STR("%Y-%m-%d")).format(expectedPrefixLS, helpers::Date::currentTime(), p);
+		LOG4CXX_ENCODE_CHAR(rolledPrefix, expectedPrefixLS);
 		int fileCount = 0;
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})
 		{
-			LogString filename(dir_entry.path().filename().string());
-			if (expectedPrefix.size() < filename.size() &&
-				filename.substr(0, expectedPrefix.size()) == expectedPrefix)
+			std::string filename(dir_entry.path().filename().string());
+			if (rolledPrefix.size() < filename.size() &&
+				filename.substr(0, rolledPrefix.size()) == rolledPrefix)
 				++fileCount;
 		}
 		LOGUNIT_ASSERT(1 < fileCount);


### PR DESCRIPTION
This PR prevents compilation errors when defining LOG4CXX_CHAR=wchar_t and LOG4CXX_MULTIPROCESS_ROLLING_FILE_APPENDER=on

It also prevent a possible buffer overflow (in memcpy) when LOG4CXX_MULTIPROCESS_ROLLING_FILE_APPENDER=on