### PR TITLE
Prevent SonarCloud warning

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,8 +18,8 @@ on:
   push:
     branches:
       - master
-#  pull_request:
-#    types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -94,6 +94,6 @@ jobs:
           # Consult https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/ for more information and options
           args: >
             --define sonar.host.url="${{ env.SONAR_SERVER_URL }}"
-            --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+            --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" 
             --define sonar.coverageReportPaths=build/coverage.xml
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,8 +18,8 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, synchronize, reopened]
+#  pull_request:
+#    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -45,7 +45,7 @@ public: // Object method stubs
 public: // ...structors
 	SingletonHolder() {}
 	template < typename ... Args
-	         , typename = std::enable_if<!std::is_same<std::decay<T>::type, SingletonHolder>::value>::type
+	         , typename = std::enable_if<!std::is_same<std::decay<T>::type, SingletonHolder<T>>::value>::type
 	         >
 	SingletonHolder(Args&& ... args)
 		: m_data(std::forward<Args>(args) ... )

--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -45,7 +45,7 @@ public: // Object method stubs
 public: // ...structors
 	SingletonHolder() {}
 	template < typename ... Args
-	         , typename = std::enable_if<!std::is_same_v<std::decay_t<T>, SingletonHolder>>::type
+	         , typename = std::enable_if<!std::is_same<std::decay<T>::type, SingletonHolder>::value>::type
 	         >
 	SingletonHolder(Args&& ... args)
 		: m_data(std::forward<Args>(args) ... )

--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -45,7 +45,7 @@ public: // Object method stubs
 public: // ...structors
 	SingletonHolder() {}
 	template < typename Arg0, typename ... Args
-	         , typename = std::enable_if<!std::is_same<typename std::decay<Arg0>::type, SingletonHolder>::value>::type
+	         , typename = typename std::enable_if<!std::is_same<typename std::decay<Arg0>::type, SingletonHolder>::value>::type
 	         >
 	SingletonHolder(Arg0 arg0, Args&& ... args)
 		: m_data(arg0, std::forward<Args>(args) ... )

--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -44,13 +44,15 @@ public: // Object method stubs
 
 public: // ...structors
 	SingletonHolder() {}
-	template <typename ... Args>
+	template <typename ... Args
+	         , typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, SingletonHolder>>
+	         >
 	SingletonHolder(Args&& ... args)
 		: m_data(std::forward<Args>(args) ... )
 	{}
-    // Prevent copying
-    SingletonHolder(const SingletonHolder&) = delete;
-    SingletonHolder(SingletonHolder&&) = delete;
+	// Prevent copying
+	SingletonHolder(const SingletonHolder&) = delete;
+	SingletonHolder(SingletonHolder&&) = delete;
 
 public: // Accessors
 	T& value() { return m_data; }

--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -44,8 +44,8 @@ public: // Object method stubs
 
 public: // ...structors
 	SingletonHolder() {}
-	template <typename ... Args
-	         , typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, SingletonHolder>>
+	template < typename ... Args
+	         , typename = std::enable_if<!std::is_same_v<std::decay_t<T>, SingletonHolder>>::type
 	         >
 	SingletonHolder(Args&& ... args)
 		: m_data(std::forward<Args>(args) ... )

--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -44,11 +44,11 @@ public: // Object method stubs
 
 public: // ...structors
 	SingletonHolder() {}
-	template < typename ... Args
-	         , typename = std::enable_if<!std::is_same<std::decay<T>::type, SingletonHolder<T>>::value>::type
+	template < typename Arg0, typename ... Args
+	         , typename = std::enable_if<!std::is_same<std::decay<Arg0>::type, SingletonHolder>::value>::type
 	         >
-	SingletonHolder(Args&& ... args)
-		: m_data(std::forward<Args>(args) ... )
+	SingletonHolder(Arg0 arg0, Args&& ... args)
+		: m_data(arg0, std::forward<Args>(args) ... )
 	{}
 	// Prevent copying
 	SingletonHolder(const SingletonHolder&) = delete;

--- a/src/main/include/log4cxx/helpers/singletonholder.h
+++ b/src/main/include/log4cxx/helpers/singletonholder.h
@@ -45,7 +45,7 @@ public: // Object method stubs
 public: // ...structors
 	SingletonHolder() {}
 	template < typename Arg0, typename ... Args
-	         , typename = std::enable_if<!std::is_same<std::decay<Arg0>::type, SingletonHolder>::value>::type
+	         , typename = std::enable_if<!std::is_same<typename std::decay<Arg0>::type, SingletonHolder>::value>::type
 	         >
 	SingletonHolder(Arg0 arg0, Args&& ... args)
 		: m_data(arg0, std::forward<Args>(args) ... )


### PR DESCRIPTION
This PR addresses the warning "Property 'sonar.cfamily.build-wrapper-output' is deprecated; build-wrapper now generates a compilation database."