### PR TITLE
Improve Logger interface consistency in the next ABI

### DIFF
--- a/src/main/cpp/logger.cpp
+++ b/src/main/cpp/logger.cpp
@@ -327,10 +327,17 @@ const LevelPtr& Logger::getEffectiveLevel() const
 #endif
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
 LoggerRepository* Logger::getLoggerRepository() const
 {
 	return m_priv->repositoryRaw;
 }
+#else
+LoggerRepositoryPtr Logger::getLoggerRepository()
+{
+	return LogManager::getLoggerRepository();
+}
+#endif
 
 LoggerRepository* Logger::getHierarchy() const
 {

--- a/src/main/include/log4cxx/logger.h
+++ b/src/main/include/log4cxx/logger.h
@@ -843,11 +843,13 @@ class LOG4CXX_EXPORT Logger
 		*/
 		virtual const LevelPtr& getEffectiveLevel() const;
 
+#if LOG4CXX_ABI_VERSION <= 15
 		/**
 		Return the the LoggerRepository where this
 		<code>Logger</code> is attached.
 		*/
 		spi::LoggerRepository* getLoggerRepository() const;
+#endif
 
 		/**
 		* Get the logger name.
@@ -897,6 +899,13 @@ class LOG4CXX_EXPORT Logger
 		@return Level - the assigned Level, can be null.
 		*/
 		const LevelPtr& getLevel() const;
+
+#if 15 < LOG4CXX_ABI_VERSION
+		/**
+		The object that holds all Logger instances.
+		*/
+		static spi::LoggerRepositoryPtr getLoggerRepository();
+#endif
 
 		/**
 		* Retrieve a logger by name in current encoding.


### PR DESCRIPTION
This PR will resolve #545 when a Log4cxx using the next ABI is released.

The resolved inconsistency is that Logger::getLogger() is static and Logger::getLoggerRepository() is not, and the LogManager method documentation assumes a single LoggerRepository.