### PR TITLE
Add SO_REUSEADDR to APRServerSocket

### DIFF
--- a/src/main/cpp/serversocket.cpp
+++ b/src/main/cpp/serversocket.cpp
@@ -51,6 +51,12 @@ void ServerSocket::setSoTimeout(int newVal)
 	m_priv->timeout = newVal;
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
 ServerSocketUniquePtr ServerSocket::create(int port){
 	return std::make_unique<APRServerSocket>(port);
+}
+#endif
+
+ServerSocketUniquePtr ServerSocket::create(int port, bool reuseAddress){
+	return std::make_unique<APRServerSocket>(port, reuseAddress);
 }

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -58,6 +58,7 @@ struct TelnetAppender::TelnetAppenderPriv : public AppenderSkeletonPrivate
 	{ stopAcceptingConnections(); }
 
 	int port;
+	bool reuseAddress = false;
 	ConnectionList connections;
 	LogString encoding;
 	LOG4CXX_NS::helpers::CharsetEncoderPtr encoder;
@@ -112,7 +113,7 @@ void TelnetAppender::activateOptions(Pool& /* p */)
 {
 	if (_priv->serverSocket == NULL)
 	{
-		_priv->serverSocket = ServerSocket::create(_priv->port);
+		_priv->serverSocket = ServerSocket::create(_priv->port, _priv->reuseAddress);
 		_priv->serverSocket->setSoTimeout(1000);
 	}
 
@@ -134,6 +135,10 @@ void TelnetAppender::setOption(const LogString& option,
 	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("ENCODING"), LOG4CXX_STR("encoding")))
 	{
 		setEncoding(value);
+	}
+	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("REUSEADDRESS"), LOG4CXX_STR("reuseaddress")))
+	{
+		setReuseAddress(OptionConverter::toBoolean(value, true));
 	}
 	else
 	{
@@ -356,6 +361,11 @@ void TelnetAppender::setMaxConnections(int newValue)
 			--_priv->activeConnections;
 		}
 	}
+}
+
+void TelnetAppender::setReuseAddress(bool reuseAddress)
+{
+	_priv->reuseAddress = reuseAddress;
 }
 
 bool TelnetAppender::requiresLayout() const

--- a/src/main/include/log4cxx/helpers/serversocket.h
+++ b/src/main/include/log4cxx/helpers/serversocket.h
@@ -57,7 +57,12 @@ class LOG4CXX_EXPORT ServerSocket
 		*/
 		void setSoTimeout(int timeout);
 
+#if LOG4CXX_ABI_VERSION <= 15
 		static ServerSocketUniquePtr create(int port);
+		static ServerSocketUniquePtr create(int port, bool reuseAddress);
+#else
+		static ServerSocketUniquePtr create(int port, bool reuseAddress = false);
+#endif
 
 };
 }  // namespace helpers

--- a/src/main/include/log4cxx/net/telnetappender.h
+++ b/src/main/include/log4cxx/net/telnetappender.h
@@ -42,6 +42,9 @@ especially when monitoring a servlet remotely.
 
 If no layout is provided, the log message only is sent to attached client(s).
 
+The ReuseAddress option is disabled by default,
+enable it if you want it to be able to bind to the address immediately after restarting / crashing
+
 See TelnetAppender::setOption() for the available options.
 
 */
@@ -96,6 +99,7 @@ class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 		Port | {int} | 23
 		MaxConnections | {int} | 20
 		Encoding | C,UTF-8,UTF-16,UTF-16BE,UTF-16LE,646,US-ASCII,ISO646-US,ANSI_X3.4-1968,ISO-8859-1,ISO-LATIN-1 | UTF-8
+		ReuseAddress | True,False | True
 
 		\sa AppenderSkeleton::setOption()
 		*/
@@ -125,6 +129,14 @@ class LOG4CXX_EXPORT TelnetAppender : public AppenderSkeleton
 		 */
 		void setMaxConnections(int newValue);
 
+		/**
+		Set the SO_REUSEADDR option to of the server socket.
+		This allows the socket to bind to an address that is in a TIME_WAIT state.
+		This is useful for restarting immediately after it has been closed.
+
+		\sa setOption
+		 */
+		void setReuseAddress(bool reuseAddress);
 
 		/** Shutdown this appender. */
 		void close() override;

--- a/src/main/include/log4cxx/private/aprserversocket.h
+++ b/src/main/include/log4cxx/private/aprserversocket.h
@@ -31,7 +31,12 @@ namespace helpers
 class LOG4CXX_EXPORT APRServerSocket : public helpers::ServerSocket
 {
         public:
+#if LOG4CXX_ABI_VERSION <= 15
             APRServerSocket(int port);
+            APRServerSocket(int port, bool reuseAddress);
+#else
+            APRServerSocket(int port, bool reuseAddress = false);
+#endif
 
 	    void close() override;
 

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -80,7 +80,7 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 			helpers::ServerSocketUniquePtr serverSocket;
 			try
 			{
-				serverSocket = helpers::ServerSocket::create(tcpPort);
+				serverSocket = helpers::ServerSocket::create(tcpPort, true);
 			}
 			catch (std::exception& ex)
 			{

--- a/src/test/cpp/net/telnetappendertestcase.cpp
+++ b/src/test/cpp/net/telnetappendertestcase.cpp
@@ -105,6 +105,7 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 			TelnetAppenderPtr appender(new TelnetAppender());
 			appender->setPort(TEST_PORT);
 			appender->setMaxConnections(1);
+			appender->setReuseAddress(true);
 			Pool p;
 			appender->activateOptions(p);
 			LoggerPtr root(Logger::getRootLogger());


### PR DESCRIPTION
Setting SO_REUSEADDR by default allows server applications to restart and bind to the same address and port without waiting for the OS to fully clean up previous connections. This avoids the issue where we would get "address already in use" after restarting an application after a crash/...