### PR TITLE
Ensure log events are sent to an appender during a reconfiguration event

### DIFF
--- a/src/main/cpp/appenderattachableimpl.cpp
+++ b/src/main/cpp/appenderattachableimpl.cpp
@@ -167,4 +167,37 @@ void AppenderAttachableImpl::removeAppender(const LogString& name)
 	}
 }
 
+bool AppenderAttachableImpl::replaceAppender(const AppenderPtr& oldAppender, const AppenderPtr& newAppender)
+{
+	bool found = false;
+	if (m_priv && oldAppender && newAppender)
+	{
+		auto oldName = oldAppender->getName();
+		std::lock_guard<std::mutex> lock( m_priv->m_mutex );
+		auto it = std::find_if(m_priv->appenderList.begin(), m_priv->appenderList.end()
+			, [&oldName](const AppenderPtr& appender) -> bool
+			{
+				return oldName == appender->getName();
+			});
+		if (it != m_priv->appenderList.end())
+		{
+			m_priv->appenderList.erase(it);
+			m_priv->appenderList.push_back(newAppender);
+			found = true;
+		}
+	}
+	return found;
+}
+
+void AppenderAttachableImpl::replaceAppenders(const AppenderList& newList)
+{
+	auto oldAppenders = getAllAppenders();
+	if (!m_priv)
+		m_priv = std::make_unique<AppenderAttachableImpl::priv_data>();
+	std::lock_guard<std::mutex> lock( m_priv->m_mutex );
+	for (auto a : oldAppenders)
+		a->close();
+	m_priv->appenderList = newList;
+}
+
 

--- a/src/main/cpp/appenderattachableimpl.cpp
+++ b/src/main/cpp/appenderattachableimpl.cpp
@@ -181,8 +181,7 @@ bool AppenderAttachableImpl::replaceAppender(const AppenderPtr& oldAppender, con
 			});
 		if (it != m_priv->appenderList.end())
 		{
-			m_priv->appenderList.erase(it);
-			m_priv->appenderList.push_back(newAppender);
+			*it = newAppender;
 			found = true;
 		}
 	}

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -413,6 +413,16 @@ void AsyncAppender::removeAppender(const LogString& n)
 	priv->appenders.removeAppender(n);
 }
 
