### PR TITLE
Escape control characters in JSONLayout data

### DIFF
--- a/src/test/cpp/jsonlayouttest.cpp
+++ b/src/test/cpp/jsonlayouttest.cpp
@@ -163,6 +163,13 @@ public:
 
 		appendQuotedEscapedString(cr_escaped, cr);
 		LOGUNIT_ASSERT_EQUAL(cr_expected, cr_escaped);
+
+		logchar esc[] = {0x1e, 0x00};
+		logchar esc_expected[] = {0x22, 0x5c, 'u', 0x30, 0x30, 0x31, 0x3e, 0x22, 0x00};      /* ESC */
+		LogString esc_escaped;
+
+		appendQuotedEscapedString(esc_escaped, esc);
+		LOGUNIT_ASSERT_EQUAL(esc_expected, esc_escaped);
 	}
 
 	/**


### PR DESCRIPTION
This PR ensures that the control characters (U+0000  through U+001F) that are escaped in JSON output