### PR TITLE
build fuzzers with utf-8 and wchar_t

### DIFF
--- a/src/fuzzers/bash/oss-fuzz-build.sh
+++ b/src/fuzzers/bash/oss-fuzz-build.sh
@@ -43,9 +43,8 @@ declare -a encodings=("utf-8" "wchar_t")
 
 for encoding in "${encodings[@]}"
 do
-  echo heeeeere
   # Build the project
-  mkdir -p build && cd $_
+  mkdir -p build-"${encoding}" && cd $_
   cmake \
     -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_TESTING=OFF \
@@ -58,5 +57,5 @@ do
   # Copy executables & resources
   find src/fuzzers/cpp -maxdepth 1 -executable -type f -exec cp -v {} "$outputDir/" \;
   cp ../src/fuzzers/resources/* "$outputDir/"
-  cd .. && rm -r build
+  cd .. && rm -r build-"${encoding}"
 done

--- a/src/fuzzers/bash/oss-fuzz-build.sh
+++ b/src/fuzzers/bash/oss-fuzz-build.sh
@@ -38,16 +38,25 @@ mkdir -p "$outputDir"
 # Switch to the project directory (by referencing from the script directory)
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && cd ../../..
 
-# Build the project
-mkdir -p build && cd $_
-cmake \
-  -DBUILD_SHARED_LIBS=OFF \
-  -DBUILD_TESTING=OFF \
-  -DBUILD_EXAMPLES=OFF \
-  -DBUILD_FUZZERS=ON \
-  ..
-cmake --build . -j
+# Build a fuzzer with each encoding
+declare -a encodings=("utf-8" "wchar_t")
 
-# Copy executables & resources
-find src/fuzzers/cpp -maxdepth 1 -executable -type f -exec cp -v {} "$outputDir/" \;
-cp -v ../src/fuzzers/resources/* "$outputDir/"
+for encoding in "${encodings[@]}"
+do
+  echo heeeeere
+  # Build the project
+  mkdir -p build && cd $_
+  cmake \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_FUZZERS=ON \
+    -DLOG4CXX_CHAR="${encoding}" \
+    ..
+  cmake --build . -j
+
+  # Copy executables & resources
+  find src/fuzzers/cpp -maxdepth 1 -executable -type f -exec cp -v {} "$outputDir/" \;
+  cp ../src/fuzzers/resources/* "$outputDir/"
+  cd .. && rm -r build
+done

--- a/src/fuzzers/cpp/CMakeLists.txt
+++ b/src/fuzzers/cpp/CMakeLists.txt
@@ -24,7 +24,6 @@ set(ALL_LOG4CXX_FUZZERS
     PatternConverterFuzzer
     DOMConfiguratorFuzzer
 )
-set(LOG4CXX_CHAR "utf-8")
 
 # Get the most recent Git commit ID
 execute_process(
@@ -49,7 +48,7 @@ else()
 endif()
 
 foreach(fuzzerName IN LISTS ALL_LOG4CXX_FUZZERS)
-  set(PROGRAM_NAME "${fuzzerName}")
+  set(PROGRAM_NAME "${fuzzerName}-${LOG4CXX_CHAR}")
   add_executable(${PROGRAM_NAME} ${fuzzerName}.cpp)
   target_compile_definitions(${PROGRAM_NAME}
     PRIVATE

--- a/src/fuzzers/cpp/JSONLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/JSONLayoutFuzzer.cpp
@@ -22,6 +22,7 @@
 #include <fuzzer/FuzzedDataProvider.h>
 #include <log4cxx/mdc.h>
 #include <log4cxx/jsonlayout.h>
+#include <log4cxx/helpers/transcoder.h>
 
 using namespace log4cxx;
 using namespace log4cxx::helpers;
@@ -47,28 +48,40 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	}
 
 	// Create random strings we need later
-	std::string key1 = fdp.ConsumeRandomLengthString();
-	std::string val1 = fdp.ConsumeRandomLengthString();
-	std::string key2 = fdp.ConsumeRandomLengthString();
-	std::string val2 = fdp.ConsumeRandomLengthString();
-	std::string key3 = fdp.ConsumeRandomLengthString();
-	std::string val3 = fdp.ConsumeRandomLengthString();
-	std::string key4 = fdp.ConsumeRandomLengthString();
-	std::string val4 = fdp.ConsumeRandomLengthString();
-	std::string ndcMessage = fdp.ConsumeRandomLengthString();
+	std::string key1Str = fdp.ConsumeRandomLengthString();
+	std::string val1Str = fdp.ConsumeRandomLengthString();
+	std::string key2Str = fdp.ConsumeRandomLengthString();
+	std::string val2Str = fdp.ConsumeRandomLengthString();
+	std::string key3Str = fdp.ConsumeRandomLengthString();
+	std::string val3Str = fdp.ConsumeRandomLengthString();
+	std::string key4Str = fdp.ConsumeRandomLengthString();
+	std::string val4Str = fdp.ConsumeRandomLengthString();
+	std::string ndcMessageStr = fdp.ConsumeRandomLengthString();
 	std::string loggerStr = fdp.ConsumeRandomLengthString();
-	std::string content = fdp.ConsumeRemainingBytesAsString();
+	std::string contentStr = fdp.ConsumeRemainingBytesAsString();
 
-	log4cxx::LogString logger = LOG4CXX_STR(loggerStr);
+	LogString key1, val1, key2, val2, key3, val3, key4, val4, ndcMessage, logger, content;
+	Transcoder::decode(key1Str, key1);
+	Transcoder::decode(val1Str, val1);
+	Transcoder::decode(key2Str, key2);
+	Transcoder::decode(val2Str, val2);
+	Transcoder::decode(key3Str, key3);
+	Transcoder::decode(val3Str, val3);
+	Transcoder::decode(key4Str, key4);
+	Transcoder::decode(val4Str, val4);
+	Transcoder::decode(ndcMessageStr, ndcMessage);
+	Transcoder::decode(loggerStr, logger);
+	Transcoder::decode(contentStr, content);
+
 	log4cxx::LevelPtr level = log4cxx::Level::getInfo();
 	log4cxx::NDC::push(ndcMessage);
 	log4cxx::spi::LoggingEventPtr event = log4cxx::spi::LoggingEventPtr(
 		new log4cxx::spi::LoggingEvent(
-			logger, level, LOG4CXX_STR(content), LOG4CXX_LOCATION));
+			logger, level, content, LOG4CXX_LOCATION));
 
 	// Set properties
-	event->setProperty(LOG4CXX_STR(key1), LOG4CXX_STR(val1));
-	event->setProperty(LOG4CXX_STR(key2), LOG4CXX_STR(val2));
+	event->setProperty(key1, val1);
+	event->setProperty(key2, val2);
 
 	// Set MDC
 	log4cxx::MDC::put(key3, val3);

--- a/src/fuzzers/cpp/PatternParserFuzzer.cpp
+++ b/src/fuzzers/cpp/PatternParserFuzzer.cpp
@@ -21,6 +21,7 @@
 #include <log4cxx/helpers/stringhelper.h>
 #include <fuzzer/FuzzedDataProvider.h>
 #include <log4cxx/pattern/patternparser.h>
+#include <log4cxx/helpers/transcoder.h>
 
 #include <log4cxx/pattern/loggerpatternconverter.h>
 #include <log4cxx/pattern/literalpatternconverter.h>
@@ -108,13 +109,22 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	
 	std::string loggerStr = fdp.ConsumeRandomLengthString();
 	std::string content = fdp.ConsumeRandomLengthString();
+	std::string pattern = fdp.ConsumeRandomLengthString();
+
+	LogString contentLogString;
+	LogString loggerLogString;
+	LogString patternLogString;
+
+	Transcoder::decode(content, contentLogString);
+	Transcoder::decode(loggerStr, loggerLogString);
+	Transcoder::decode(pattern, patternLogString);
 
 	// Create the event
-	log4cxx::LogString logger = LOG4CXX_STR(loggerStr);
+	log4cxx::LogString logger = loggerLogString;
 	log4cxx::LevelPtr level = log4cxx::Level::getInfo();
 	log4cxx::spi::LoggingEventPtr event = log4cxx::spi::LoggingEventPtr(
 		new log4cxx::spi::LoggingEvent(
-			logger, level, LOG4CXX_STR(content), LOG4CXX_LOCATION));
+			logger, level, contentLogString, LOG4CXX_LOCATION));
 
 
 	log4cxx::helpers::Pool p;
@@ -122,8 +132,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	std::vector<PatternConverterPtr> converters;
 	std::vector<FormattingInfoPtr> fields;
 
-	log4cxx::LogString pattern = LOG4CXX_STR(fdp.ConsumeRandomLengthString());
-	PatternParser::parse(pattern, converters, fields, patternMap);
+	PatternParser::parse(patternLogString, converters, fields, patternMap);
 
   	return 0;
 }

--- a/src/fuzzers/cpp/XMLLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/XMLLayoutFuzzer.cpp
@@ -16,16 +16,25 @@
  */
 
 #include "stdint.h"