+bool AsyncAppender::replaceAppender(const AppenderPtr& oldAppender, const AppenderPtr& newAppender)
+{
+	return priv->appenders.replaceAppender(oldAppender, newAppender);
+}
+
+void AsyncAppender::replaceAppenders( const AppenderList& newList)
+{
+	priv->appenders.replaceAppenders(newList);
+}
+
 bool AsyncAppender::getLocationInfo() const
 {
 	return priv->locationInfo;

--- a/src/main/cpp/fallbackerrorhandler.cpp
+++ b/src/main/cpp/fallbackerrorhandler.cpp
@@ -94,7 +94,7 @@ void FallbackErrorHandler::error(const LogString& message,
 		}
 		if (!l->replaceAppender(primaryLocked, backupLocked))
 		{
-			LogLog::warn(LOG4CXX_STR("FB: Failed to replace [")
+			LogLog::debug(LOG4CXX_STR("FB: Failed to replace [")
 				+ primaryLocked->getName() + LOG4CXX_STR("] with [")
 				+ backupLocked->getName() + LOG4CXX_STR("] in logger [")
 				+ l->getName() + LOG4CXX_STR("]."));

--- a/src/main/cpp/fallbackerrorhandler.cpp
+++ b/src/main/cpp/fallbackerrorhandler.cpp
@@ -87,22 +87,18 @@ void FallbackErrorHandler::error(const LogString& message,
 	{
 		if (LogLog::isDebugEnabled())
 		{
-			LogLog::debug(((LogString) LOG4CXX_STR("FB: Searching for ["))
-				+ primaryLocked->getName() + LOG4CXX_STR("] in logger [")
-				+ l->getName() + LOG4CXX_STR("]."));
-			LogLog::debug(((LogString) LOG4CXX_STR("FB: Replacing ["))
-				+ primaryLocked->getName() + LOG4CXX_STR("] by [")
+			LogLog::debug(LOG4CXX_STR("FB: Replacing [")
+				+ primaryLocked->getName() + LOG4CXX_STR("] with [")
 				+ backupLocked->getName() + LOG4CXX_STR("] in logger [")
 				+ l->getName() + LOG4CXX_STR("]."));
 		}
-		l->removeAppender(primaryLocked);
-		if (LogLog::isDebugEnabled())
+		if (!l->replaceAppender(primaryLocked, backupLocked))
 		{
-			LogLog::debug(((LogString) LOG4CXX_STR("FB: Adding appender ["))
-				+ backupLocked->getName() + LOG4CXX_STR("] to logger ")
-				+ l->getName());
+			LogLog::warn(LOG4CXX_STR("FB: Failed to replace [")
+				+ primaryLocked->getName() + LOG4CXX_STR("] with [")
+				+ backupLocked->getName() + LOG4CXX_STR("] in logger [")
+				+ l->getName() + LOG4CXX_STR("]."));
 		}
-		l->addAppender(backupLocked);
 	}
 	m_priv->errorReported = true;
 }

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -253,11 +253,9 @@ void RollingFileAppender::activateOptions(Pool& p)
 
 			FileAppender::activateOptionsInternal(p);
 		}
-		catch (std::exception&)
+		catch (std::exception& ex)
 		{
-			LogLog::warn(
-				LogString(LOG4CXX_STR("Exception will initializing RollingFileAppender named "))
-				+ getName());
+			LogLog::warn(LOG4CXX_STR("Exception activating RollingFileAppender ") + getName(), ex);
 		}
 	}
 }

--- a/src/main/include/log4cxx/asyncappender.h
+++ b/src/main/include/log4cxx/asyncappender.h
@@ -153,6 +153,17 @@ class LOG4CXX_EXPORT AsyncAppender :
 		void removeAppender(const LogString& name) override;
 
 		/**
+		 * Replace \c oldAppender  with \c newAppender.
+		 * @return true if oldAppender was replaced with newAppender.
+		 */
+		bool replaceAppender(const AppenderPtr& oldAppender, const AppenderPtr& newAppender) LOG4CXX_16_VIRTUAL_SPECIFIER;
+
+		/**
+		 * Replace any previously added appenders with \c newList.
+		 */
+		void replaceAppenders(const AppenderList& newList) LOG4CXX_16_VIRTUAL_SPECIFIER;
+
+		/**
 		* The <b>LocationInfo</b> attribute is provided for compatibility
 		* with log4j and has no effect on the log output.
 		* @param flag new value.

--- a/src/main/include/log4cxx/helpers/appenderattachableimpl.h
+++ b/src/main/include/log4cxx/helpers/appenderattachableimpl.h
@@ -101,6 +101,17 @@ class LOG4CXX_EXPORT AppenderAttachableImpl :
 		 */
 		void removeAppender(const LogString& name) override;
 
+		/**
+		 * Replace \c oldAppender  with \c newAppender.
+		 * @return true if oldAppender was replaced with newAppender.
+		 */
+		bool replaceAppender(const AppenderPtr& oldAppender, const AppenderPtr& newAppender) LOG4CXX_16_VIRTUAL_SPECIFIER;
+
+		/**
+		 * Replace any previously added appenders with \c newList.
+		 */
+		void replaceAppenders(const AppenderList& newList) LOG4CXX_16_VIRTUAL_SPECIFIER;
+
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(priv_data, m_priv)
 

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -788,8 +788,7 @@ class LOG4CXX_EXPORT Logger
 		Return the the LoggerRepository where this
 		<code>Logger</code> is attached.
 		*/
-		LOG4CXX_NS::spi::LoggerRepository* getLoggerRepository() const;
-
+		spi::LoggerRepository* getLoggerRepository() const;
 
 		/**
 		* Get the logger name.
@@ -1792,6 +1791,17 @@ class LOG4CXX_EXPORT Logger
 		void removeAppender(const LogString& name) override;
 
 		/**
+		 * Replace \c oldAppender  with \c newAppender.
+		 * @return true if oldAppender was replaced with newAppender.
+		 */
+		bool replaceAppender(const AppenderPtr& oldAppender, const AppenderPtr& newAppender) LOG4CXX_16_VIRTUAL_SPECIFIER;
+
+		/**
+		 * Replace all previously added appenders with \c newList.
+		 */
+		void replaceAppenders(const AppenderList& newList) LOG4CXX_16_VIRTUAL_SPECIFIER;
+
+		/**
 		 Set the additivity flag for this logger.
 		  */
 		void setAdditivity(bool additive);
@@ -2095,12 +2105,13 @@ class LOG4CXX_EXPORT Logger
 		void trace(const std::string& msg) const;
 
 		/**
-		 * Reconfigure this logger by configuring all of the appenders.
+		 * Replace all current appenders with \c newList and
+		 * set the additivity flag to \c newAdditivity.
 		 *
-		 * @param appenders The appenders to set.  Any currently existing appenders are removed.
-		 * @param additivity The additivity of this logger
+		 * @param newList The appenders to set.
+		 * @param newAdditivity Whether this logger should send events to its parent.
 		 */
-		void reconfigure( const std::vector<AppenderPtr>& appenders, bool additivity );
+		void reconfigure( const AppenderList& newList, bool newAdditivity );
 
 	private:
 		//

--- a/src/main/include/log4cxx/spi/appenderattachable.h
+++ b/src/main/include/log4cxx/spi/appenderattachable.h
@@ -72,6 +72,19 @@ class LOG4CXX_EXPORT AppenderAttachable : public virtual helpers::Object
 		 */
 		virtual void removeAppender(const LogString& name) = 0;
 
+#if 15 < LOG4CXX_ABI_VERSION
+		/**
+		 * Replace \c oldAppender  with \c newAppender.
+		 * @return true if oldAppender was replaced with newAppender.
+		 */
+		virtual bool replaceAppender(const AppenderPtr& oldAppender, const AppenderPtr& newAppender) = 0;
+
+		/**
+		 * Replace any previously added appenders with \c newList.
+		 */
+		virtual void replaceAppenders(const AppenderList& newList) = 0;
+#endif
+
 		// Dtor
 		virtual ~AppenderAttachable() {}
 };
