### PR TITLE
Allow for use of either Qt5 or Qt6

### DIFF
--- a/.github/workflows/log4cxx-ubuntu.yml
+++ b/.github/workflows/log4cxx-ubuntu.yml
@@ -31,6 +31,7 @@ jobs:
             cxx: g++
             fmt: OFF
             qt: ON
+            qt6: OFF
             odbc: OFF
             multiprocess: ON
             multithread: OFF
@@ -42,6 +43,7 @@ jobs:
             cxx: clang++
             fmt: ON
             qt: OFF
+            qt6: OFF
             odbc: ON
             multiprocess: OFF
             multithread: OFF
@@ -52,7 +54,8 @@ jobs:
             os: ubuntu-22.04
             cxx: g++
             fmt: OFF
-            qt: OFF
+            qt: ON
+            qt6: ON
             odbc: OFF
             multiprocess: OFF
             multithread: ON
@@ -64,6 +67,7 @@ jobs:
             cxx: clang++
             fmt: ON
             qt: OFF
+            qt6: OFF
             odbc: OFF
             multiprocess: OFF
             multithread: ON
@@ -83,7 +87,8 @@ jobs:
         sudo apt-get install -y libapr1-dev libaprutil1-dev
         if [ ${{ matrix.fmt }} == ON ]; then sudo apt-get install -y libfmt-dev; fi
         if [ ${{ matrix.odbc }} == ON ]; then sudo apt-get install -y unixodbc-dev; fi
-        if [ ${{ matrix.qt }} == ON ]; then sudo apt-get install -y qtbase5-dev; fi
+        if [ ${{ matrix.qt }} == ON && ${{ matrix.qt6 }} == OFF ]; then sudo apt-get install -y qtbase5-dev; fi
+        if [ ${{ matrix.qt }} == ON && ${{ matrix.qt6 }} == ON ]; then sudo apt-get install -y qt6-base-dev; fi
 
     - name: WORKAROUND FOR https://github.com/actions/runner-images/issues/8659
       if: |

--- a/src/main/cpp-qt/CMakeLists.txt
+++ b/src/main/cpp-qt/CMakeLists.txt
@@ -17,7 +17,8 @@
 
 # Log4cxx Qt support, if enabled
 if(LOG4CXX_QT_SUPPORT)
-    find_package(Qt5 COMPONENTS Core REQUIRED)
+    find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
 
     add_library(log4cxx-qt)
     if(BUILD_SHARED_LIBS)
@@ -27,7 +28,7 @@ if(LOG4CXX_QT_SUPPORT)
     endif()
     add_dependencies(log4cxx-qt log4cxx-qt-include)
     target_compile_definitions(log4cxx-qt PRIVATE "QT_NO_KEYWORDS")
-    target_link_libraries(log4cxx-qt Qt5::Core log4cxx)
+    target_link_libraries(log4cxx-qt Qt${QT_VERSION_MAJOR}::Core log4cxx)
     target_sources(log4cxx-qt
         PRIVATE
         messagehandler.cpp

--- a/src/main/cpp/loglog.cpp
+++ b/src/main/cpp/loglog.cpp
@@ -92,7 +92,7 @@ void LogLog::debug(const LogString& msg)
 
 		std::lock_guard<std::mutex> lock(p->mutex);
 
-		emit(msg);
+		emit_log(msg);
 	}
 }
 
@@ -105,8 +105,8 @@ void LogLog::debug(const LogString& msg, const std::exception& e)
 			return;
 
 		std::lock_guard<std::mutex> lock(p->mutex);
-		emit(msg);
-		emit(e);
+		emit_log(msg);
+		emit_log(e);
 	}
 }
 
@@ -118,7 +118,7 @@ void LogLog::error(const LogString& msg)
 	{
 		std::lock_guard<std::mutex> lock(p->mutex);
 
-		emit(msg);
+		emit_log(msg);
 	}
 }
 
@@ -128,8 +128,8 @@ void LogLog::error(const LogString& msg, const std::exception& e)
 	if (p && !p->quietMode) // Not deleted by onexit processing?
 	{
 		std::lock_guard<std::mutex> lock(p->mutex);
-		emit(msg);
-		emit(e);
+		emit_log(msg);
+		emit_log(e);
 	}
 }
 
@@ -147,7 +147,7 @@ void LogLog::warn(const LogString& msg)
 	if (p && !p->quietMode) // Not deleted by onexit processing?
 	{
 		std::lock_guard<std::mutex> lock(p->mutex);
-		emit(msg);
+		emit_log(msg);
 	}
 }
 
@@ -157,12 +157,12 @@ void LogLog::warn(const LogString& msg, const std::exception& e)
 	if (p && !p->quietMode) // Not deleted by onexit processing?
 	{
 		std::lock_guard<std::mutex> lock(p->mutex);
-		emit(msg);
-		emit(e);
+		emit_log(msg);
+		emit_log(e);
 	}
 }
 
-void LogLog::emit(const LogString& msg)
+void LogLog::emit_log(const LogString& msg)
 {
 	LogString out(LOG4CXX_STR("log4cxx: "));
 
@@ -172,7 +172,7 @@ void LogLog::emit(const LogString& msg)
 	SystemErrWriter::write(out);
 }
 
-void LogLog::emit(const std::exception& ex)
+void LogLog::emit_log(const std::exception& ex)
 {
 	LogString out(LOG4CXX_STR("log4cxx: "));
 	const char* raw = ex.what();

--- a/src/main/include/log4cxx/helpers/loglog.h
+++ b/src/main/include/log4cxx/helpers/loglog.h
@@ -102,8 +102,8 @@ class LOG4CXX_EXPORT LogLog
 		static void warn(const LogString&  msg, const std::exception& ex);
 
 	private:
-		static void emit(const LogString& msg);
-		static void emit(const std::exception& ex);
+		static void emit_log(const LogString& msg);
+		static void emit_log(const std::exception& ex);
 };
 }  // namespace helpers
 } // namespace log4cxx


### PR DESCRIPTION
Since Qt `#defines emit`, the `LogLog` class fails to compile properly as the function prototype no longer exists.

Oddly this works fine in Qt5, but it breaks with Qt6.  We can work around it with defining `QT_NO_KEYWORDS`, but this would require anybody who links with us and with Qt to define this as well, which is not a good requirement for a library.