### PR TITLE
Fix SEGV with invalid appenders

### DIFF
--- a/src/main/cpp/domconfigurator.cpp
+++ b/src/main/cpp/domconfigurator.cpp
@@ -224,6 +224,10 @@ AppenderPtr DOMConfigurator::parseAppender(Pool& p,
 	{
 		ObjectPtr instance = ObjectPtr(Loader::loadClass(className).newInstance());
 		AppenderPtr appender = LOG4CXX_NS::cast<Appender>(instance);
+		if(!appender){
+			LogLog::error(LOG4CXX_STR("Could not cast class of type [") + className + LOG4CXX_STR("] to appender"));
+			return AppenderPtr();
+		}
 		PropertySetter propSetter(appender);
 
 		appender->setName(subst(getAttribute(utf8Decoder, appenderElement, NAME_ATTR)));

--- a/src/test/cpp/xml/domtestcase.cpp
+++ b/src/test/cpp/xml/domtestcase.cpp
@@ -53,6 +53,7 @@ LOGUNIT_CLASS(DOMTestCase)
 #endif
 	LOGUNIT_TEST(test3);
 	LOGUNIT_TEST(test4);
+	LOGUNIT_TEST(invalidAppender);
 	LOGUNIT_TEST_SUITE_END();
 
 	LoggerPtr root;
@@ -225,6 +226,13 @@ public:
 		Pool p;
 		bool exists = file.exists(p);
 		LOGUNIT_ASSERT(exists);
+	}
+
+	void invalidAppender()
+	{
+		// Load an XML file that attempts to use a levelmatchfilter as an appender.
+		// We should not crash when loading this file.
+		DOMConfigurator::configure(LOG4CXX_TEST_STR("input/xml/DOMInvalidAppender.xml"));
 	}
 };
 

--- a/src/test/resources/input/xml/DOMInvalidAppender.xml
+++ b/src/test/resources/input/xml/DOMInvalidAppender.xml
@@ -1,0 +1,7 @@
+<log4j:configuration xmlns:log4j=' '>
+  <appender name="TEMP" class="levelmatchfilter"></appender>
+
+  <root>
+    <appender-ref ref="TEMP"/>
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
If a non-appender class is attempted to be used as an appender, a SEGV can occur.  Add explicit check to make sure that the class being used is in fact an appender.