+#include <iostream>
+#include <string>
+#include <cwchar>
 #include <log4cxx/logstring.h>
 #include <log4cxx/ndc.h>
 #include <log4cxx/xml/xmllayout.h>
 #include <log4cxx/helpers/stringhelper.h>
 #include <fuzzer/FuzzedDataProvider.h>
 #include <log4cxx/mdc.h>
+#include <log4cxx/helpers/transcoder.h>
+
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+using namespace log4cxx::spi;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	// Setup XMLLayout
 	log4cxx::xml::XMLLayout layout;
+	Pool p;
 
 	// Create random strings
 	FuzzedDataProvider fdp(data, size);
@@ -33,19 +42,34 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	std::string val1 = fdp.ConsumeRandomLengthString();
 	std::string key2 = fdp.ConsumeRandomLengthString();
 	std::string val2 = fdp.ConsumeRandomLengthString();
+	std::string ndcMessage = fdp.ConsumeRandomLengthString();
+	std::string loggerString = fdp.ConsumeRandomLengthString();
+	std::string propkey = fdp.ConsumeRandomLengthString();
+	std::string propval = fdp.ConsumeRandomLengthString();
 	std::string content = fdp.ConsumeRemainingBytesAsString();
 
-	log4cxx::LogString logger = LOG4CXX_STR("com.example.bar");
 	log4cxx::LevelPtr level = log4cxx::Level::getInfo();
