### PR TITLE
out-of-bounds write when CyclicBuffer is empty

### DIFF
--- a/src/main/cpp/cyclicbuffer.cpp
+++ b/src/main/cpp/cyclicbuffer.cpp
@@ -64,6 +64,11 @@ Add an <code>event</code> as the last event in the buffer.
 */
 void CyclicBuffer::add(const spi::LoggingEventPtr& event)
 {
+	if (m_priv->ea.empty())
+	{
+		return;
+	}
+
 	m_priv->ea[m_priv->last] = event;
 
 	if (++m_priv->last == m_priv->maxSize)


### PR DESCRIPTION
## Fix out-of-bounds write when CyclicBuffer is empty

### Problem
`CyclicBuffer::resize` allows the buffer size to be set to `0`, but `add()` writes to the buffer without checking if storage exists.

This can lead to an out-of-bounds write when the buffer is empty.

### Fix
Add a simple guard in `CyclicBuffer::add` to return early when the buffer has no storage (`ea.empty()`).

### Impact
- Prevents invalid memory access
- No change in behaviour for valid buffer sizes
- Minimal, localized fix