### PR TITLE
Fix empty appender ref recursion

### DIFF
--- a/src/main/cpp/domconfigurator.cpp
+++ b/src/main/cpp/domconfigurator.cpp
@@ -295,7 +295,7 @@ AppenderPtr DOMConfigurator::parseAppender(Pool& p,
 			{
 				LogString refName = subst(getAttribute(utf8Decoder, currentElement, REF_ATTR));
 
-				if (appender->instanceof(AppenderAttachable::getStaticClass()))
+				if (!refName.empty() && appender->instanceof(AppenderAttachable::getStaticClass()))
 				{
 					AppenderAttachablePtr aa = LOG4CXX_NS::cast<AppenderAttachable>(appender);
 					if (LogLog::isDebugEnabled())
@@ -305,6 +305,10 @@ AppenderPtr DOMConfigurator::parseAppender(Pool& p,
 							appender->getName() + LOG4CXX_STR("]."));
 					}
 					aa->addAppender(findAppenderByReference(p, utf8Decoder, currentElement, doc, appenders));
+				}
+				else if (refName.empty())
+				{
+					LogLog::error(LOG4CXX_STR("Can't add appender with empty ref attribute"));
 				}
 				else
 				{

--- a/src/test/cpp/xml/domtestcase.cpp
+++ b/src/test/cpp/xml/domtestcase.cpp
@@ -53,6 +53,7 @@ LOGUNIT_CLASS(DOMTestCase)
 #endif
 	LOGUNIT_TEST(test3);
 	LOGUNIT_TEST(test4);
+	LOGUNIT_TEST(recursiveAppenderRef);
 	LOGUNIT_TEST_SUITE_END();
 
 	LoggerPtr root;
@@ -225,6 +226,12 @@ public:
 		Pool p;
 		bool exists = file.exists(p);
 		LOGUNIT_ASSERT(exists);
+	}
+
+	void recursiveAppenderRef()
+	{
+		// Load a bad XML file, make sure that we don't crash in endless recursion
+		DOMConfigurator::configure(LOG4CXX_TEST_STR("input/xml/DOMConfiguratorRecursive.xml"));
 	}
 };
 

--- a/src/test/resources/input/xml/DOMConfiguratorRecursive.xml
+++ b/src/test/resources/input/xml/DOMConfiguratorRecursive.xml
@@ -1,0 +1,10 @@
+<log4j:configuration xmlns:log4j=" ">
+  <appender class="AsyncAppender">
+    <appender-ref/>
+  </appender>
+
+  <logger>
+    <appender-ref/>
+  </logger>
+
+</log4j:configuration>


### PR DESCRIPTION
If an appender-ref tag is added with no ref, parsing the XML file gets stuck in a recursive loop until the stack overflows.  Check to make sure that the ref attribute is in the XML file.