### PR TITLE
Allow binary-to-text conversion to be moved to a background thread

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources(log4cxx
   appenderskeleton.cpp
   aprinitializer.cpp
   asyncappender.cpp
+  asyncbuffer.cpp
   basicconfigurator.cpp
   bufferedwriter.cpp
   bytearrayinputstream.cpp

--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -498,7 +498,7 @@ LoggingEventPtr DiscardSummary::createEvent(Pool& p)
 	LogString msg(LOG4CXX_STR("Discarded "));
 	StringHelper::toString(count, p, msg);
 	msg.append(LOG4CXX_STR(" messages due to a full event buffer including: "));
-	msg.append(maxEvent->getMessage());
+	msg.append(maxEvent->getRenderedMessage());
 	return std::make_shared<LoggingEvent>(
 				maxEvent->getLoggerName(),
 				maxEvent->getLevel(),

--- a/src/main/cpp/asyncbuffer.cpp
+++ b/src/main/cpp/asyncbuffer.cpp
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <log4cxx/helpers/asyncbuffer.h>
+
+namespace LOG4CXX_NS
+{
+
+namespace helpers
+{
+
+struct AsyncBuffer::Private
+{
+	std::vector<MessageBufferAppender> data;
+};
+
+/** An empty buffer.
+*/
+AsyncBuffer::AsyncBuffer()
+{}
+
+/** A new buffer with the content of \c other
+*/
+AsyncBuffer::AsyncBuffer(AsyncBuffer&& other)
+	: m_priv(std::move(other.m_priv))
+{
+}
+
+/** Release resources.
+*/
+AsyncBuffer::~AsyncBuffer()
+{
+}
+
+/**
+* Has no item been added to this?
+*/
+bool AsyncBuffer::empty() const { return !m_priv || m_priv->data.empty(); }
+
+/**
+* Add text version of buffered values to \c msg
+*/
+void AsyncBuffer::renderMessage(helpers::MessageBuffer& msg)
+{
+	if (m_priv)
+		for (auto& renderer : m_priv->data)
+			renderer(msg);
+}
+
+/**
+* Remove all message appenders
+*/
+void AsyncBuffer::clear()
+{
+	if (m_priv)
+		m_priv->data.clear();
+}
+
+/**
+ *   Append \c function to this buffer.
+ */
+void AsyncBuffer::append(const MessageBufferAppender& f)
+{
+	if (!m_priv)
+		m_priv = std::make_unique<Private>();
+	m_priv->data.push_back(f);
+}
+
+} // namespace helpers
+} // namespace LOG4CXX_NS
+

--- a/src/main/cpp/fmtlayout.cpp
+++ b/src/main/cpp/fmtlayout.cpp
@@ -89,7 +89,8 @@ void FMTLayout::format(LogString& output,
 	const spi::LoggingEventPtr& event,
 	LOG4CXX_NS::helpers::Pool&) const
 {
-	output.reserve(m_priv->expectedPatternLength + event->getMessage().size());
+	auto lsMsg = event->getRenderedMessage();
+	output.reserve(m_priv->expectedPatternLength + lsMsg.size());
 	auto locationFull = fmt::format("{}({})",
 										 event->getLocationInformation().getFileName(),
 										 event->getLocationInformation().getLineNumber());
@@ -100,7 +101,7 @@ void FMTLayout::format(LogString& output,
 	LOG4CXX_ENCODE_CHAR(sPattern, m_priv->conversionPattern);
 	LOG4CXX_ENCODE_CHAR(sLogger, event->getLoggerName());
 	LOG4CXX_ENCODE_CHAR(sLevel, event->getLevel()->toString());
-	LOG4CXX_ENCODE_CHAR(sMsg, event->getMessage());
+	LOG4CXX_ENCODE_CHAR(sMsg, lsMsg);
 	LOG4CXX_ENCODE_CHAR(sThread, event->getThreadName());
 	LOG4CXX_ENCODE_CHAR(endOfLine, LOG4CXX_EOL);
 #else
@@ -108,7 +109,7 @@ void FMTLayout::format(LogString& output,
 	auto& sPattern = m_priv->conversionPattern;
 	auto& sLogger = event->getLoggerName();
 	auto sLevel = event->getLevel()->toString();
-	auto& sMsg = event->getMessage();
+	auto& sMsg = lsMsg;
 	auto& sThread = event->getThreadName();
 	auto endOfLine = LOG4CXX_EOL;
 #endif

--- a/src/main/cpp/htmllayout.cpp
+++ b/src/main/cpp/htmllayout.cpp
@@ -84,7 +84,8 @@ void HTMLLayout::format(LogString& output,
 	const spi::LoggingEventPtr& event,
 	Pool& p) const
 {
-	output.reserve(m_priv->expectedPatternLength + event->getMessage().size());
+	auto lsMsg = event->getRenderedMessage();
+	output.reserve(m_priv->expectedPatternLength + lsMsg.size());
 	output.append(LOG4CXX_EOL);
 	output.append(LOG4CXX_STR("<tr>"));
 	output.append(LOG4CXX_EOL);
@@ -152,7 +153,7 @@ void HTMLLayout::format(LogString& output,
 	}
 
 	output.append(LOG4CXX_STR("<td title=\"Message\">"));
-	Transform::appendEscapingTags(output, event->getRenderedMessage());
+	Transform::appendEscapingTags(output, lsMsg);
 	output.append(LOG4CXX_STR("</td>"));
 	output.append(LOG4CXX_EOL);
 	output.append(LOG4CXX_STR("</tr>"));

--- a/src/main/cpp/jsonlayout.cpp
+++ b/src/main/cpp/jsonlayout.cpp
@@ -132,7 +132,8 @@ void JSONLayout::format(LogString& output,
 	const spi::LoggingEventPtr& event,
 	Pool& p) const
 {
-	output.reserve(m_priv->expectedPatternLength + event->getMessage().size());
+	auto lsMsg = event->getRenderedMessage();
+	output.reserve(m_priv->expectedPatternLength + lsMsg.size());
 	output.append(LOG4CXX_STR("{"));
 	output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 
@@ -187,7 +188,7 @@ void JSONLayout::format(LogString& output,
 	}
 
 	output.append(LOG4CXX_STR("\"message\": "));
-	appendQuotedEscapedString(output, event->getMessage());
+	appendQuotedEscapedString(output, lsMsg);
 
 	appendSerializedMDC(output, event);
 	appendSerializedNDC(output, event);

--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -173,6 +173,15 @@ void Logger::closeNestedAppenders()
 	}
 }
 
+void Logger::addEvent(const LevelPtr& level, helpers::AsyncBuffer&& messageAppender, const LocationInfo& location) const
+{
+	if (!getHierarchy()) // Has removeHierarchy() been called?
+		return;
+	auto event = std::make_shared<LoggingEvent>(m_priv->name, level, location, std::move(messageAppender));
+	Pool p;
+	callAppenders(event, p);
+}
+
 void Logger::addEvent(const LevelPtr& level, std::string&& message, const LocationInfo& location) const
 {
 	if (!getHierarchy()) // Has removeHierarchy() been called?
@@ -205,6 +214,11 @@ void Logger::addWarnEvent(std::string&& message, const LocationInfo& location) c
 void Logger::addInfoEvent(std::string&& message, const LocationInfo& location) const
 {
 	addEvent(m_priv->levelData->Info, std::move(message), location);
+}
+
+void Logger::addInfoEvent(helpers::AsyncBuffer&& messageAppender, const LocationInfo& location) const
+{
+	addEvent(m_priv->levelData->Info, std::move(messageAppender), location);
 }
 
 void Logger::addDebugEvent(std::string&& message, const LocationInfo& location) const

--- a/src/main/cpp/patternlayout.cpp
+++ b/src/main/cpp/patternlayout.cpp
@@ -122,7 +122,8 @@ void PatternLayout::format(LogString& output,
 	const spi::LoggingEventPtr& event,
 	Pool& pool) const
 {
-	output.reserve(m_priv->expectedPatternLength + event->getMessage().size());
+	auto lsMsg = event->getRenderedMessage();
+	output.reserve(m_priv->expectedPatternLength + lsMsg.size());
 	std::vector<FormattingInfoPtr>::const_iterator formatterIter =
 		m_priv->patternFields.begin();
 

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -230,7 +230,7 @@ void TelnetAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 		if (_priv->layout)
 			_priv->layout->format(msg, event, p);
 		else
-			msg = event->getMessage();
+			msg = event->getRenderedMessage();
 		msg.append(LOG4CXX_STR("\r\n"));
 		size_t bytesSize = msg.size() * 2;
 		char* bytes = p.pstralloc(bytesSize);

--- a/src/main/cpp/xmllayout.cpp
+++ b/src/main/cpp/xmllayout.cpp
@@ -78,7 +78,8 @@ void XMLLayout::format(LogString& output,
 	const spi::LoggingEventPtr& event,
 	Pool& p) const
 {
-	output.reserve(m_priv->expectedPatternLength + event->getMessage().size());
+	auto lsMsg = event->getRenderedMessage();
+	output.reserve(m_priv->expectedPatternLength + lsMsg.size());
 	output.append(LOG4CXX_STR("<log4j:event logger=\""));
 	Transform::appendEscapingTags(output, event->getLoggerName());
 	output.append(LOG4CXX_STR("\" timestamp=\""));
@@ -93,7 +94,7 @@ void XMLLayout::format(LogString& output,
 	output.append(LOG4CXX_STR("<log4j:message><![CDATA["));
 	// Append the rendered message. Also make sure to escape any
 	// existing CDATA sections.
-	Transform::appendEscapingCDATA(output, event->getRenderedMessage());
+	Transform::appendEscapingCDATA(output, lsMsg);
 	output.append(LOG4CXX_STR("]]></log4j:message>"));
 	output.append(LOG4CXX_EOL);
 

--- a/src/main/include/log4cxx/helpers/asyncbuffer.h
+++ b/src/main/include/log4cxx/helpers/asyncbuffer.h
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LOG4CXX_ASYNC_BUFFER_H
+#define LOG4CXX_ASYNC_BUFFER_H
+
+#include <log4cxx/helpers/messagebuffer.h>
+#include <functional>
+#include <vector>
+
+namespace LOG4CXX_NS
+{
+
+namespace helpers
+{
+
+/**
+ *   This class is used by the LOG4CXX2_INFO and similar
+ *   macros to support insertion operators.
+ *   The class is not intended for use outside of that context.
+ */
+class LOG4CXX_EXPORT AsyncBuffer
+{
+public:
+	/** An empty buffer.
+	*/
+	AsyncBuffer();
+
+	/** A new buffer with the content of \c other
+	*/
+	AsyncBuffer(AsyncBuffer&& other);
+
+	/** Release resources.
+	*/
+	~AsyncBuffer();
+
+	/** Append a function to this buffer that will convert \c value to text.
+	 *   @param value must be copy-constructable or move-constructable
+	 *   @return this buffer.
+	 */
+	template<typename T>
+	AsyncBuffer& operator<<(const T& value)
+	{
+		append([value](MessageBuffer& msgBuf)
+			{
+				msgBuf << value;
+			});
+		return *this;
+	}
+
+	/**
+	* Has no item been added to this?
+	*/
+	bool empty() const;
+
+	/**
+	* Add text version of buffered values to \c msg
+	*/
+	void renderMessage(helpers::MessageBuffer& msg);
+
+	/**
+	* Remove all message appenders
+	*/
+	void clear();
+
+private:
+	AsyncBuffer(const AsyncBuffer&) = delete;
+	AsyncBuffer& operator=(const AsyncBuffer&) = delete;
+
+	LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(Private, m_priv)
+	using MessageBufferAppender = std::function<void(MessageBuffer&)>;
+
+	/**
+	 *   Append \c function to this buffer.
+	 */
+	void append(const MessageBufferAppender& f);
+};
+
+} // namespace helpers
+} // namespace LOG4CXX_NS
+
+/**
+Add a new logging event containing \c message to attached appender(s) if \c logger is enabled for <code>INFO</code> events.
+
+\usage
+~~~{.cpp}
+LOG4CXX2_INFO(m_log, surface->GetName()
+	<< " successfully planned " << std::fixed << std::setprecision(1) << ((plannedArea  / (plannedArea + unplannedArea)) * 100.0) << "%"
+	<< " planned area " << std::fixed << std::setprecision(4) << plannedArea << "m^2"
+	<< " unplanned area " << unplannedArea << "m^2"
+	<< " planned segments " << surface->GetSegmentPlanCount() << " of " << surface->GetSegmentCount()
+	);
+~~~
+
+@param logger the logger that has the enabled status.
+@param message a valid r-value expression of an <code>operator<<(std::ostream&. ...)</code> overload.
+*/
+#define LOG4CXX2_INFO(logger, message) do { \
+		if (::LOG4CXX_NS::Logger::isInfoEnabledFor(logger)) {\
+			::LOG4CXX_NS::helpers::AsyncBuffer buf;\
+			logger->addInfoEvent(std::move(buf << message), LOG4CXX_LOCATION);\
+		}} while (0)
+
+#endif
+

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -23,6 +23,7 @@
 #include <log4cxx/helpers/pool.h>
 #include <log4cxx/spi/location/locationinfo.h>
 #include <log4cxx/helpers/resourcebundle.h>
+#include <log4cxx/helpers/asyncbuffer.h>
 #include <log4cxx/helpers/messagebuffer.h>
 
 namespace LOG4CXX_NS
@@ -507,6 +508,16 @@ class LOG4CXX_EXPORT Logger
 			, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
 
 		/**
+		Add to attached appender(s) a new \c level LoggingEvent which was requested at \c sourceLocation where the message is built asynchronously by \c messageAppender
+		without further checks.
+		@param level The logging event level.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addEvent(const LevelPtr& level, helpers::AsyncBuffer&& messageAppender
+			, const spi::LocationInfo& sourceLocation = spi::LocationInfo::getLocationUnavailable()) const;
+
+		/**
 		Add a new fatal level logging event containing \c message and \c location to attached appender(s)
 		without further checks.
 		@param message The text to add to the logging event.
@@ -537,6 +548,14 @@ class LOG4CXX_EXPORT Logger
 		@param location The source code location of the logging request.
 		*/
 		void addInfoEvent(std::string&& message, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
+
+		/**
+		Add to attached appender(s) a new INFO level LoggingEvent which was requested at \c sourceLocation where the message is built asynchronously by \c messageAppender
+		without further checks.
+		@param message The text to add to the logging event.
+		@param location The source code location of the logging request.
+		*/
+		void addInfoEvent(helpers::AsyncBuffer&& messageAppender, const spi::LocationInfo& location = spi::LocationInfo::getLocationUnavailable()) const;
 
 		/**
 		Add a new debug level logging event containing \c message and \c location to attached appender(s)

--- a/src/main/include/log4cxx/spi/loggingevent.h
+++ b/src/main/include/log4cxx/spi/loggingevent.h
@@ -87,6 +87,21 @@ class LOG4CXX_EXPORT LoggingEvent :
 			, const LocationInfo& location
 			);
 
+		/**
+		An event composed using the supplied parameters.
+
+		@param logger The logger used to make the logging request.
+		@param level The severity of this event.
+		@param location The source code location of the logging request.
+		@param messageAppender  Builds the message text to add to this event.
+		*/
+		LoggingEvent
+			( const LogString& logger
+			, const LevelPtr& level
+			, const LocationInfo& location
+			, helpers::AsyncBuffer&& messageAppender
+			);
+
 		~LoggingEvent();
 
 		/** The severity level of the logging request that generated this event. */
@@ -194,6 +209,11 @@ class LOG4CXX_EXPORT LoggingEvent :
 		* Associate \c value with the property \c key.
 		*/
 		void setProperty(const LogString& key, const LogString& value);
+
+		/**
+		* Use the renderers to construct the message
+		*/
+		void renderMessage();
 
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(LoggingEventPrivate, m_priv)

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -105,7 +105,8 @@ class LoggingVectorAppender : public VectorAppender
 	void append(const spi::LoggingEventPtr& event, log4cxx::helpers::Pool& p) override
 	{
 		VectorAppender::append(event, p);
-		if (event->getMessage() == LOG4CXX_STR("Hello, World"))
+		auto lsMsg = event->getRenderedMessage();
+		if (LogString::npos != lsMsg.find(LOG4CXX_STR("World")))
 		{
 			LOG4CXX_LOGLS(logger, Level::getError(), LOG4CXX_STR("Some example error"));
 			LOG4CXX_LOGLS(logger, Level::getWarn(), LOG4CXX_STR("Some example warning"));
@@ -347,7 +348,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 
 				for (int i = 0; i < 140; i++)
 				{
-					LOG4CXX_INFO(rootLogger, "Hello, World");
+					LOG4CXX2_INFO(rootLogger, "Hello, World " << i);
 				}
 
 				LOG4CXX_ERROR(rootLogger, "That's all folks.");
@@ -418,7 +419,7 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) ); // Wait for the dispatch thread  to be ready
 			for (int i = 0; i < 10; i++)
 			{
-				LOG4CXX_INFO(rootLogger, "Hello, World");
+				LOG4CXX2_INFO(rootLogger, "Hello, World " << i);
 			}
 			LOG4CXX_INFO(rootLogger, "Bye bye World");
 			std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) ); // Wait for the dispatch thread take the above events

--- a/src/test/cpp/benchmark/benchmark.cpp
+++ b/src/test/cpp/benchmark/benchmark.cpp
@@ -416,7 +416,7 @@ BENCHMARK_DEFINE_F(benchmarker, asyncIntPlusFloatValueMessageBuffer)(benchmark::
 	for (auto _ : state)
 	{
 		auto f = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-		LOG4CXX_INFO( m_asyncLogger, "Hello: message number " << ++x
+		LOG4CXX2_INFO( m_asyncLogger, "Hello: message number " << ++x
 			<< " pseudo-random float " << std::setprecision(3) << std::fixed << f);
 	}
 }
@@ -429,7 +429,7 @@ BENCHMARK_DEFINE_F(benchmarker, fileIntPlusFloatValueMessageBuffer)(benchmark::S
 	for (auto _ : state)
 	{
 		auto f = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-		LOG4CXX_INFO( m_fileLogger, "Hello: message number " << ++x
+		LOG4CXX2_INFO( m_fileLogger, "Hello: message number " << ++x
 			<< " pseudo-random float " << std::setprecision(3) << std::fixed << f);
 	}
 }


### PR DESCRIPTION
This PR introduces to Log4cxx the equivalent of Log4j2's asynchronous loggers