### PR TITLE
Remove unnecessary static data in the next ABI version

### DIFF
--- a/src/main/cpp/fileinputstream.cpp
+++ b/src/main/cpp/fileinputstream.cpp
@@ -19,12 +19,8 @@
 #include <log4cxx/helpers/fileinputstream.h>
 #include <log4cxx/helpers/exception.h>
 #include <log4cxx/helpers/bytebuffer.h>
+#include <log4cxx/helpers/pool.h>
 #include <apr_file_io.h>
-#include <log4cxx/helpers/transcoder.h>
-#if !defined(LOG4CXX)
-	#define LOG4CXX 1
-#endif
-#include <log4cxx/helpers/aprinitializer.h>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
@@ -82,7 +78,7 @@ FileInputStream::FileInputStream(const File& aFile) :
 
 FileInputStream::~FileInputStream()
 {
-	if (m_priv->fileptr != NULL && !APRInitializer::isDestructed)
+	if (m_priv->fileptr)
 	{
 		apr_file_close(m_priv->fileptr);
 	}

--- a/src/main/cpp/fileoutputstream.cpp
+++ b/src/main/cpp/fileoutputstream.cpp
@@ -17,14 +17,10 @@
 
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/fileoutputstream.h>
+#include <log4cxx/helpers/pool.h>
 #include <log4cxx/helpers/exception.h>
 #include <log4cxx/helpers/bytebuffer.h>
 #include <apr_file_io.h>
-#include <log4cxx/helpers/transcoder.h>
-#if !defined(LOG4CXX)
-	#define LOG4CXX 1
-#endif
-#include <log4cxx/helpers/aprinitializer.h>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
@@ -81,7 +77,7 @@ apr_file_t* FileOutputStream::open(const LogString& filename,
 
 FileOutputStream::~FileOutputStream()
 {
-	if (m_priv->fileptr != NULL && !APRInitializer::isDestructed)
+	if (m_priv->fileptr)
 	{
 		apr_file_close(m_priv->fileptr);
 	}
@@ -89,7 +85,7 @@ FileOutputStream::~FileOutputStream()
 
 void FileOutputStream::close(Pool& /* p */)
 {
-	if (m_priv->fileptr != NULL)
+	if (m_priv->fileptr)
 	{
 		apr_status_t stat = apr_file_close(m_priv->fileptr);
 

--- a/src/main/cpp/threadspecificdata.cpp
+++ b/src/main/cpp/threadspecificdata.cpp
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <algorithm>
 #include <thread>
+#include <mutex>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;

--- a/src/main/cpp/threadspecificdata.cpp
+++ b/src/main/cpp/threadspecificdata.cpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <thread>
 #include <mutex>
+#include <list>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;

--- a/src/main/include/log4cxx/helpers/aprinitializer.h
+++ b/src/main/include/log4cxx/helpers/aprinitializer.h
@@ -23,34 +23,32 @@
 #endif
 
 #include <log4cxx/helpers/object.h>
-#include <list>
-#include <log4cxx/helpers/date.h>
 #include <log4cxx/helpers/widelife.h>
 
 extern "C" {
 	struct apr_threadkey_t;
 	struct apr_pool_t;
 }
-
-#include <mutex>
 #include <functional>
 
 namespace LOG4CXX_NS
 {
 namespace helpers
 {
+#if LOG4CXX_ABI_VERSION <= 15
 class FileWatchdog;
+#endif
 
 class APRInitializer
 {
 	public:
 #if LOG4CXX_ABI_VERSION <= 15
 		static log4cxx_time_t initialize();
+		static bool isDestructed;
 #endif
 		static apr_pool_t* getRootPool();
 		static log4cxx_time_t getStartTime();
 		static apr_threadkey_t* getTlsKey();
-		static bool isDestructed;
 
 #if LOG4CXX_ABI_VERSION <= 15
 		/**

--- a/src/main/include/log4cxx/helpers/fileinputstream.h
+++ b/src/main/include/log4cxx/helpers/fileinputstream.h
@@ -20,7 +20,6 @@
 
 #include <log4cxx/helpers/inputstream.h>
 #include <log4cxx/file.h>
-#include <log4cxx/helpers/pool.h>
 #include <memory>
 
 namespace LOG4CXX_NS
@@ -81,9 +80,10 @@ class LOG4CXX_EXPORT FileInputStream : public InputStream
 
 	private:
 
-		FileInputStream(const FileInputStream&);
+		FileInputStream(const FileInputStream&) = delete;
+		FileInputStream(FileInputStream&&) = delete;
 
-		FileInputStream& operator=(const FileInputStream&);
+		FileInputStream& operator=(const FileInputStream&) = delete;
 		void open(const LogString&);
 
 };

--- a/src/main/include/log4cxx/helpers/fileoutputstream.h
+++ b/src/main/include/log4cxx/helpers/fileoutputstream.h
@@ -20,7 +20,6 @@
 
 #include <log4cxx/helpers/outputstream.h>
 #include <log4cxx/file.h>
-#include <log4cxx/helpers/pool.h>
 
 
 namespace LOG4CXX_NS
@@ -55,8 +54,9 @@ class LOG4CXX_EXPORT FileOutputStream : public OutputStream
 		apr_file_t* getFilePtr() const;
 
 	private:
-		FileOutputStream(const FileOutputStream&);
-		FileOutputStream& operator=(const FileOutputStream&);
+		FileOutputStream(const FileOutputStream&) = delete;
+		FileOutputStream(FileOutputStream&&) = delete;
+		FileOutputStream& operator=(const FileOutputStream&) = delete;
 		static apr_file_t* open(const LogString& fn, bool append,
 			LOG4CXX_NS::helpers::Pool& p);
 };


### PR DESCRIPTION
This PR prepares for the next ABI version.

The no longer required guard bool `APRInitializer::isDestructed` (introduced in 2005) will be removed in the next ABI version.