### PR TITLE
Correct async benchmark descriptions

### DIFF
--- a/src/site/markdown/performance.md
+++ b/src/site/markdown/performance.md
@@ -111,8 +111,8 @@ The "Iterations" column derivation is explained in [Google Benchmark documentati
 | Appending int+10float using FMT, pattern: \%m\%n/threads:6 | 1275 ns | 7297 ns | 96222 |
 | Async, Sending int+10float using FMT and AsyncBuffer | 784 ns | 783 ns | 891953 |
 | Async, Sending int+10float using FMT and AsyncBuffer/threads:6 | 1375 ns | 7692 ns | 88554 |
-| Async, Sending int+10float using operator<< and AsyncBuffer, pattern: \%m\%n | 1211 ns | 1211 ns | 578034 |
-| Async, Sending int+10float using operator<< and AsyncBuffer, pattern: \%m\%n/threads:6 | 1351 ns | 7670 ns | 90912 |
+| Async, Sending int+10float using operator<< and AsyncBuffer | 1211 ns | 1211 ns | 578034 |
+| Async, Sending int+10float using operator<< and AsyncBuffer/threads:6 | 1351 ns | 7670 ns | 90912 |
 | Logging int+float using MessageBuffer, pattern: \%d \%m\%n | 1073 ns | 1073 ns | 656652 |
 | Logging int+float using MessageBuffer, pattern: \%d \%m\%n/threads:6 | 1083 ns | 4895 ns | 142776 |
 | Logging int+float using MessageBuffer, JSON | 1394 ns | 1394 ns | 507493 |

--- a/src/test/cpp/benchmark/benchmark.cpp
+++ b/src/test/cpp/benchmark/benchmark.cpp
@@ -478,7 +478,7 @@ BENCHMARK_DEFINE_F(benchmarker, logIntPlus10FloatValueFMT)(benchmark::State& sta
 BENCHMARK_REGISTER_F(benchmarker, logIntPlus10FloatValueFMT)->Name("Appending int+10float using FMT, pattern: %m%n");
 BENCHMARK_REGISTER_F(benchmarker, logIntPlus10FloatValueFMT)->Name("Appending int+10float using FMT, pattern: %m%n")->Threads(benchmarker::threadCount());
 
-BENCHMARK_DEFINE_F(benchmarker, asyncIntPlus10FloatValueFmtBuffer)(benchmark::State& state)
+BENCHMARK_DEFINE_F(benchmarker, asyncIntPlus10FloatFmtAsyncBuffer)(benchmark::State& state)
 {
 	int x = 0;
 	for (auto _ : state)
@@ -510,8 +510,8 @@ BENCHMARK_DEFINE_F(benchmarker, asyncIntPlus10FloatValueFmtBuffer)(benchmark::St
 			);
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, asyncIntPlus10FloatValueFmtBuffer)->Name("Async, Sending int+10float using FMT and AsyncBuffer");
-BENCHMARK_REGISTER_F(benchmarker, asyncIntPlus10FloatValueFmtBuffer)->Name("Async, Sending int+10float using FMT and AsyncBuffer")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, asyncIntPlus10FloatFmtAsyncBuffer)->Name("Async, Sending int+10float using FMT and AsyncBuffer");
+BENCHMARK_REGISTER_F(benchmarker, asyncIntPlus10FloatFmtAsyncBuffer)->Name("Async, Sending int+10float using FMT and AsyncBuffer")->Threads(benchmarker::threadCount());
 #endif
 
 BENCHMARK_DEFINE_F(benchmarker, asyncIntPlus10FloatAsyncBuffer)(benchmark::State& state)
@@ -546,8 +546,8 @@ BENCHMARK_DEFINE_F(benchmarker, asyncIntPlus10FloatAsyncBuffer)(benchmark::State
 			);
 	}
 }
-BENCHMARK_REGISTER_F(benchmarker, asyncIntPlus10FloatAsyncBuffer)->Name("Async, Sending int+10float using operator<< and AsyncBuffer, pattern: %m%n");
-BENCHMARK_REGISTER_F(benchmarker, asyncIntPlus10FloatAsyncBuffer)->Name("Async, Sending int+10float using operator<< and AsyncBuffer, pattern: %m%n")->Threads(benchmarker::threadCount());
+BENCHMARK_REGISTER_F(benchmarker, asyncIntPlus10FloatAsyncBuffer)->Name("Async, Sending int+10float using operator<< and AsyncBuffer");
+BENCHMARK_REGISTER_F(benchmarker, asyncIntPlus10FloatAsyncBuffer)->Name("Async, Sending int+10float using operator<< and AsyncBuffer")->Threads(benchmarker::threadCount());
 
 BENCHMARK_DEFINE_F(benchmarker, fileIntPlusFloatValueMessageBuffer)(benchmark::State& state)
 {


### PR DESCRIPTION
Async benchmark tests do not use a layout as the event is disarded in the background thread