### PR TITLE
use OSS-Fuzz linker flags when OSS-Fuzz builds the fuzzers

### DIFF
--- a/src/fuzzers/cpp/CMakeLists.txt
+++ b/src/fuzzers/cpp/CMakeLists.txt
@@ -33,8 +33,16 @@ execute_process(
     OUTPUT_VARIABLE GIT_COMMIT_ID
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-set(FUZZER_SANITIZE_FLAGS "-fsanitize=fuzzer,address,signed-integer-overflow")
-set(FUZZER_COMPILE_DEFINITIONS "-DCOMPILE_DEFINITIONS=${FUZZER_SANITIZE_FLAGS}" "-DGIT_COMMIT_ID=\"${GIT_COMMIT_ID}\"")
+# If we are building the fuzzers in the OSS-Fuzz environment
+# we use their linker flag.
+if(DEFINED ENV{LIB_FUZZING_ENGINE})
+  set(FUZZER_SANITIZE_FLAGS $ENV{LIB_FUZZING_ENGINE})
+  set(FUZZER_COMPILE_DEFINITIONS "-DGIT_COMMIT_ID=\"${GIT_COMMIT_ID}\"")
+else()
+  set(FUZZER_SANITIZE_FLAGS "-fsanitize=fuzzer,address,signed-integer-overflow")
+  set(FUZZER_COMPILE_DEFINITIONS "-DCOMPILE_DEFINITIONS=${FUZZER_SANITIZE_FLAGS}" "-DGIT_COMMIT_ID=\"${GIT_COMMIT_ID}\"")
+endif()
+
 
 if(WIN32)
   include(win32_target_environment_path)


### PR DESCRIPTION
When OSS-Fuzz builds the fuzzers, the build script should use OSS-Fuzz's linker flags. OSS-Fuzz runs the fuzzers with different sanitizers during different runtime jobs, and it sets the sanitizer in the `LIB_FUZZING_ENGINE` environment variable. Until this is merged, OSS-Fuzz will not run the fuzzers with some sanitizers like memory sanitizer. 

Doc: https://google.github.io/oss-fuzz/getting-started/new-project-guide/#Requirements