### PR TITLE
Ignore an invalid time zone specifier in a date pattern

### DIFF
--- a/src/main/cpp/datepatternconverter.cpp
+++ b/src/main/cpp/datepatternconverter.cpp
@@ -97,7 +97,7 @@ DateFormatPtr DatePatternConverter::getDateFormat(const OptionsList& options)
 					maximumCacheValidity =
 						CachedDateFormat::getMaximumCacheValidity(dateFormatStr);
 				}
-				catch (IllegalArgumentException& e)
+				catch (std::exception& e)
 				{
 					df = std::make_shared<ISO8601DateFormat>();
 					LogLog::warn(((LogString)
@@ -113,9 +113,17 @@ DateFormatPtr DatePatternConverter::getDateFormat(const OptionsList& options)
 
 		if (options.size() >= 2)
 		{
-			TimeZonePtr tz(TimeZone::getTimeZone(options[1]));
+			TimeZonePtr tz;
+			try
+			{
+				tz = TimeZone::getTimeZone(options[1]);
+			}
+			catch (std::exception& e)
+			{
+				LogLog::warn(LOG4CXX_STR("Invalid time zone: ") + options[1], e);
+			}
 
-			if (tz != NULL)
+			if (tz)
 			{
 				df->setTimeZone(tz);
 			}

--- a/src/test/cpp/pattern/patternparsertestcase.cpp
+++ b/src/test/cpp/pattern/patternparsertestcase.cpp
@@ -270,6 +270,10 @@ public:
 		assertFormattedEquals(LOG4CXX_STR("%d{HH:mm:ss}{GMT} %d{HH:mm:ss} %c  - %m"),
 			getFormatSpecifiers(),
 			expected);
+		// Check an invalid timezone is equivalent to an unspecified timezone
+		assertFormattedEquals(LOG4CXX_STR("%d{HH:mm:ss}{GMT} %d{HH:mm:ss}{GMT-X} %c  - %m"),
+			getFormatSpecifiers(),
+			expected);
 	}
 
 	void testThreadUsername()


### PR DESCRIPTION
This PR logs a warning instead of throwing an exception when the time zone specifier is invalid.