### PR TITLE
Allow AsyncAppender to have a sub-class in the next ABI version

### DIFF
--- a/src/main/include/log4cxx/asyncappender.h
+++ b/src/main/include/log4cxx/asyncappender.h
@@ -89,7 +89,7 @@ See AsyncAppender::setOption for details.
 */
 class LOG4CXX_EXPORT AsyncAppender :
 	public virtual spi::AppenderAttachable,
-	public virtual AppenderSkeleton
+	public AppenderSkeleton
 {
 	protected:
 		struct AsyncAppenderPriv;

--- a/src/main/include/log4cxx/asyncappender.h
+++ b/src/main/include/log4cxx/asyncappender.h
@@ -89,7 +89,11 @@ See AsyncAppender::setOption for details.
 */
 class LOG4CXX_EXPORT AsyncAppender :
 	public virtual spi::AppenderAttachable,
+#if LOG4CXX_ABI_VERSION <= 15
+	public virtual AppenderSkeleton
+#else
 	public AppenderSkeleton
+#endif
 {
 	protected:
 		struct AsyncAppenderPriv;


### PR DESCRIPTION
The AsyncAppender m_priv member is the wrong type in a subclass, as the constructor body skips initialisation code when it is subclassed.

