### PR TITLE
The Repository state is now the Configurator's responsibility

### DIFF
--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -345,7 +345,7 @@ void Hierarchy::shutdown()
 void Hierarchy::shutdownInternal()
 {
 	m_priv->configured = false;
-	m_priv->alreadyTriedMethod = 0;
+	m_priv->alreadyTriedMethod = NULL;
 
 	// begin by closing nested appenders
 	if (m_priv->root)

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -345,6 +345,7 @@ void Hierarchy::shutdown()
 void Hierarchy::shutdownInternal()
 {
 	m_priv->configured = false;
+	m_priv->alreadyTriedMethod = 0;
 
 	// begin by closing nested appenders
 	if (m_priv->root)

--- a/src/main/cpp/hierarchy.cpp
+++ b/src/main/cpp/hierarchy.cpp
@@ -64,6 +64,8 @@ struct Hierarchy::HierarchyPrivate
 	std::vector<AppenderPtr> allAppenders;
 
 	mutable std::mutex listenerMutex;
+
+	const char* alreadyTriedMethod{ NULL };
 };
 
 IMPLEMENT_LOG4CXX_OBJECT(Hierarchy)
@@ -302,10 +304,10 @@ bool Hierarchy::isDisabled(int level) const
 void Hierarchy::ensureIsConfigured(std::function<void()> configurator)
 {
 	std::lock_guard<std::mutex> lock(m_priv->configuredMutex);
-	if (!m_priv->configured)
+	if (!m_priv->configured && m_priv->alreadyTriedMethod != configurator.target_type().name())
 	{
 		configurator();
-		m_priv->configured = true;
+		m_priv->alreadyTriedMethod = configurator.target_type().name();
 	}
 }
 


### PR DESCRIPTION
This PR is in preparation for the next which will make the Configurator implementation more careful about calling  'repository->setConfigured(true)'