### PR TITLE
Simplify WriterAppender interface in the next ABI version

### DIFF
--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -323,7 +323,7 @@ void FileAppender::setFileInternal(
 
 	try
 	{
-		outStream = FileOutputStreamPtr(new FileOutputStream(filename, append1));
+		outStream = std::make_shared<FileOutputStream>(filename, append1);
 	}
 	catch (IOException&)
 	{
@@ -336,7 +336,7 @@ void FileAppender::setFileInternal(
 
 			if (!parentDir.exists(p) && parentDir.mkdirs(p))
 			{
-				outStream = OutputStreamPtr(new FileOutputStream(filename, append1));
+				outStream = std::make_shared<FileOutputStream>(filename, append1);
 			}
 			else
 			{

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -428,7 +428,7 @@ void MultiprocessRollingFileAppender::subAppend(const LoggingEventPtr& event, Po
  @param os output stream, may not be null.
  @return new writer.
  */
-WriterPtr MultiprocessRollingFileAppender::createWriter(const OutputStreamPtr& os)
+WriterPtr MultiprocessRollingFileAppender::createWriter(LOG4CXX_16_CONST OutputStreamPtr& os)
 {
 	auto fos = LOG4CXX_NS::cast<FileOutputStream>(os);
 	if( fos )

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -428,7 +428,7 @@ void MultiprocessRollingFileAppender::subAppend(const LoggingEventPtr& event, Po
  @param os output stream, may not be null.
  @return new writer.
  */
-WriterPtr MultiprocessRollingFileAppender::createWriter(OutputStreamPtr& os)
+WriterPtr MultiprocessRollingFileAppender::createWriter(const OutputStreamPtr& os)
 {
 	auto fos = LOG4CXX_NS::cast<FileOutputStream>(os);
 	if( fos )

--- a/src/main/cpp/outputstreamwriter.cpp
+++ b/src/main/cpp/outputstreamwriter.cpp
@@ -27,38 +27,43 @@ using namespace LOG4CXX_NS::helpers;
 
 IMPLEMENT_LOG4CXX_OBJECT(OutputStreamWriter)
 
-struct OutputStreamWriter::OutputStreamWriterPrivate{
-	OutputStreamWriterPrivate(OutputStreamPtr& out1) : out(out1), enc(CharsetEncoder::getDefaultEncoder()){}
-
-	OutputStreamWriterPrivate(OutputStreamPtr& out1,
-							  CharsetEncoderPtr& enc1)
-		: out(out1), enc(enc1){}
+struct OutputStreamWriter::OutputStreamWriterPrivate
+{
+	OutputStreamWriterPrivate
+		( const OutputStreamPtr& out1
+		, const CharsetEncoderPtr& enc1 = CharsetEncoder::getDefaultEncoder()
+		)
+		: out(out1)
+		, enc(enc1)
+		{}
 
 	OutputStreamPtr out;
 	CharsetEncoderPtr enc;
 };
 
-OutputStreamWriter::OutputStreamWriter(OutputStreamPtr& out1)
-	: m_priv(std::make_unique<OutputStreamWriterPrivate>(out1))
+OutputStreamWriter::OutputStreamWriter(const OutputStreamPtr& out)
+	: m_priv(std::make_unique<OutputStreamWriterPrivate>(out))
 {
-	if (out1 == 0)
+	if (!out)
 	{
-		throw NullPointerException(LOG4CXX_STR("out parameter may not be null."));
+		throw NullPointerException(LOG4CXX_STR("OutputStream parameter may not be null."));
 	}
 }
 
-OutputStreamWriter::OutputStreamWriter(OutputStreamPtr& out1,
-	CharsetEncoderPtr& enc1)
-	: m_priv(std::make_unique<OutputStreamWriterPrivate>(out1, enc1))
+OutputStreamWriter::OutputStreamWriter
+	( const OutputStreamPtr& out
+	, const CharsetEncoderPtr& enc
+	)
+	: m_priv(std::make_unique<OutputStreamWriterPrivate>(out, enc))
 {
-	if (out1 == 0)
+	if (!out)
 	{
-		throw NullPointerException(LOG4CXX_STR("out parameter may not be null."));
+		throw NullPointerException(LOG4CXX_STR("OutputStream parameter may not be null."));
 	}
 
-	if (enc1 == 0)
+	if (!enc)
 	{
-		throw NullPointerException(LOG4CXX_STR("enc parameter may not be null."));
+		throw NullPointerException(LOG4CXX_STR("CharsetEncoder parameter may not be null."));
 	}
 }
 

--- a/src/main/cpp/outputstreamwriter.cpp
+++ b/src/main/cpp/outputstreamwriter.cpp
@@ -41,7 +41,7 @@ struct OutputStreamWriter::OutputStreamWriterPrivate
 	CharsetEncoderPtr enc;
 };
 
-OutputStreamWriter::OutputStreamWriter(const OutputStreamPtr& out)
+OutputStreamWriter::OutputStreamWriter(LOG4CXX_16_CONST OutputStreamPtr& out)
 	: m_priv(std::make_unique<OutputStreamWriterPrivate>(out))
 {
 	if (!out)
@@ -51,8 +51,8 @@ OutputStreamWriter::OutputStreamWriter(const OutputStreamPtr& out)
 }
 
 OutputStreamWriter::OutputStreamWriter
-	( const OutputStreamPtr& out
-	, const CharsetEncoderPtr& enc
+	( LOG4CXX_16_CONST OutputStreamPtr& out
+	, LOG4CXX_16_CONST CharsetEncoderPtr& enc
 	)
 	: m_priv(std::make_unique<OutputStreamWriterPrivate>(out, enc))
 {

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -357,7 +357,7 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 							setFileInternal(rollover1->getActiveFileName());
 							// Call activateOptions to create any intermediate directories(if required)
 							FileAppender::activateOptionsInternal(p);
-							auto os = std::make_shared<FileOutputStream>
+							OutputStreamPtr os = std::make_shared<FileOutputStream>
 									( rollover1->getActiveFileName()
 									, rollover1->getAppend()
 									);
@@ -570,7 +570,7 @@ class CountingOutputStream : public OutputStream
  @param os output stream, may not be null.
  @return new writer.
  */
-WriterPtr RollingFileAppender::createWriter(const OutputStreamPtr& os)
+WriterPtr RollingFileAppender::createWriter(LOG4CXX_16_CONST OutputStreamPtr& os)
 {
 	OutputStreamPtr cos = std::make_shared<CountingOutputStream>(os, this);
 	return FileAppender::createWriter(cos);

--- a/src/main/cpp/writerappender.cpp
+++ b/src/main/cpp/writerappender.cpp
@@ -36,18 +36,26 @@ WriterAppender::WriterAppender() :
 {
 }
 
-WriterAppender::WriterAppender(const LayoutPtr& layout1,
-	LOG4CXX_NS::helpers::WriterPtr& writer1)
-	: AppenderSkeleton (std::make_unique<WriterAppenderPriv>(layout1, writer1))
+#if LOG4CXX_ABI_VERSION <= 15
+WriterAppender::WriterAppender(const LayoutPtr& layout, helpers::WriterPtr& writer)
+	: AppenderSkeleton (std::make_unique<WriterAppenderPriv>(layout, writer))
 {
 	Pool p;
 	activateOptions(p);
 }
 
-WriterAppender::WriterAppender(const LayoutPtr& layout1)
-	: AppenderSkeleton (std::make_unique<WriterAppenderPriv>(layout1))
+WriterAppender::WriterAppender(const LayoutPtr& layout)
+	: AppenderSkeleton (std::make_unique<WriterAppenderPriv>(layout))
 {
 }
+#else
+WriterAppender::WriterAppender(const LayoutPtr& layout, const helpers::WriterPtr& writer)
+	: AppenderSkeleton(std::make_unique<WriterAppenderPriv>(layout, writer))
+{
+	Pool p;
+	activateOptions(p);
+}
+#endif
 
 WriterAppender::WriterAppender(std::unique_ptr<WriterAppenderPriv> priv)
 	: AppenderSkeleton (std::move(priv))
@@ -182,7 +190,7 @@ void WriterAppender::closeWriter()
    <code>encoding</code> property.  If the encoding value is
    specified incorrectly the writer will be opened using the default
    system encoding (an error message will be printed to the loglog.  */
-WriterPtr WriterAppender::createWriter(OutputStreamPtr& os)
+WriterPtr WriterAppender::createWriter(const OutputStreamPtr& os)
 {
 
 	LogString enc(getEncoding());
@@ -213,7 +221,7 @@ WriterPtr WriterAppender::createWriter(OutputStreamPtr& os)
 		}
 	}
 
-	return WriterPtr(new OutputStreamWriter(os, encoder));
+	return std::make_shared<OutputStreamWriter>(os, encoder);
 }
 
 LogString WriterAppender::getEncoding() const

--- a/src/main/cpp/writerappender.cpp
+++ b/src/main/cpp/writerappender.cpp
@@ -190,7 +190,7 @@ void WriterAppender::closeWriter()
    <code>encoding</code> property.  If the encoding value is
    specified incorrectly the writer will be opened using the default
    system encoding (an error message will be printed to the loglog.  */
-WriterPtr WriterAppender::createWriter(const OutputStreamPtr& os)
+WriterPtr WriterAppender::createWriter(LOG4CXX_16_CONST OutputStreamPtr& os)
 {
 
 	LogString enc(getEncoding());

--- a/src/main/include/log4cxx/fileappender.h
+++ b/src/main/include/log4cxx/fileappender.h
@@ -219,7 +219,7 @@ class LOG4CXX_EXPORT FileAppender : public WriterAppender
 		static LogString stripDuplicateBackslashes(const LogString& name);
 
 	protected:
-		void activateOptionsInternal(LOG4CXX_NS::helpers::Pool& p);
+		void activateOptionsInternal(helpers::Pool& p);
 
 		/**
 		Sets and <i>opens</i> the file where the log output will
@@ -243,7 +243,7 @@ class LOG4CXX_EXPORT FileAppender : public WriterAppender
 		*/
 		void setFileInternal(const LogString& file, bool append,
 			bool bufferedIO, size_t bufferSize,
-			LOG4CXX_NS::helpers::Pool& p);
+			helpers::Pool& p);
 
 		void setFileInternal(const LogString& file);
 

--- a/src/main/include/log4cxx/helpers/outputstreamwriter.h
+++ b/src/main/include/log4cxx/helpers/outputstreamwriter.h
@@ -43,8 +43,8 @@ class LOG4CXX_EXPORT OutputStreamWriter : public Writer
 		LOG4CXX_CAST_ENTRY_CHAIN(Writer)
 		END_LOG4CXX_CAST_MAP()
 
-		OutputStreamWriter(OutputStreamPtr& out);
-		OutputStreamWriter(OutputStreamPtr& out, CharsetEncoderPtr& enc);
+		OutputStreamWriter(const OutputStreamPtr& out);
+		OutputStreamWriter(const OutputStreamPtr& out, const CharsetEncoderPtr& enc);
 		~OutputStreamWriter();
 
 		void close(Pool& p) override;

--- a/src/main/include/log4cxx/helpers/outputstreamwriter.h
+++ b/src/main/include/log4cxx/helpers/outputstreamwriter.h
@@ -22,6 +22,12 @@
 #include <log4cxx/helpers/outputstream.h>
 #include <log4cxx/helpers/charsetencoder.h>
 
+#if 15 < LOG4CXX_ABI_VERSION
+#define LOG4CXX_16_CONST const
+#else
+#define LOG4CXX_16_CONST 
+#endif
+
 namespace LOG4CXX_NS
 {
 
@@ -43,8 +49,8 @@ class LOG4CXX_EXPORT OutputStreamWriter : public Writer
 		LOG4CXX_CAST_ENTRY_CHAIN(Writer)
 		END_LOG4CXX_CAST_MAP()
 
-		OutputStreamWriter(const OutputStreamPtr& out);
-		OutputStreamWriter(const OutputStreamPtr& out, const CharsetEncoderPtr& enc);
+		OutputStreamWriter(LOG4CXX_16_CONST OutputStreamPtr& out);
+		OutputStreamWriter(LOG4CXX_16_CONST OutputStreamPtr& out, LOG4CXX_16_CONST CharsetEncoderPtr& enc);
 		~OutputStreamWriter();
 
 		void close(Pool& p) override;

--- a/src/main/include/log4cxx/private/writerappender_priv.h
+++ b/src/main/include/log4cxx/private/writerappender_priv.h
@@ -42,8 +42,7 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 	{
 	}
 
-	WriterAppenderPriv(const LayoutPtr& layout1,
-		LOG4CXX_NS::helpers::WriterPtr& writer1) :
+	WriterAppenderPriv(const LayoutPtr& layout1, const helpers::WriterPtr& writer1) :
 		AppenderSkeletonPrivate(layout1),
 		immediateFlush(true),
 		writer(writer1)
@@ -53,6 +52,7 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 	{
 	}
 
+#if LOG4CXX_ABI_VERSION <= 15
 	WriterAppenderPriv(const LayoutPtr& layout1) :
 		AppenderSkeletonPrivate(layout1),
 		immediateFlush(true)
@@ -61,6 +61,7 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 #endif
 	{
 	}
+#endif
 
 	void flush()
 	{
@@ -94,7 +95,7 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 	/**
 	*  This is the {@link Writer Writer} where we will write to.
 	*/
-	LOG4CXX_NS::helpers::WriterPtr writer;
+	helpers::WriterPtr writer;
 
 #if LOG4CXX_EVENTS_AT_EXIT
 	helpers::AtExitRegistry::Raii atExitRegistryRaii;

--- a/src/main/include/log4cxx/private/writerappender_priv.h
+++ b/src/main/include/log4cxx/private/writerappender_priv.h
@@ -42,26 +42,12 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 	{
 	}
 
-	WriterAppenderPriv(const LayoutPtr& layout1, const helpers::WriterPtr& writer1) :
-		AppenderSkeletonPrivate(layout1),
-		immediateFlush(true),
-		writer(writer1)
-#if LOG4CXX_EVENTS_AT_EXIT
-		, atExitRegistryRaii{ [this]{flush();} }
-#endif
+	WriterAppenderPriv(const LayoutPtr& layout1, const helpers::WriterPtr& writer1 = helpers::WriterPtr())
+		: WriterAppenderPriv()
 	{
+		this->layout = layout1;
+		this->writer = writer1;
 	}
-
-#if LOG4CXX_ABI_VERSION <= 15
-	WriterAppenderPriv(const LayoutPtr& layout1) :
-		AppenderSkeletonPrivate(layout1),
-		immediateFlush(true)
-#if LOG4CXX_EVENTS_AT_EXIT
-		, atExitRegistryRaii{ [this]{flush();} }
-#endif
-	{
-	}
-#endif
 
 	void flush()
 	{

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -91,7 +91,7 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		 @param os output stream, may not be null.
 		 @return new writer.
 		 */
-		helpers::WriterPtr createWriter(const helpers::OutputStreamPtr& os) override;
+		helpers::WriterPtr createWriter(LOG4CXX_16_CONST helpers::OutputStreamPtr& os) override;
 
 	private:
 		/**

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -91,7 +91,7 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 		 @param os output stream, may not be null.
 		 @return new writer.
 		 */
-		helpers::WriterPtr createWriter(helpers::OutputStreamPtr& os) override;
+		helpers::WriterPtr createWriter(const helpers::OutputStreamPtr& os) override;
 
 	private:
 		/**

--- a/src/main/include/log4cxx/rolling/rollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/rollingfileappender.h
@@ -220,7 +220,7 @@ class LOG4CXX_EXPORT RollingFileAppender : public FileAppender
 		 @param os output stream, may not be null.
 		 @return new writer.
 		 */
-		helpers::WriterPtr createWriter(helpers::OutputStreamPtr& os) override;
+		helpers::WriterPtr createWriter(const helpers::OutputStreamPtr& os) override;
 
 	public:
 		/**

--- a/src/main/include/log4cxx/rolling/rollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/rollingfileappender.h
@@ -220,7 +220,7 @@ class LOG4CXX_EXPORT RollingFileAppender : public FileAppender
 		 @param os output stream, may not be null.
 		 @return new writer.
 		 */
-		helpers::WriterPtr createWriter(const helpers::OutputStreamPtr& os) override;
+		helpers::WriterPtr createWriter(LOG4CXX_16_CONST helpers::OutputStreamPtr& os) override;
 
 	public:
 		/**

--- a/src/main/include/log4cxx/writerappender.h
+++ b/src/main/include/log4cxx/writerappender.h
@@ -22,6 +22,12 @@
 #include <log4cxx/helpers/outputstreamwriter.h>
 #include <atomic>
 
+#if 15 < LOG4CXX_ABI_VERSION
+#define LOG4CXX_16_CONST const
+#else
+#define LOG4CXX_16_CONST 
+#endif
+
 namespace LOG4CXX_NS
 {
 
@@ -126,7 +132,7 @@ class LOG4CXX_EXPORT WriterAppender : public AppenderSkeleton
 		    <code>encoding</code> property.  If the encoding value is
 		    specified incorrectly the writer will be opened using the default
 		    system encoding (an error message will be printed to the loglog.  */
-		virtual helpers::WriterPtr createWriter(const helpers::OutputStreamPtr& os);
+		virtual helpers::WriterPtr createWriter(LOG4CXX_16_CONST helpers::OutputStreamPtr& os);
 
 	public:
 		/**

--- a/src/main/include/log4cxx/writerappender.h
+++ b/src/main/include/log4cxx/writerappender.h
@@ -22,12 +22,6 @@
 #include <log4cxx/helpers/outputstreamwriter.h>
 #include <atomic>
 
-#if 15 < LOG4CXX_ABI_VERSION
-#define LOG4CXX_16_CONST const
-#else
-#define LOG4CXX_16_CONST 
-#endif
-
 namespace LOG4CXX_NS
 {
 

--- a/src/main/include/log4cxx/writerappender.h
+++ b/src/main/include/log4cxx/writerappender.h
@@ -25,11 +25,6 @@
 namespace LOG4CXX_NS
 {
 
-namespace helpers
-{
-class Transcoder;
-}
-
 /**
 WriterAppender appends log events to a standard output stream
 */
@@ -48,9 +43,12 @@ class LOG4CXX_EXPORT WriterAppender : public AppenderSkeleton
 		This default constructor does nothing.*/
 		WriterAppender();
 	protected:
-		WriterAppender(const LayoutPtr& layout,
-			LOG4CXX_NS::helpers::WriterPtr& writer);
+#if LOG4CXX_ABI_VERSION <= 15
+		WriterAppender(const LayoutPtr& layout, helpers::WriterPtr& writer);
 		WriterAppender(const LayoutPtr& layout);
+#else
+		WriterAppender(const LayoutPtr& layout, const helpers::WriterPtr& writer = helpers::WriterPtr());
+#endif
 		WriterAppender(std::unique_ptr<WriterAppenderPriv> priv);
 
 	public:
@@ -128,7 +126,7 @@ class LOG4CXX_EXPORT WriterAppender : public AppenderSkeleton
 		    <code>encoding</code> property.  If the encoding value is
 		    specified incorrectly the writer will be opened using the default
 		    system encoding (an error message will be printed to the loglog.  */
-		virtual helpers::WriterPtr createWriter(helpers::OutputStreamPtr& os);
+		virtual helpers::WriterPtr createWriter(const helpers::OutputStreamPtr& os);
 
 	public:
 		/**
@@ -165,9 +163,9 @@ class LOG4CXX_EXPORT WriterAppender : public AppenderSkeleton
 
 		  @param writer An already opened Writer.
 		*/
-		void setWriter(const LOG4CXX_NS::helpers::WriterPtr& writer);
+		void setWriter(const helpers::WriterPtr& writer);
 
-		const LOG4CXX_NS::helpers::WriterPtr getWriter() const;
+		const helpers::WriterPtr getWriter() const;
 
 		bool requiresLayout() const override;
 
@@ -175,23 +173,23 @@ class LOG4CXX_EXPORT WriterAppender : public AppenderSkeleton
 		/**
 		 Actual writing occurs here.
 		*/
-		virtual void subAppend(const spi::LoggingEventPtr& event, LOG4CXX_NS::helpers::Pool& p);
+		virtual void subAppend(const spi::LoggingEventPtr& event, helpers::Pool& p);
 
 
 		/**
 		Write a footer as produced by the embedded layout's
 		Layout#appendFooter method.  */
-		virtual void writeFooter(LOG4CXX_NS::helpers::Pool& p);
+		virtual void writeFooter(helpers::Pool& p);
 
 		/**
 		Write a header as produced by the embedded layout's
 		Layout#appendHeader method.  */
-		virtual void writeHeader(LOG4CXX_NS::helpers::Pool& p);
+		virtual void writeHeader(helpers::Pool& p);
 
 		/**
 		 * Set the writer.  Mutex must already be held.
 		 */
-		void setWriterInternal(const LOG4CXX_NS::helpers::WriterPtr& writer);
+		void setWriterInternal(const helpers::WriterPtr& writer);
 
 	private:
 		//


### PR DESCRIPTION
This PR also changes the `createWriter` parameter to a `const reference` expecting that such a change should not break the ABI