@@ -80,5 +93,10 @@ LOG4CXX_PTR_DEF(AppenderAttachable);
 }
 }
 
+#if 15 < LOG4CXX_ABI_VERSION
+#define LOG4CXX_16_VIRTUAL_SPECIFIER override
+#else
+#define LOG4CXX_16_VIRTUAL_SPECIFIER 
+#endif
 
 #endif //_LOG4CXX_SPI_APPENDER_ATTACHABLE_H_

--- a/src/test/cpp/varia/errorhandlertestcase.cpp
+++ b/src/test/cpp/varia/errorhandlertestcase.cpp
@@ -86,12 +86,12 @@ public:
 	void test1()
 	{
 		DOMConfigurator::configure("input/xml/fallback1.xml");
-		AppenderPtr appender = root->getAppender(LOG4CXX_STR("PRIMARY"));
-		FileAppenderPtr primary = log4cxx::cast<FileAppender>(appender);
-		log4cxx::varia::FallbackErrorHandlerPtr eh;
-		log4cxx::spi::ErrorHandlerPtr errHandle = primary->getErrorHandler();
-		eh = log4cxx::cast<log4cxx::varia::FallbackErrorHandler>(errHandle);
+		auto appender = root->getAppender(LOG4CXX_STR("PRIMARY"));
+		auto primary = log4cxx::cast<FileAppender>(appender);
+		auto errHandle = primary->getErrorHandler();
+		auto eh = log4cxx::cast<log4cxx::varia::FallbackErrorHandler>(errHandle);
 		LOGUNIT_ASSERT(eh != 0);
+
 		primary->setOption(LOG4CXX_STR("FILE"), BadPath);
 		Pool p;
 		primary->activateOptions(p);
@@ -128,12 +128,13 @@ public:
 	void test2()
 	{
 		DOMConfigurator::configure("input/xml/fallback2.xml");
-		AppenderPtr appender = root->getAppender(LOG4CXX_STR("PRIMARY"));
-		FileAppenderPtr primary = log4cxx::cast<FileAppender>(appender);
-		log4cxx::varia::FallbackErrorHandlerPtr eh;
-		log4cxx::spi::ErrorHandlerPtr errHandle = primary->getErrorHandler();
-		eh = log4cxx::cast<log4cxx::varia::FallbackErrorHandler>(errHandle);
+		auto appender = root->getAppender(LOG4CXX_STR("PRIMARY"));
+		auto primary = log4cxx::cast<FileAppender>(appender);
+		auto errHandle = primary->getErrorHandler();
+		auto eh = log4cxx::cast<varia::FallbackErrorHandler>(errHandle);
 		LOGUNIT_ASSERT(eh != 0);
+		
+		// Also check the logger named "test" for a reference to "PRIMARY" when "PRIMARY" fails
 		eh->setLogger(logger);
 
 		primary->setOption(LOG4CXX_STR("FILE"), BadPath);

--- a/src/test/cpp/varia/errorhandlertestcase.cpp
+++ b/src/test/cpp/varia/errorhandlertestcase.cpp
@@ -21,12 +21,27 @@
 #include <log4cxx/varia/fallbackerrorhandler.h>
 #include <log4cxx/appender.h>
 #include <log4cxx/helpers/loglog.h>
+#include <log4cxx/helpers/pool.h>
 #include "../logunit.h"
 #include "../util/transformer.h"
 #include "../util/compare.h"
 #include "../util/controlfilter.h"
 #include "../util/linenumberfilter.h"
 #include <iostream>
+
+namespace
+{
+	/*
+        The following path is carefully designed to fail on Linux and Windows,
+        so that the appender FALLBACK is used instead and the test succeeds in
+        the end. Linux considers "." as current directory, which can not be
+        created as a file, while Windows strips "/."[1] internally and fails at
+        ":", which is an invalid name.
+
+        [1]: https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
+	*/
+	log4cxx::LogString BadPath{ LOG4CXX_STR("output/xyz/:/.") };
+}
 
 using namespace log4cxx;
 using namespace log4cxx::helpers;
@@ -77,9 +92,12 @@ public:
 		log4cxx::spi::ErrorHandlerPtr errHandle = primary->getErrorHandler();
 		eh = log4cxx::cast<log4cxx::varia::FallbackErrorHandler>(errHandle);
 		LOGUNIT_ASSERT(eh != 0);
+		primary->setOption(LOG4CXX_STR("FILE"), BadPath);
+		Pool p;
+		primary->activateOptions(p);
+		LOGUNIT_ASSERT(eh->errorReported());
 
 		common();
-		LOGUNIT_ASSERT(eh->errorReported());
 
 		std::string TEST1_PAT =
 			"FALLBACK - (root|test) - Message {0-9}";
@@ -117,8 +135,13 @@ public:
 		eh = log4cxx::cast<log4cxx::varia::FallbackErrorHandler>(errHandle);
 		LOGUNIT_ASSERT(eh != 0);
 		eh->setLogger(logger);
-		common();
+
+		primary->setOption(LOG4CXX_STR("FILE"), BadPath);
+		Pool p;
+		primary->activateOptions(p);
 		LOGUNIT_ASSERT(eh->errorReported());
+
+		common();
 
 		std::string TEST1_PAT =
 			"FALLBACK - (root|test) - Message {0-9}";

--- a/src/test/resources/input/xml/fallback1.xml
+++ b/src/test/resources/input/xml/fallback1.xml
@@ -26,17 +26,7 @@
       <root-ref/>
       <appender-ref ref="FALLBACK" />
     </errorHandler>
-
-    <!--
-        The following path is carefully designed to fail on Linux and Windows,
-        so that the appender FALLBACK is used instead and the test succeeds in
-        the end. Linux considers "." as current directory, which can not be
-        created as a file, while Windows strips "/."[1] internally and fails at
-        ":", which is an invalid name.
-
-        [1]: https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
-    -->
-    <param name="File"      value="output/xyz/:/."   />
+    <param name="File"      value="output/xyz/x.log"   />
     <param name="Append"    value="false"            />
 
     <layout class="org.apache.log4j.PatternLayout">

--- a/src/test/resources/input/xml/fallback2.xml
+++ b/src/test/resources/input/xml/fallback2.xml
@@ -27,16 +27,7 @@
       <appender-ref ref="FALLBACK" />
     </errorHandler>
 
-    <!--
-        The following path is carefully designed to fail on Linux and Windows,
-        so that the appender FALLBACK is used instead and the test succeeds in
-        the end. Linux considers "." as current directory, which can not be
-        created as a file, while Windows strips "/."[1] internally and fails at
-        ":", which is an invalid name.
-
-        [1]: https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
-    -->
-    <param name="File"      value="output/xyz/:/."   />
+    <param name="File"      value="output/xyz/x.log"   />
     <param name="Append"    value="false"            />
 
     <layout class="org.apache.log4j.PatternLayout">


### PR DESCRIPTION
This PR addresses a race condition where an active thread sends an event to a Logger after the reconfiguration thread has removed all appenders but before the new appender list is established.

The new *replaceAppender* methods block event producing threads while the list of appenders is updated.

The modified test case [errorhandler test](https://github.com/apache/logging-log4cxx/compare/reconfiguration_synchronization?expand=1#diff-8d655beadcefc87795cfe34d8c7796085a484cb0b3ff8e5cc4d51d4145951ba3) previously used an invalid configuration to trigger the fallback handler. This fallback process (Installing the FALLBACK appender in place of the faulty PRIMARY appender) was happening during configuration, but the PRIMARY appender (with a NULL writer) was later being added to the root logger. After configuration the root logger had two appenders, one of which had a a NULL writer.

I believe the intent of the errorhandler test is in checking the fallback handling on any error, not specifically a faulty configuration.

The behaviour of Log4cxx when the configuration file is invalid should ideally be to leave the current configuration unchanged, as happens when the xml is not parsable. However doing this for other types of configuration errors is a larger job than I am attempting here.