### PR TITLE
Prevent SonarCloud warning

### DIFF
--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -48,6 +48,9 @@ public: // ...structors
 	SingletonHolder(Args&& ... args)
 		: m_data(std::forward<Args>(args) ... )
 	{}
+    // Prevent copying
+    SingletonHolder(const SingletonHolder&) = delete;
+    SingletonHolder(SingletonHolder&&) = delete;
 
 public: // Accessors
 	T& value() { return m_data; }


### PR DESCRIPTION
This PR prevents the forwarding constructor from being used to copy or move objects of the same type