### PR TITLE
Prevent a fault when an option name has an emedded NUL character

### DIFF
--- a/src/main/cpp/stringhelper.cpp
+++ b/src/main/cpp/stringhelper.cpp
@@ -41,7 +41,7 @@ bool StringHelper::equalsIgnoreCase(const LogString& s1, const logchar* upper, c
 		++lower;
 	}
 
-	return 0 == *upper && iter == s1.end();
+	return 0 == *upper;
 }
 
 bool StringHelper::equalsIgnoreCase(const LogString& s1, const LogString& upper, const LogString& lower)

--- a/src/main/cpp/stringhelper.cpp
+++ b/src/main/cpp/stringhelper.cpp
@@ -30,7 +30,7 @@ using namespace LOG4CXX_NS::helpers;
 
 bool StringHelper::equalsIgnoreCase(const LogString& s1, const logchar* upper, const logchar* lower)
 {
-	for (auto& item : s1)
+	for (const auto& item : s1)
 	{
 		if (0 == item || // OSS-Fuzz makes strings with embedded NUL characters
 			(item != *upper && item != *lower))

--- a/src/main/cpp/stringhelper.cpp
+++ b/src/main/cpp/stringhelper.cpp
@@ -30,17 +30,18 @@ using namespace LOG4CXX_NS::helpers;
 
 bool StringHelper::equalsIgnoreCase(const LogString& s1, const logchar* upper, const logchar* lower)
 {
-	for (LogString::const_iterator iter = s1.begin();
-		iter != s1.end();
-		iter++, upper++, lower++)
+	for (auto& item : s1)
 	{
-		if (*iter != *upper && *iter != * lower)
+		if (0 == item || // OSS-Fuzz makes strings with embedded NUL characters
+			(item != *upper && item != *lower))
 		{
 			return false;
 		}
+		++upper;
+		++lower;
 	}
 
-	return (*upper == 0);
+	return 0 == *upper && iter == s1.end();
 }
 
 bool StringHelper::equalsIgnoreCase(const LogString& s1, const LogString& upper, const LogString& lower)


### PR DESCRIPTION
This PR addresses [this OSS-Fuzz issue](https://issues.oss-fuzz.com/issues/394331188)