### PR TITLE
Prevent undefined behavior during a configuration change

### DIFF
--- a/src/main/cpp/appenderskeleton.cpp
+++ b/src/main/cpp/appenderskeleton.cpp
@@ -144,6 +144,14 @@ bool AppenderSkeleton::AppenderSkeletonPrivate::checkNotClosed()
 	return true;
 }
 
+bool AppenderSkeleton::AppenderSkeletonPrivate::setClosed()
+{
+	std::lock_guard<std::recursive_mutex> lock(this->mutex);
+	bool wasOpen = !this->closed;
+	this->closed = true;
+	return wasOpen;
+}
+
 bool AppenderSkeleton::AppenderSkeletonPrivate::checkLayout()
 {
 	if (!this->layout)

--- a/src/main/cpp/dbappender.cpp
+++ b/src/main/cpp/dbappender.cpp
@@ -109,7 +109,9 @@ DBAppender::~DBAppender()
     close();
 }
 
-void DBAppender::close(){
+void DBAppender::close()
+{
+    _priv->setClosed();
     if(_priv->m_driver && _priv->m_databaseHandle){
         apr_dbd_close(_priv->m_driver, _priv->m_databaseHandle);
     }

--- a/src/main/cpp/nteventlogappender.cpp
+++ b/src/main/cpp/nteventlogappender.cpp
@@ -50,6 +50,8 @@ struct NTEventLogAppender::NTEventLogAppenderPrivate : public AppenderSkeleton::
 	LogString source;
 	HANDLE hEventLog;
 	SID* pCurrentUserSID;
+
+	void close();
 };
 
 class CCtUserSIDHelper
@@ -134,17 +136,21 @@ NTEventLogAppender::~NTEventLogAppender()
 void NTEventLogAppender::close()
 {
 	priv->setClosed();
+	priv->close();
+}
 
-	if (priv->hEventLog != NULL)
+void NTEventLogAppender::NTEventLogAppenderPrivate::close()
+{
+	if (this->hEventLog != NULL)
 	{
-		::DeregisterEventSource(priv->hEventLog);
-		priv->hEventLog = NULL;
+		::DeregisterEventSource(this->hEventLog);
+		this->hEventLog = NULL;
 	}
 
-	if (priv->pCurrentUserSID != NULL)
+	if (this->pCurrentUserSID != NULL)
 	{
-		CCtUserSIDHelper::FreeSid((::SID*) priv->pCurrentUserSID);
-		priv->pCurrentUserSID = NULL;
+		CCtUserSIDHelper::FreeSid((::SID*) this->pCurrentUserSID);
+		this->pCurrentUserSID = NULL;
 	}
 }
 
@@ -183,7 +189,7 @@ void NTEventLogAppender::activateOptions(Pool&)
 		priv->log = LOG4CXX_STR("Application");
 	}
 
-	close();
+	priv->close();
 
 	// current user security identifier
 	CCtUserSIDHelper::GetCurrentUserSID((::SID**) &priv->pCurrentUserSID);

--- a/src/main/cpp/nteventlogappender.cpp
+++ b/src/main/cpp/nteventlogappender.cpp
@@ -133,6 +133,8 @@ NTEventLogAppender::~NTEventLogAppender()
 
 void NTEventLogAppender::close()
 {
+	priv->setClosed();
+
 	if (priv->hEventLog != NULL)
 	{
 		::DeregisterEventSource(priv->hEventLog);

--- a/src/main/cpp/odbcappender.cpp
+++ b/src/main/cpp/odbcappender.cpp
@@ -392,6 +392,7 @@ void ODBCAppender::close()
 		_priv->errorHandler->error(LOG4CXX_STR("Error closing connection"),
 			e, ErrorCode::GENERIC_FAILURE);
 	}
+	_priv->setClosed();
 
 #if LOG4CXX_HAVE_ODBC
 
@@ -407,7 +408,6 @@ void ODBCAppender::close()
 	}
 
 #endif
-	_priv->closed = true;
 }
 
 #if LOG4CXX_HAVE_ODBC

