### PR TITLE
multiprocessrollingtest in macOS: fix compilation and the test itself

### DIFF
--- a/.github/workflows/log4cxx-macos.yml
+++ b/.github/workflows/log4cxx-macos.yml
@@ -31,16 +31,19 @@ jobs:
             cxx: clang++
             odbc: OFF
             qt: ON
+            multiprocess: OFF
           - name: osx-14
             os: macos-14
             cxx: clang++
             odbc: ON
             qt: OFF
+            multiprocess: ON
           - name: osx-g++
             os: macos-latest
             cxx: g++-14
             odbc: OFF
             qt: OFF
+            multiprocess: OFF
 
     steps:
     - uses: actions/checkout@v4
@@ -59,7 +62,13 @@ jobs:
         cd main
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DLOG4CXX_ENABLE_ODBC=${{ matrix.odbc }} -DLOG4CXX_CFSTRING=ON -DCMAKE_BUILD_TYPE=Debug ..
+        cmake \
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+          -DLOG4CXX_ENABLE_ODBC=${{ matrix.odbc }} \
+          -DLOG4CXX_MULTIPROCESS_ROLLING_FILE_APPENDER=${{ matrix.multiprocess }} \
+          -DLOG4CXX_CFSTRING=ON \
+          -DCMAKE_BUILD_TYPE=Debug \
+          ..
         cmake --build .
 
     - name: run unit tests


### PR DESCRIPTION
Fixes apache#501:
1. Add necessary `#include`s to get the per-platform calls in `GetExecutableFileName()` to compile.
2. Fix buffer size passed to `_NSGetExecutablePath()` in macOS.

Plus:
A. Add more diagnostics for test failures like this.
B. Add useful TODO comments.

Also fix some linter warnings:
a. 3 signed-unsigned comparison mismatches;
b. 1 possibly unused variable.