-	std::string ndcMessage = "<envelope><faultstring><![CDATA[The EffectiveDate]]></faultstring><envelope>";
 	log4cxx::NDC::push(ndcMessage);
+        LogString logstring1;
+        LogString key1LogString;
+        LogString val1LogString;
+        LogString propkeyLogString;
+        LogString propvalLogString;
+        LogString logger;
+
+        Transcoder::decode(content, logstring1);
+        Transcoder::decode(loggerString, logger);
+        Transcoder::decode(key1, key1LogString);
+        Transcoder::decode(val1, val1LogString);
+        Transcoder::decode(propkey, propkeyLogString);
+        Transcoder::decode(propval, propvalLogString);
 	log4cxx::spi::LoggingEventPtr event = log4cxx::spi::LoggingEventPtr(
 		new log4cxx::spi::LoggingEvent(
-			logger, level, LOG4CXX_STR(content), LOG4CXX_LOCATION));
-
+			logger, level, logstring1, LOG4CXX_LOCATION));
 	// Set properties
 	layout.setProperties(true);
-	event->setProperty(LOG4CXX_STR(key1), LOG4CXX_STR(val1));
+	event->setProperty(propkeyLogString, propvalLogString);
+
 
 	// Set MDC
 	log4cxx::MDC::put(key2, val2);
@@ -54,7 +78,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	layout.setLocationInfo(true);
 
 	// Call the target API
-	log4cxx::helpers::Pool p;
 	log4cxx::LogString result;
 	layout.format(result, event, p);
 


### PR DESCRIPTION
Set up the CMake file so it builds each fuzzer with utf-8 and wchar_t.

I have had to remove the `LOG4CXX_STR` and use the Transcoder instead to create `LogString` variables.