### PR TITLE
Fix: Remote Denial of Service (Infinite Loop) in TelnetAppender

### DIFF
--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -205,7 +205,8 @@ void TelnetAppender::write(ByteBuffer& buf)
 
 void TelnetAppender::writeStatus(const SocketPtr& socket, const LogString& msg, Pool& p)
 {
-	size_t bytesSize = msg.size() * 2;
+	// Ensure minimum buffer size to prevent infinite loop in encoder with short messages
+        size_t bytesSize = (msg.size() * 2 > 1024) ? msg.size() * 2 : 1024;
 	char* bytes = p.pstralloc(bytesSize);
 
 	LogString::const_iterator msgIter(msg.begin());
@@ -232,7 +233,8 @@ void TelnetAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 		else
 			msg = event->getRenderedMessage();
 		msg.append(LOG4CXX_STR("\r\n"));
-		size_t bytesSize = msg.size() * 2;
+		// Ensure minimum buffer size to prevent infinite loop in encoder with short messages
+                size_t bytesSize = (msg.size() * 2 > 1024) ? msg.size() * 2 : 1024;
 		char* bytes = p.pstralloc(bytesSize);
 
 		LogString::const_iterator msgIter(msg.begin());


### PR DESCRIPTION
### Summary
I identified a critical robustness issue in `TelnetAppender` where logging a message shorter than 4 characters (e.g., "OK", "404") triggers an infinite loop, causing 100% CPU usage on the worker thread.

### Technical Analysis
The vulnerability is caused by a logic mismatch between the memory allocation strategy in `TelnetAppender` and the safety requirements of the `UTF8CharsetEncoder`.

1. **Vulnerable Allocation (`telnetappender.cpp`)**:
   The buffer is allocated dynamically based strictly on message length:
   ```cpp
   size_t bytesSize = msg.size() * 2;
   ```
For a 2-byte message ("Hi"), the allocated buffer is 4 bytes.

2. **Blocker Guard (`charsetencoder.cpp`)**: The `UTF8CharsetEncoder` enforces a safety check requiring at least 8 bytes of remaining space:
   ```cpp
   if (out.remaining() >= 8) { ... }
   ```

If the buffer is smaller, it returns `APR_SUCCESS` without consuming input or advancing the iterator.

3. **The Infinite Loop**: `TelnetAppender` receives a success code but detects the message hasn't been fully processed (`msgIter != msg.end()`). It retries the loop indefinitely with the same insufficient buffer, creating a deadlock.

**Remediation**
This patch modifies `TelnetAppender::append` to enforce a minimum buffer allocation (1024 bytes). This ensures the buffer always satisfies the encoder's requirements, preventing the infinite loop regardless of the input message length.

**Threat Model Context**
While this requires an untrusted log event, it results in a high-severity availability impact (Thread Hang).