--- a/src/main/cpp/smtpappender.cpp
+++ b/src/main/cpp/smtpappender.cpp
@@ -694,7 +694,7 @@ bool SMTPAppender::checkEntryConditions()
 
 void SMTPAppender::close()
 {
-	_priv->closed = true;
+	_priv->setClosed();
 }
 
 LogString SMTPAppender::getTo() const

--- a/src/main/cpp/socketappenderskeleton.cpp
+++ b/src/main/cpp/socketappenderskeleton.cpp
@@ -235,7 +235,7 @@ void SocketAppenderSkeleton::retryConnect()
 
 void SocketAppenderSkeleton::SocketAppenderSkeletonPriv::stopMonitor()
 {
-	this->closed = true;
+	this->setClosed();
 	if (this->taskName.empty())
 		;
 	else if (auto pManager = this->taskManager.lock())

--- a/src/main/cpp/syslogappender.cpp
+++ b/src/main/cpp/syslogappender.cpp
@@ -69,7 +69,7 @@ SyslogAppender::~SyslogAppender()
 /** Release any resources held by this SyslogAppender.*/
 void SyslogAppender::close()
 {
-	_priv->closed = true;
+	_priv->setClosed();
 
 	if (_priv->sw)
 	{

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -82,12 +82,10 @@ struct TelnetAppender::TelnetAppenderPriv : public AppenderSkeletonPrivate
 
 	void stopAcceptingConnections()
 	{
-		{
-			std::lock_guard<std::recursive_mutex> lock(this->mutex);
-			if (!this->serverSocket || this->closed)
-				return;
-			this->closed = true;
-		}
+		if (!this->setClosed())
+			return;
+		if (!this->serverSocket)
+			return;
 		// Interrupt accept()
 		try
 		{

--- a/src/main/cpp/writerappender.cpp
+++ b/src/main/cpp/writerappender.cpp
@@ -147,14 +147,11 @@ bool WriterAppender::WriterAppenderPriv::checkWriter()
    */
 void WriterAppender::close()
 {
-	std::lock_guard<std::recursive_mutex> lock(_priv->mutex);
-
-	if (_priv->closed)
+	if (!_priv->setClosed())
 	{
 		return;
 	}
 
-	_priv->closed = true;
 	closeWriter();
 }
 

--- a/src/main/include/log4cxx/private/appenderskeleton_priv.h
+++ b/src/main/include/log4cxx/private/appenderskeleton_priv.h
@@ -76,6 +76,11 @@ struct AppenderSkeleton::AppenderSkeletonPrivate
 
 	bool warnedNoLayout = false;
 	bool checkLayout();
+
+	/**
+	@returns true if the appender was not already closed
+	*/
+	bool setClosed();
 };
 
 }

--- a/src/test/cpp/vectorappender.cpp
+++ b/src/test/cpp/vectorappender.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "vectorappender.h"
+#include <log4cxx/private/appenderskeleton_priv.h>
 #include <thread>
 
 using namespace log4cxx;
@@ -30,12 +31,12 @@ void VectorAppender::append(const spi::LoggingEventPtr& event, Pool& /*p*/)
 	this->vector.push_back(event);
 }
 
+bool VectorAppender::isClosed() const
+{
+	return m_priv->closed;
+}
+
 void VectorAppender::close()
 {
-	if (m_priv->closed)
-	{
-		return;
-	}
-
 	m_priv->closed = true;
 }

--- a/src/test/cpp/vectorappender.h
+++ b/src/test/cpp/vectorappender.h
@@ -18,7 +18,6 @@
 #include <log4cxx/appenderskeleton.h>
 #include <vector>
 #include <log4cxx/spi/loggingevent.h>
-#include <log4cxx/private/appenderskeleton_priv.h>
 
 namespace LOG4CXX_NS
 {
@@ -52,10 +51,7 @@ class VectorAppender : public AppenderSkeleton
 
 		void close() override;
 
-		bool isClosed() const
-		{
-			return m_priv->closed;
-		}
+		bool isClosed() const;
 
 		bool requiresLayout() const override
 		{


### PR DESCRIPTION
This PR applies the `WriterAppender::close` logic to other (less used) appenders