### PR TITLE
Prevent potential fault configuring a user-defined Level

### DIFF
--- a/src/main/cpp/domconfigurator.cpp
+++ b/src/main/cpp/domconfigurator.cpp
@@ -824,10 +824,7 @@ void DOMConfigurator::parseLevel(
 
 			try
 			{
-				Level::LevelClass& levelClass =
-					(Level::LevelClass&)Loader::loadClass(className);
-				LevelPtr level = levelClass.toLevel(levelStr);
-				logger->setLevel(level);
+				logger->setLevel(dynamic_cast<const Level::LevelClass&>(Loader::loadClass(className)).toLevel(levelStr));
 			}
 			catch (Exception& oops)
 			{


### PR DESCRIPTION
This PR applies this [C++ core guideline](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-dynamic_cast)