### PR TITLE
Restrict pattern layout min/max field width specifiers to 3 digits

### DIFF
--- a/src/main/cpp/patternparser.cpp
+++ b/src/main/cpp/patternparser.cpp
@@ -125,6 +125,7 @@ void PatternParser::parse(
 	int state = LITERAL_STATE;
 	logchar c;
 	size_t i = 0;
+	int minDigitCount{ 0 }, maxDigitCount{ 0 };
 	FormattingInfoPtr formattingInfo(FormattingInfo::getDefault());
 
 	while (i < patternLength)
@@ -198,6 +199,7 @@ void PatternParser::parse(
 										formattingInfo->isLeftAligned(), c - 0x30 /* '0' */,
 										formattingInfo->getMaxLength());
 							state = MIN_STATE;
+							minDigitCount = 1;
 						}
 						else
 						{
@@ -221,12 +223,13 @@ void PatternParser::parse(
 			case MIN_STATE:
 				currentLiteral.append(1, c);
 
-				if ((c >= 0x30 /* '0' */) && (c <= 0x39 /* '9' */))
+				if ((c >= 0x30 /* '0' */) && (c <= 0x39 /* '9' */) && minDigitCount < 3)
 				{
 					formattingInfo = std::make_shared<FormattingInfo>(
 								formattingInfo->isLeftAligned(),
 								(formattingInfo->getMinLength() * 10) + (c - 0x30 /* '0' */),
 								formattingInfo->getMaxLength());
+					++minDigitCount;
 				}
 				else if (c == 0x2E /* '.' */)
 				{
@@ -257,6 +260,7 @@ void PatternParser::parse(
 								formattingInfo->isLeftAligned(), formattingInfo->getMinLength(),
 								c - 0x30 /* '0' */);
 					state = MAX_STATE;
+					maxDigitCount = 1;
 				}
 				else
 				{
@@ -270,11 +274,12 @@ void PatternParser::parse(
 			case MAX_STATE:
 				currentLiteral.append(1, c);
 
-				if ((c >= 0x30 /* '0' */) && (c <= 0x39 /* '9' */))
+				if ((c >= 0x30 /* '0' */) && (c <= 0x39 /* '9' */) && maxDigitCount < 3)
 				{
 					formattingInfo = std::make_shared<FormattingInfo>(
 								formattingInfo->isLeftAligned(), formattingInfo->getMinLength(),
 								(formattingInfo->getMaxLength() * 10) + (c - 0x30 /* '0' */));
+					++maxDigitCount;
 				}
 				else
 				{

--- a/src/main/include/log4cxx/patternlayout.h
+++ b/src/main/include/log4cxx/patternlayout.h
@@ -283,7 +283,7 @@ LOG4CXX_LIST_DEF(FormattingInfoList, LOG4CXX_NS::pattern::FormattingInfoPtr);
  * <p>
  *  The first optional format modifier is the <em>left justification flag</em> which is
  *  just the minus (-) character. Then comes the optional <em>minimum field width</em>
- *  modifier. This is a decimal constant that represents the minimum number of characters
+ *  modifier. This is a 1 to 3 decimal digit constant that represents the minimum number of characters
  *  to output. If the data item requires fewer characters, it is padded on either the left
  *  or the right until the minimum width is reached. The default is to pad on the left
  *  (right justify) but you can specify right padding with the left justification flag. The
@@ -293,7 +293,7 @@ LOG4CXX_LIST_DEF(FormattingInfoList, LOG4CXX_NS::pattern::FormattingInfoPtr);
  *
  * <p>
  *  This behavior can be changed using the <em>maximum field width</em> modifier which is
- *  designated by a period followed by a decimal constant. If the data item is longer than
+ *  designated by a period followed by a 1 to 3 decimal digit constant. If the data item is longer than
  *  the maximum field, then the extra characters are removed from the <em>beginning</em> of
  *  the data item and not from the end. For example, it the maximum field width is eight
  *  and the data item is ten characters long, then the first two characters of the data

--- a/src/test/cpp/pattern/patternparsertestcase.cpp
+++ b/src/test/cpp/pattern/patternparsertestcase.cpp
@@ -80,6 +80,7 @@ LOGUNIT_CLASS(PatternParserTestCase)
 	LOGUNIT_TEST(testBasic2);
 	LOGUNIT_TEST(testMultiOption);
 	LOGUNIT_TEST(testThreadUsername);
+	LOGUNIT_TEST(testInvalidPatterns);
 	LOGUNIT_TEST_SUITE_END();
 
 	LoggingEventPtr event;
@@ -291,6 +292,16 @@ public:
 		assertFormattedEquals(LOG4CXX_STR("%relative %-5level [%threadname] %logger - %m%n"),
 			getFormatSpecifiers(),
 			expected);
+	}
+
+	void testInvalidPatterns()
+	{
+		assertFormattedEquals(LOG4CXX_STR("%6666c"),
+			getFormatSpecifiers(),
+			LOG4CXX_STR("%6666c"));
+		assertFormattedEquals(LOG4CXX_STR("%6.6666c"),
+			getFormatSpecifiers(),
+			LOG4CXX_STR("%6.6666c"));
 	}
 
 };


### PR DESCRIPTION
This PR proposes adding documentation and checks to avoid integer-overflow bugs.  