### PR TITLE
Fix out of bounds memory access

### DIFF
--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -85,7 +85,7 @@ LogString OptionConverter::convertSpecialChars(const LogString& s)
 	{
 		c = *i++;
 
-		if (c == 0x5C /* '\\' */)
+		if (i != s.end() && c == 0x5C /* '\\' */)
 		{
 			c =  *i++;
 


### PR DESCRIPTION
If the attribute for an XML entry is over 2000 characters long and happens to end with a \, the iterator can be incremented past the end of the string.