### PR TITLE
Simplify StringHelper functions in the next ABI version

### DIFF
--- a/src/main/cpp/asyncappender.cpp
+++ b/src/main/cpp/asyncappender.cpp
@@ -588,7 +588,7 @@ void DiscardSummary::add(const LoggingEventPtr& event)
 LoggingEventPtr DiscardSummary::createEvent(Pool& p)
 {
 	LogString msg(LOG4CXX_STR("Discarded "));
-	StringHelper::toString(this->count, p, msg);
+	StringHelper::toString(this->count, msg);
 	msg.append(LOG4CXX_STR(" messages ") + this->reason + LOG4CXX_STR(" including: "));
 	msg.append(this->maxEvent->getRenderedMessage());
 	return std::make_shared<LoggingEvent>
@@ -605,7 +605,7 @@ DiscardSummary::createEvent(::LOG4CXX_NS::helpers::Pool& p,
 	size_t discardedCount)
 {
 	LogString msg(LOG4CXX_STR("Discarded "));
-	StringHelper::toString(discardedCount, p, msg);
+	StringHelper::toString(discardedCount, msg);
 	msg.append(LOG4CXX_STR(" messages due to a full event buffer"));
 
 	return std::make_shared<LoggingEvent>(
@@ -691,27 +691,26 @@ void AsyncAppender::AsyncAppenderPriv::dispatch(const LogString& appenderName)
 	}
 	if (LogLog::isDebugEnabled())
 	{
-		Pool p;
 		LogString msg(LOG4CXX_STR("[") + appenderName + LOG4CXX_STR("] AsyncAppender"));
 #ifdef _DEBUG
 		msg += LOG4CXX_STR(" iterationCount ");
-		StringHelper::toString(iterationCount, p, msg);
+		StringHelper::toString(iterationCount, msg);
 		msg += LOG4CXX_STR(" waitCount ");
-		StringHelper::toString(waitCount, p, msg);
+		StringHelper::toString(waitCount, msg);
 		msg += LOG4CXX_STR(" producerBlockedCount ");
-		StringHelper::toString(producerBlockedCount, p, msg);
+		StringHelper::toString(producerBlockedCount, msg);
 		msg += LOG4CXX_STR(" commitCount ");
-		StringHelper::toString(this->commitCount, p, msg);
+		StringHelper::toString(this->commitCount, msg);
 #endif
 		msg += LOG4CXX_STR(" dispatchedCount ");
-		StringHelper::toString(this->dispatchedCount, p, msg);
+		StringHelper::toString(this->dispatchedCount, msg);
 		msg += LOG4CXX_STR(" discardCount ");
-		StringHelper::toString(discardCount, p, msg);
+		StringHelper::toString(discardCount, msg);
 		msg += LOG4CXX_STR(" pendingCountHistogram");
 		for (auto item : pendingCountHistogram)
 		{
 			msg += logchar(' ');
-			StringHelper::toString(item, p, msg);
+			StringHelper::toString(item, msg);
 		}
 		LogLog::debug(msg);
 	}

--- a/src/main/cpp/colorstartpatternconverter.cpp
+++ b/src/main/cpp/colorstartpatternconverter.cpp
@@ -59,7 +59,7 @@ static LogString colorToANSISequence(const LogString& color, bool isForeground, 
 	if( isForeground == false ){
 		numberToConvert += 10;
 	}
-	StringHelper::toString(numberToConvert, pool, ret);
+	StringHelper::toString(numberToConvert, ret);
 	return ret;
 }
 
@@ -86,7 +86,7 @@ static LogString graphicsModeToANSISequence(const LogString& graphicsMode, Pool&
 		return LOG4CXX_STR("");
 	}
 	LogString ret;
-	StringHelper::toString(numberToConvert, pool, ret);
+	StringHelper::toString(numberToConvert, ret);
 	return ret;
 }
 

--- a/src/main/cpp/cyclicbuffer.cpp
+++ b/src/main/cpp/cyclicbuffer.cpp
@@ -48,8 +48,7 @@ CyclicBuffer::CyclicBuffer(int maxSize1)
 	if (maxSize1 < 1)
 	{
 		LogString msg(LOG4CXX_STR("The maxSize argument ("));
-		Pool p;
-		StringHelper::toString(maxSize1, p, msg);
+		StringHelper::toString(maxSize1, msg);
 		msg.append(LOG4CXX_STR(") is not a positive integer."));
 		throw IllegalArgumentException(msg);
 	}
@@ -134,8 +133,7 @@ void CyclicBuffer::resize(int newSize)
 	if (newSize < 0)
 	{
 		LogString msg(LOG4CXX_STR("Negative array size ["));
-		Pool p;
-		StringHelper::toString(newSize, p, msg);
+		StringHelper::toString(newSize, msg);
 		msg.append(LOG4CXX_STR("] not allowed."));
 		throw IllegalArgumentException(msg);
 	}

--- a/src/main/cpp/dateformat.cpp
+++ b/src/main/cpp/dateformat.cpp
@@ -31,7 +31,7 @@ void DateFormat::setTimeZone(const TimeZonePtr&) {}
 
 void DateFormat::numberFormat(LogString& s, int n, Pool& p) const
 {
-	StringHelper::toString(n, p, s);
+	StringHelper::toString(n, s);
 }
 
 DateFormat::DateFormat() {}

--- a/src/main/cpp/defaultconfigurator.cpp
+++ b/src/main/cpp/defaultconfigurator.cpp
@@ -42,9 +42,8 @@ void DefaultConfigurator::setConfigurationFileName(const LogString& path)
 
 void DefaultConfigurator::setConfigurationWatchSeconds(int seconds)
 {
-	Pool p;
 	LogString strSeconds;
-	StringHelper::toString(seconds, p, strSeconds);
+	StringHelper::toString(seconds, strSeconds);
 	Configurator::properties().setProperty(LOG4CXX_STR("LOG4CXX_CONFIGURATION_WATCH_SECONDS"), strSeconds);
 }
 

--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -21,7 +21,6 @@
 #include <string>
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/transcoder.h>
-#include <log4cxx/helpers/pool.h>
 #include <apr_errno.h>
 
 using namespace LOG4CXX_NS;
@@ -106,8 +105,7 @@ RuntimeException& RuntimeException::operator=(const RuntimeException& src)
 LogString RuntimeException::formatMessage(log4cxx_status_t stat)
 {
 	LogString s(LOG4CXX_STR("RuntimeException: return code = "));
-	Pool p;
-	StringHelper::toString(stat, p, s);
+	StringHelper::toString(stat, s);
 	return s;
 }
 
@@ -188,8 +186,7 @@ LogString Exception::makeMessage(const LogString& type, log4cxx_status_t stat)
 	if (0 == err_buff[0] || 0 == strncmp(err_buff, "APR does not understand", 23))
 	{
 		s.append(LOG4CXX_STR(": error code "));
-		Pool p;
-		StringHelper::toString(stat, p, s);
+		StringHelper::toString(stat, s);
 	}
 	else
 	{
@@ -294,8 +291,7 @@ InterruptedException& InterruptedException::operator=(const InterruptedException
 LogString InterruptedException::formatMessage(log4cxx_status_t stat)
 {
 	LogString s(LOG4CXX_STR("InterruptedException: stat = "));
-	Pool p;
-	StringHelper::toString(stat, p, s);
+	StringHelper::toString(stat, s);
 	return s;
 }
 

--- a/src/main/cpp/fallbackerrorhandler.cpp
+++ b/src/main/cpp/fallbackerrorhandler.cpp
@@ -90,11 +90,10 @@ void FallbackErrorHandler::error
 	, const spi::LoggingEventPtr& event
 	) const
 {
-	Pool p;
 	if (LogLog::isDebugEnabled())
 	{
 		LogString msg{ LOG4CXX_STR("FB: error code ") };
-		StringHelper::toString(errorCode, p, msg);
+		StringHelper::toString(errorCode, msg);
 		LogLog::debug(msg);
 	}
 	LogLog::warn(message, ex);
@@ -143,7 +142,10 @@ void FallbackErrorHandler::error
 	}
 	m_priv->errorReported = true;
 	if (event)
+    {
+        Pool p;
 		backupLocked->doAppend(event, p);
+    }
 	m_priv->primary = backupLocked;
 }
 

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -135,11 +135,10 @@ void FileWatchdog::start()
 	{
 		if (LogLog::isDebugEnabled())
 		{
-			Pool p;
 			LogString msg(LOG4CXX_STR("Checking ["));
 			msg += m_priv->file.getPath();
 			msg += LOG4CXX_STR("] at ");
-			StringHelper::toString((int)m_priv->delay, p, msg);
+			StringHelper::toString((int)m_priv->delay, msg);
 			msg += LOG4CXX_STR(" ms interval");
 			LogLog::debug(msg);
 		}

--- a/src/main/cpp/fulllocationpatternconverter.cpp
+++ b/src/main/cpp/fulllocationpatternconverter.cpp
@@ -49,6 +49,6 @@ void FullLocationPatternConverter::format(
 	toAppendTo.append(1, (logchar) 0x28 /* '(' */);
 	StringHelper::toString(
 		event->getLocationInformation().getLineNumber(),
-		p, toAppendTo);
+		toAppendTo);
 	toAppendTo.append(1, (logchar) 0x29 /* ')' */);
 }

--- a/src/main/cpp/htmllayout.cpp
+++ b/src/main/cpp/htmllayout.cpp
@@ -145,7 +145,7 @@ void HTMLLayout::format(LogString& output,
 
 		if (line != 0)
 		{
-			StringHelper::toString(line, p, output);
+			StringHelper::toString(line, output);
 		}
 
 		output.append(LOG4CXX_STR("</td>"));

--- a/src/main/cpp/inputstreamreader.cpp
+++ b/src/main/cpp/inputstreamreader.cpp
@@ -102,8 +102,7 @@ LogString InputStreamReader::read(Pool& p)
 		msg.push_back(toHexDigit((ch & 0xF0) >> 4));
 		msg.push_back(toHexDigit((ch & 0xF)));
 		msg += LOG4CXX_STR(" at offset ");
-		Pool p;
-		StringHelper::toString(output.size(), p, msg);
+		StringHelper::toString(output.size(), msg);
 		throw RuntimeException(msg);
 	}
 

--- a/src/main/cpp/integerpatternconverter.cpp
+++ b/src/main/cpp/integerpatternconverter.cpp
@@ -47,6 +47,6 @@ void IntegerPatternConverter::format(
 
 	if (i != NULL)
 	{
-		StringHelper::toString(i->intValue(), p, toAppendTo);
+		StringHelper::toString(i->intValue(), toAppendTo);
 	}
 }

--- a/src/main/cpp/jsonlayout.cpp
+++ b/src/main/cpp/jsonlayout.cpp
@@ -425,7 +425,7 @@ void JSONLayout::appendSerializedLocationInfo(LogString& buf,
 	appendQuotedEscapedString(buf, LOG4CXX_STR("line"));
 	buf.append(LOG4CXX_STR(": "));
 	LogString lineNumber;
-	StringHelper::toString(locInfo.getLineNumber(), p, lineNumber);
+	StringHelper::toString(locInfo.getLineNumber(), lineNumber);
 	appendQuotedEscapedString(buf, lineNumber);
 	buf.append(LOG4CXX_STR(","));
 	buf.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));

--- a/src/main/cpp/linelocationpatternconverter.cpp
+++ b/src/main/cpp/linelocationpatternconverter.cpp
@@ -47,5 +47,5 @@ void LineLocationPatternConverter::format(
 {
 	StringHelper::toString(
 		event->getLocationInformation().getLineNumber(),
-		p, toAppendTo);
+		toAppendTo);
 }

--- a/src/main/cpp/nteventlogappender.cpp
+++ b/src/main/cpp/nteventlogappender.cpp
@@ -349,9 +349,8 @@ WORD NTEventLogAppender::getEventCategory(const LoggingEventPtr& event)
 
 LogString NTEventLogAppender::getErrorString(const LogString& function)
 {
-	Pool p;
 	enum { MSGSIZE = 5000 };
-
+	Pool p;
 	wchar_t* lpMsgBuf = (wchar_t*) p.palloc(MSGSIZE * sizeof(wchar_t));
 	DWORD dw = GetLastError();
 
@@ -365,7 +364,7 @@ LogString NTEventLogAppender::getErrorString(const LogString& function)
 
 	LogString msg(function);
 	msg.append(LOG4CXX_STR(" failed with error "));
-	StringHelper::toString((size_t) dw, p, msg);
+	StringHelper::toString((size_t) dw, msg);
 	msg.append(LOG4CXX_STR(": "));
 	Transcoder::decode(lpMsgBuf, msg);
 

--- a/src/main/cpp/odbcappender.cpp
+++ b/src/main/cpp/odbcappender.cpp
@@ -494,9 +494,9 @@ void ODBCAppender::ODBCAppenderPriv::setPreparedStatement(SQLHDBC con, Pool& p)
 			if (SQL_INTEGER != targetType)
 			{
 				LogString msg(LOG4CXX_STR("Unexpected targetType ("));
-				helpers::StringHelper::toString(targetType, p, msg);
+				helpers::StringHelper::toString(targetType, msg);
 				msg += LOG4CXX_STR(") at parameter ");
-				helpers::StringHelper::toString(parameterNumber, p, msg);
+				helpers::StringHelper::toString(parameterNumber, msg);
 				msg += LOG4CXX_STR(" while preparing SQL");
 				LogLog::warn(msg);
 			}

--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -107,7 +107,7 @@ LogString substVarsSafely(const LogString& val, helpers::Properties& props, cons
 				msg.append(val);
 				msg.append(LOG4CXX_STR("\" has no closing brace. Opening brace at position "));
 				helpers::Pool p;
-				helpers::StringHelper::toString(j, p, msg);
+				helpers::StringHelper::toString(j, msg);
 				msg.append(1, (logchar) 0x2E /* '.' */);
 				throw helpers::IllegalArgumentException(msg);
 			}

--- a/src/main/cpp/relativetimedateformat.cpp
+++ b/src/main/cpp/relativetimedateformat.cpp
@@ -32,5 +32,5 @@ void LOG4CXX_NS::helpers::RelativeTimeDateFormat::format(
 	Pool& p) const
 {
 	int64_t interval = (date - startTime) / int64_t(1000);
-	StringHelper::toString(interval, p, s);
+	StringHelper::toString(interval, s);
 }

--- a/src/main/cpp/relativetimepatternconverter.cpp
+++ b/src/main/cpp/relativetimepatternconverter.cpp
@@ -47,6 +47,6 @@ void RelativeTimePatternConverter::format(
 	Pool& p) const
 {
 	log4cxx_time_t delta = (event->getTimeStamp() - LoggingEvent::getStartTime()) / 1000;
-	StringHelper::toString(delta, p, toAppendTo);
+	StringHelper::toString(delta, toAppendTo);
 }
 

--- a/src/main/cpp/simpledateformat.cpp
+++ b/src/main/cpp/simpledateformat.cpp
@@ -247,7 +247,7 @@ class NumericToken : public PatternToken
 		{
 			size_t initialLength = s.length();
 
-			StringHelper::toString( getField( tm ), p, s );
+			StringHelper::toString( getField( tm ), s );
 			size_t finalLength = s.length();
 
 			if ( initialLength + width > finalLength )
@@ -610,14 +610,14 @@ class RFC822TimeZoneToken : public PatternToken
 				}
 
 				LogString hours;
-				StringHelper::toString( off / 3600, p, hours );
+				StringHelper::toString( off / 3600, hours );
 				if( hours.size() == 1 ){
 					s.push_back( '0' );
 				}
 				s.append(hours);
 
 				LogString min;
-				StringHelper::toString( ( off % 3600 ) / 60, p, min );
+				StringHelper::toString( ( off % 3600 ) / 60, min );
 				if( min.size() == 1 ){
 					s.push_back( '0' );
 				}

--- a/src/main/cpp/socketappenderskeleton.cpp
+++ b/src/main/cpp/socketappenderskeleton.cpp
@@ -89,7 +89,7 @@ void SocketAppenderSkeleton::connect(Pool& p)
 			{
 				LogString msg(LOG4CXX_STR("Connecting to [")
 					+ _priv->address->toString() + LOG4CXX_STR(":"));
-				StringHelper::toString(_priv->port, p, msg);
+				StringHelper::toString(_priv->port, msg);
 				msg += LOG4CXX_STR("].");
 				LogLog::debug(msg);
 			}
@@ -100,7 +100,7 @@ void SocketAppenderSkeleton::connect(Pool& p)
 		{
 			LogString msg = LOG4CXX_STR("Could not connect to [")
 				+ _priv->address->toString() + LOG4CXX_STR(":");
-			StringHelper::toString(_priv->port, p, msg);
+			StringHelper::toString(_priv->port, msg);
 			msg += LOG4CXX_STR("].");
 
 			fireConnector(); // fire the connector thread
@@ -138,23 +138,20 @@ void SocketAppenderSkeleton::fireConnector()
 	std::lock_guard<std::recursive_mutex> lock(_priv->mutex);
     if (_priv->taskName.empty())
     {
-        Pool p;
         _priv->taskName = _priv->name + LOG4CXX_STR(":")
             + _priv->address->toString() + LOG4CXX_STR(":");
-        StringHelper::toString(_priv->port, p, _priv->taskName);
+        StringHelper::toString(_priv->port, _priv->taskName);
     }
     auto taskManager = ThreadUtility::instancePtr();
     if (!taskManager->value().hasPeriodicTask(_priv->taskName))
     {
-        Pool p;
         if (LogLog::isDebugEnabled())
         {
-            Pool p;
             LogString msg(LOG4CXX_STR("Waiting "));
-            StringHelper::toString(_priv->reconnectionDelay, p, msg);
+            StringHelper::toString(_priv->reconnectionDelay, msg);
             msg += LOG4CXX_STR(" ms before retrying [")
                 + _priv->address->toString() + LOG4CXX_STR(":");
-            StringHelper::toString(_priv->port, p, msg);
+            StringHelper::toString(_priv->port, msg);
             msg += LOG4CXX_STR("].");
             LogLog::debug(msg);
         }
@@ -175,7 +172,7 @@ void SocketAppenderSkeleton::retryConnect()
 	}
 	else
 	{
-		Pool p;
+        Pool p;
 		SocketPtr socket;
 		try
 		{
@@ -183,7 +180,7 @@ void SocketAppenderSkeleton::retryConnect()
 			{
 				LogString msg(LOG4CXX_STR("Attempting connection to [")
 					+ _priv->address->toString() + LOG4CXX_STR(":"));
-				StringHelper::toString(_priv->port, p, msg);
+				StringHelper::toString(_priv->port, msg);
 				msg += LOG4CXX_STR("].");
 				LogLog::debug(msg);
 			}
@@ -193,7 +190,7 @@ void SocketAppenderSkeleton::retryConnect()
 			{
 				LogString msg(LOG4CXX_STR("Connection established to [")
 					+ _priv->address->toString() + LOG4CXX_STR(":"));
-				StringHelper::toString(_priv->port, p, msg);
+				StringHelper::toString(_priv->port, msg);
 				msg += LOG4CXX_STR("].");
 				LogLog::debug(msg);
 			}
@@ -211,7 +208,7 @@ void SocketAppenderSkeleton::retryConnect()
 		{
 			LogString msg(LOG4CXX_STR("Could not connect to [")
 				+ _priv->address->toString() + LOG4CXX_STR(":"));
-			StringHelper::toString(_priv->port, p, msg);
+			StringHelper::toString(_priv->port, msg);
 			msg += LOG4CXX_STR("].");
 			LogLog::warn(msg, e);
 		}
@@ -221,10 +218,10 @@ void SocketAppenderSkeleton::retryConnect()
 			if (LogLog::isDebugEnabled())
 			{
 				LogString msg(LOG4CXX_STR("Waiting "));
-				StringHelper::toString(_priv->reconnectionDelay, p, msg);
+				StringHelper::toString(_priv->reconnectionDelay, msg);
 				msg += LOG4CXX_STR(" ms before retrying [")
 					+ _priv->address->toString() + LOG4CXX_STR(":");
-				StringHelper::toString(_priv->port, p, msg);
+				StringHelper::toString(_priv->port, msg);
 				msg += LOG4CXX_STR("].");
 				LogLog::debug(msg);
 			}

--- a/src/main/cpp/stringhelper.cpp
+++ b/src/main/cpp/stringhelper.cpp
@@ -129,7 +129,7 @@ int64_t StringHelper::toInt64(const LogString& s)
 #endif
 }
 
-void StringHelper::toString(int n, Pool& pool, LogString& dst)
+void StringHelper::toString(int n, LogString& dst)
 {
 #if LOG4CXX_LOGCHAR_IS_WCHAR
 	dst.append(std::to_wstring(n));
@@ -151,7 +151,7 @@ void StringHelper::toString(bool val, LogString& dst)
 }
 
 
-void StringHelper::toString(int64_t n, Pool& pool, LogString& dst)
+void StringHelper::toString(int64_t n, LogString& dst)
 {
 #if LOG4CXX_LOGCHAR_IS_WCHAR
 	dst.append(std::to_wstring(n));
@@ -161,7 +161,7 @@ void StringHelper::toString(int64_t n, Pool& pool, LogString& dst)
 }
 
 
-void StringHelper::toString(size_t n, Pool& pool, LogString& dst)
+void StringHelper::toString(size_t n, LogString& dst)
 {
 #if LOG4CXX_LOGCHAR_IS_WCHAR
 	dst.append(std::to_wstring(n));
@@ -195,3 +195,8 @@ LogString StringHelper::format(const LogString& pattern, const std::vector<LogSt
 	return result;
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
+void StringHelper::toString(int n, Pool& pool, LogString& dst) { toString(n, dst); }
+void StringHelper::toString(int64_t n, Pool& pool, LogString& dst) { toString(n, dst); }
+void StringHelper::toString(size_t n, Pool& pool, LogString& dst) { toString(n, dst); }
+#endif

--- a/src/main/cpp/syslogappender.cpp
+++ b/src/main/cpp/syslogappender.cpp
@@ -83,9 +83,8 @@ void SyslogAppender::initSyslogFacilityStr()
 
 	if (_priv->facilityStr.empty())
 	{
-		Pool p;
 		LogString msg(LOG4CXX_STR("\""));
-		StringHelper::toString(_priv->syslogFacility, p, msg);
+		StringHelper::toString(_priv->syslogFacility, msg);
 		msg.append(LOG4CXX_STR("\" is an unknown syslog facility. Defaulting to \"USER\"."));
 		LogLog::warn(msg);
 		_priv->syslogFacility = LOG_USER;
@@ -355,7 +354,7 @@ void SyslogAppender::append(const spi::LoggingEventPtr& event, Pool& p)
 	for (auto const& item : packets)
 	{
 		LogString sbuf(1, 0x3C /* '<' */);
-		StringHelper::toString((_priv->syslogFacility | event->getLevel()->getSyslogEquivalent()), p, sbuf);
+		StringHelper::toString((_priv->syslogFacility | event->getLevel()->getSyslogEquivalent()), sbuf);
 		sbuf.append(1, (logchar) 0x3E /* '>' */);
 
 		if (_priv->facilityPrinting)

--- a/src/main/cpp/system.cpp
+++ b/src/main/cpp/system.cpp
@@ -140,9 +140,8 @@ void System::addProgramFilePathComponents(Properties& props)
 #if defined(_WIN32)
 	if (0 == GetModuleFileName(NULL, buf, bufSize))
 	{
-		Pool p;
 		LogString lsErrorCode;
-		StringHelper::toString((int)GetLastError(), p, lsErrorCode);
+		StringHelper::toString((int)GetLastError(), lsErrorCode);
 		LogLog::warn(LOG4CXX_STR("GetModuleFileName error ") + lsErrorCode);
 		return;
 	}

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -193,9 +193,8 @@ void TelnetAppender::TelnetAppenderPriv::close()
 	std::lock_guard<std::recursive_mutex> lock(this->mutex);
 	if (this->eventCount && helpers::LogLog::isDebugEnabled())
 	{
-		Pool p;
 		LogString msg = LOG4CXX_STR("TelnetAppender eventCount ");
-		helpers::StringHelper::toString(this->eventCount, p, msg);
+		helpers::StringHelper::toString(this->eventCount, msg);
 		helpers::LogLog::debug(msg);
 	}
 	SocketPtr nullSocket;
@@ -208,11 +207,10 @@ void TelnetAppender::TelnetAppenderPriv::close()
 			item.s->close();
 			if (this->eventCount && helpers::LogLog::isDebugEnabled())
 			{
-				Pool p;
 				LogString msg = LOG4CXX_STR("TelnetAppender connection ");
-				helpers::StringHelper::toString(connectionNumber, p, msg);
+				helpers::StringHelper::toString(connectionNumber, msg);
 				msg += LOG4CXX_STR(" sentCount ");
-				helpers::StringHelper::toString(item.sentCount, p, msg);
+				helpers::StringHelper::toString(item.sentCount, msg);
 				helpers::LogLog::debug(msg);
 			}
 			item = Connection{ nullSocket, 0 };
@@ -240,13 +238,12 @@ void TelnetAppender::write(ByteBuffer& buf)
 			{
 				if (helpers::LogLog::isDebugEnabled())
 				{
-					Pool p;
 					LogString msg(LOG4CXX_STR("TelnetAppender connection "));
-					helpers::StringHelper::toString(connectionNumber, p, msg);
+					helpers::StringHelper::toString(connectionNumber, msg);
 					msg += LOG4CXX_STR(" sentCount ");
-					helpers::StringHelper::toString(item.sentCount, p, msg);
+					helpers::StringHelper::toString(item.sentCount, msg);
 					msg += LOG4CXX_STR("/");
-					helpers::StringHelper::toString(_priv->eventCount, p, msg);
+					helpers::StringHelper::toString(_priv->eventCount, msg);
 					helpers::LogLog::warn(msg, e);
 				}
 				item.s.reset();
@@ -364,11 +361,10 @@ void TelnetAppender::acceptConnections()
 						_priv->activeConnections++;
 						if (helpers::LogLog::isDebugEnabled())
 						{
-							Pool p;
 							LogString msg = LOG4CXX_STR("TelnetAppender new connection ");
-							helpers::StringHelper::toString(connectionNumber, p, msg);
+							helpers::StringHelper::toString(connectionNumber, msg);
 							msg += LOG4CXX_STR("/");
-							helpers::StringHelper::toString(_priv->activeConnections, p, msg);
+							helpers::StringHelper::toString(_priv->activeConnections, msg);
 							helpers::LogLog::debug(msg);
 						}
 
@@ -378,7 +374,7 @@ void TelnetAppender::acceptConnections()
 
 				Pool p;
 				LogString oss(LOG4CXX_STR("TelnetAppender v1.0 ("));
-				StringHelper::toString((int) count + 1, p, oss);
+				StringHelper::toString((int) count + 1, oss);
 				oss += LOG4CXX_STR(" active connections)\r\n\r\n");
 				writeStatus(newClient, oss, p);
 			}

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -472,7 +472,7 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::rollover(
 		if (MAX_FILE_LEN - sizeof (logchar) < byteCount)
 		{
 			LogString msg(newFileName + LOG4CXX_STR(": cannot exceed "));
-			StringHelper::toString(MAX_FILE_LEN / sizeof (logchar), pool, msg);
+			StringHelper::toString(MAX_FILE_LEN / sizeof (logchar), msg);
 			msg += LOG4CXX_STR(" characters");
 			throw IllegalArgumentException(msg);
 		}

--- a/src/main/cpp/timezone.cpp
+++ b/src/main/cpp/timezone.cpp
@@ -252,9 +252,8 @@ const TimeZonePtr TimeZone::getTimeZone( const LogString& id )
 		}
 
 		LogString s(gmt);
-		Pool p;
 		LogString hh;
-		StringHelper::toString(hours, p, hh);
+		StringHelper::toString(hours, hh);
 
 		if (sign > 0)
 		{
@@ -273,7 +272,7 @@ const TimeZonePtr TimeZone::getTimeZone( const LogString& id )
 		s.append(hh);
 		s.append(1, (logchar) 0x3A /*' :' */);
 		LogString mm;
-		StringHelper::toString(minutes, p, mm);
+		StringHelper::toString(minutes, mm);
 
 		if (mm.length() == 1)
 		{

--- a/src/main/cpp/transcoder.cpp
+++ b/src/main/cpp/transcoder.cpp
@@ -629,10 +629,9 @@ void Transcoder::decode(const CFStringRef& src, LogString& dst)
 #if defined(_DEBUG)
 	if (LogLog::isDebugEnabled())
 	{
-		Pool pool;
 		LogString msg(LOG4CXX_STR("Transcoder::decodeCFString"));
 		msg += LOG4CXX_STR(" length ");
-		StringHelper::toString((size_t)length, pool, msg);
+		StringHelper::toString((size_t)length, msg);
 		LogLog::debug(msg);
 	}
 #endif

--- a/src/main/cpp/xmllayout.cpp
+++ b/src/main/cpp/xmllayout.cpp
@@ -83,7 +83,7 @@ void XMLLayout::format(LogString& output,
 	output.append(LOG4CXX_STR("<log4j:event logger=\""));
 	Transform::appendLegalCharacters(output, event->getLoggerName());
 	output.append(LOG4CXX_STR("\" timestamp=\""));
-	StringHelper::toString(event->getTimeStamp() / 1000L, p, output);
+	StringHelper::toString(event->getTimeStamp() / 1000L, output);
 	output.append(LOG4CXX_STR("\" level=\""));
 	Transform::appendLegalCharacters(output, event->getLevel()->toString());
 	output.append(LOG4CXX_STR("\" thread=\""));
@@ -121,7 +121,7 @@ void XMLLayout::format(LogString& output,
 		LOG4CXX_DECODE_CHAR(fileName, locInfo.getFileName());
 		Transform::appendLegalCharacters(output, fileName);
 		output.append(LOG4CXX_STR("\" line=\""));
-		StringHelper::toString(locInfo.getLineNumber(), p, output);
+		StringHelper::toString(locInfo.getLineNumber(), output);
 		output.append(LOG4CXX_STR("\"/>"));
 		output.append(LOG4CXX_EOL);
 	}

--- a/src/main/include/log4cxx/helpers/stringhelper.h
+++ b/src/main/include/log4cxx/helpers/stringhelper.h
@@ -26,7 +26,9 @@ namespace LOG4CXX_NS
 {
 namespace helpers
 {
+#if LOG4CXX_ABI_VERSION <= 15
 class Pool;
+#endif
 /**
 String manipulation routines
 */
@@ -45,10 +47,20 @@ class LOG4CXX_EXPORT StringHelper
 		static int toInt(const LogString& s);
 		static int64_t toInt64(const LogString& s);
 
-		static void toString(int i, LOG4CXX_NS::helpers::Pool& pool, LogString& dst);
-		static void toString(int64_t i, LOG4CXX_NS::helpers::Pool& pool, LogString& dst);
-		static void toString(size_t i, LOG4CXX_NS::helpers::Pool& pool, LogString& dst);
-
+#if LOG4CXX_ABI_VERSION <= 15
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		static void toString(int i, Pool& pool, LogString& dst);
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		static void toString(int64_t i, Pool& pool, LogString& dst);
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		static void toString(size_t i, Pool& pool, LogString& dst);
+#endif
+		static void toString(int i, LogString& dst);
+		static void toString(int64_t i, LogString& dst);
+		static void toString(size_t i, LogString& dst);
 		static void toString(bool val, LogString& dst);
 
 		static LogString toLowerCase(const LogString& s);

--- a/src/test/cpp/asyncappendertestcase.cpp
+++ b/src/test/cpp/asyncappendertestcase.cpp
@@ -312,12 +312,11 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 
 			const std::vector<spi::LoggingEventPtr>& v = vectorAppender->getVector();
 			LOGUNIT_ASSERT_EQUAL(LEN, v.size());
-			Pool p;
 			int i{ 0 };
 			for (auto e : v)
 			{
 				LogString m(LOG4CXX_STR("message"));
-				StringHelper::toString(i, p, m);
+				StringHelper::toString(i, m);
 				LOGUNIT_ASSERT_EQUAL(m, e->getRenderedMessage());
 				++i;
 			}
@@ -490,18 +489,17 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			}
 			if (helpers::LogLog::isDebugEnabled())
 			{
-				Pool p;
 				LogString msg{ LOG4CXX_STR("messageCounts:") };
 				for (auto& item : levelCount)
 				{
 					msg += LOG4CXX_STR(" ");
 					msg += item.first->toString();
 					msg += LOG4CXX_STR(" ");
-					StringHelper::toString(item.second, p, msg);
+					StringHelper::toString(item.second, msg);
 				}
 				msg += LOG4CXX_STR(" ");
 				msg += LOG4CXX_STR("Discarded ");
-				StringHelper::toString(discardMessageCount, p, msg);
+				StringHelper::toString(discardMessageCount, msg);
 				helpers::LogLog::debug(msg);
 			}
 			// Check this test has activated the discard logic
@@ -570,14 +568,13 @@ class AsyncAppenderTestCase : public AppenderSkeletonTestCase
 			}
 			if (helpers::LogLog::isDebugEnabled())
 			{
-				Pool p;
 				LogString msg{ LOG4CXX_STR("messageCounts:") };
 				msg += LOG4CXX_STR(" nonAppender ");
-				StringHelper::toString(eventCount[0], p, msg);
+				StringHelper::toString(eventCount[0], msg);
 				msg += LOG4CXX_STR(" appender ");
-				StringHelper::toString(eventCount[1], p, msg);
+				StringHelper::toString(eventCount[1], msg);
 				msg += LOG4CXX_STR(" discard ");
-				StringHelper::toString(discardMessageCount, p, msg);
+				StringHelper::toString(discardMessageCount, msg);
 				LogLog::debug(msg);
 			}
 			LOGUNIT_ASSERT(12 < events.size());

--- a/src/test/cpp/fileappendertest.cpp
+++ b/src/test/cpp/fileappendertest.cpp
@@ -149,9 +149,9 @@ public:
 		if (helpers::LogLog::isDebugEnabled())
 		{
 			LogString msg(LOG4CXX_STR("initialLength "));
-			helpers::StringHelper::toString(initialLength, p, msg);
+			helpers::StringHelper::toString(initialLength, msg);
 			msg += LOG4CXX_STR(" flushedLength ");
-			helpers::StringHelper::toString(flushedLength, p, msg);
+			helpers::StringHelper::toString(flushedLength, msg);
 			helpers::LogLog::debug(msg);
 		}
 		LOGUNIT_ASSERT(initialLength < flushedLength);
@@ -202,9 +202,9 @@ public:
 		if (exitCode != 0)
 		{
 			LogString msg = LOG4CXX_STR("child exit code: ");
-			helpers::StringHelper::toString(exitCode, p, msg);
+			helpers::StringHelper::toString(exitCode, msg);
 			msg += LOG4CXX_STR("; reason: ");
-			helpers::StringHelper::toString(reason, p, msg);
+			helpers::StringHelper::toString(reason, msg);
 			helpers::LogLog::warn(msg);
 		}
 		LOGUNIT_ASSERT_EQUAL(exitCode, 0);
@@ -237,7 +237,7 @@ public:
 			 }
 		}
 		LogString msg = LOG4CXX_STR("lineCount: ");
-		helpers::StringHelper::toString(lineCount, p, msg);
+		helpers::StringHelper::toString(lineCount, msg);
 		helpers::LogLog::debug(msg);
 		for (auto& count : messageCount)
 			LOGUNIT_ASSERT_EQUAL(count, messageCount.front());

--- a/src/test/cpp/net/socketappendertestcase.cpp
+++ b/src/test/cpp/net/socketappendertestcase.cpp
@@ -169,12 +169,11 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
 
 			if (helpers::LogLog::isDebugEnabled())
 			{
-				helpers::Pool p;
 				LogString msg(LOG4CXX_STR("messageCount "));
 				for (auto item : messageCount)
 				{
 					msg += logchar(' ');
-					helpers::StringHelper::toString(item, p, msg);
+					helpers::StringHelper::toString(item, msg);
 				}
 				helpers::LogLog::debug(msg);
 			}

--- a/src/test/cpp/net/telnetappendertestcase.cpp
+++ b/src/test/cpp/net/telnetappendertestcase.cpp
@@ -160,9 +160,9 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 			if (exitCode != 0 && helpers::LogLog::isDebugEnabled())
 			{
 				LogString msg = LOG4CXX_STR("child exit code: ");
-				helpers::StringHelper::toString(exitCode, p, msg);
+				helpers::StringHelper::toString(exitCode, msg);
 				msg += LOG4CXX_STR("; reason: ");
-				helpers::StringHelper::toString(reason, p, msg);
+				helpers::StringHelper::toString(reason, msg);
 				helpers::LogLog::debug(msg);
 			}
 			LOGUNIT_ASSERT_EQUAL(exitCode, 0);

--- a/src/test/cpp/rolling/manualrollingtest.cpp
+++ b/src/test/cpp/rolling/manualrollingtest.cpp
@@ -328,7 +328,7 @@ public:
 		LogString filenamePattern = LOG4CXX_STR("output/directory-");
 
 		LogString dirNumber;
-		StringHelper::toString(dist(rng), dirNumber);
+		StringHelper::toString(static_cast<int>(dist(rng)), dirNumber);
 
 		filenamePattern.append( dirNumber );
 		LogString filenamePatternPrefix = filenamePattern;

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -214,11 +214,11 @@ public:
 			if (exitCode != 0 && helpers::LogLog::isDebugEnabled())
 			{
 				LogString msg = LOG4CXX_STR("child: ");
-				helpers::StringHelper::toString(i, p, msg);
+				helpers::StringHelper::toString(i, msg);
 				msg += LOG4CXX_STR("; exit code: ");
-				helpers::StringHelper::toString(exitCode, p, msg);
+				helpers::StringHelper::toString(exitCode, msg);
 				msg += LOG4CXX_STR("; reason: ");
-				helpers::StringHelper::toString(reason, p, msg);
+				helpers::StringHelper::toString(reason, msg);
 				helpers::LogLog::debug(msg);
 			}
 			LOGUNIT_ASSERT_EQUAL(exitCode, 0);
@@ -228,7 +228,7 @@ public:
 			LogString msg;
 			auto currentTime = helpers::Date::currentTime();
 			msg += LOG4CXX_STR("elapsed ");
-			helpers::StringHelper::toString(currentTime - startTime, p, msg);
+			helpers::StringHelper::toString(currentTime - startTime, msg);
 			helpers::LogLog::debug(msg);
 		}
 
@@ -292,7 +292,7 @@ public:
 					for (auto item : perThreadMessageCount)
 					{
 						msg += logchar(' ');
-						helpers::StringHelper::toString(item.second - initialPerThreadMessageCount[item.first], p, msg);
+						helpers::StringHelper::toString(item.second - initialPerThreadMessageCount[item.first], msg);
 					}
 					helpers::LogLog::debug(msg);
 				}
@@ -304,7 +304,7 @@ public:
 			for (auto item : messageCount)
 			{
 				msg += logchar(' ');
-				helpers::StringHelper::toString(item, p, msg);
+				helpers::StringHelper::toString(item, msg);
 			}
 			helpers::LogLog::debug(msg);
 		}
@@ -314,7 +314,7 @@ public:
 			for (auto item : perThreadMessageCount)
 			{
 				msg += logchar(' ');
-				helpers::StringHelper::toString(item.second, p, msg);
+				helpers::StringHelper::toString(item.second, msg);
 			}
 			helpers::LogLog::debug(msg);
 		}

--- a/src/test/cpp/rolling/timebasedrollingtest.cpp
+++ b/src/test/cpp/rolling/timebasedrollingtest.cpp
@@ -237,7 +237,7 @@ private:
 	{
 		LogString witness(LOG4CXX_STR("" DIR_PRE_WITNESS));
 		witness.append(prefix);
-		StringHelper::toString(witnessIdx, pool, witness);
+		StringHelper::toString(witnessIdx, witness);
 
 		//std::wcerr << L"Comparing file:    " << fname	<< L"\n";
 		//std::wcerr << L"Comparing witness: " << witness	<< L"\n";
@@ -659,7 +659,7 @@ public:
 		std::uniform_int_distribution<std::mt19937::result_type> dist(1,100000);
 		LogString filenamePattern = LOG4CXX_STR("" DIR_PRE_OUTPUT);
 		LogString dirNumber;
-		StringHelper::toString(dist(rng), dirNumber);
+		StringHelper::toString(static_cast<int>(dist(rng)), dirNumber);
 		LogString directoryName = LOG4CXX_STR("tbr-rollIntoDir-");
 		directoryName.append( dirNumber );
 		filenamePattern.append( directoryName );

--- a/src/test/cpp/util/compare.cpp
+++ b/src/test/cpp/util/compare.cpp
@@ -61,7 +61,7 @@ bool Compare::compare(const File& file1, const File& file2)
 			msg += LOG4CXX_STR("] and [");
 			msg += file2.getPath();
 			msg += LOG4CXX_STR("] differ on line ");
-			StringHelper::toString(lineCounter, pool, msg);
+			StringHelper::toString(lineCounter, msg);
 			msg += LOG4CXX_EOL;
 			msg += LOG4CXX_STR("One reads:  [");
 			msg += s1;
@@ -118,7 +118,7 @@ void Compare::outputFile(const File& file,
 	{
 		lineCounter++;
 		LogString line;
-		StringHelper::toString(lineCounter, pool, line);
+		StringHelper::toString(lineCounter, line);
 		emit(line);
 
 		if (lineCounter < 10)

--- a/src/test/cpp/varia/levelmatchfiltertestcase.cpp
+++ b/src/test/cpp/varia/levelmatchfiltertestcase.cpp
@@ -97,7 +97,7 @@ public:
 			// set the level to match
 			matchFilter->setLevelToMatch(levelArray[x]->toString());
 			LogString sbuf(LOG4CXX_STR("pass "));
-			StringHelper::toString(x, pool, sbuf);
+			StringHelper::toString(x, sbuf);
 			sbuf.append(LOG4CXX_STR("; filter set to accept only "));
 			sbuf.append(levelArray[x]->toString());
 			sbuf.append(LOG4CXX_STR(" msgs"));
@@ -137,7 +137,7 @@ public:
 			matchFilter->setLevelToMatch(levelArray[x]->toString());
 			LogString sbuf(LOG4CXX_STR("pass "));
 
-			StringHelper::toString(x, pool, sbuf);
+			StringHelper::toString(x, sbuf);
 			sbuf.append(LOG4CXX_STR("; filter set to deny only "));
 			sbuf.append(levelArray[x]->toString());
 			sbuf.append(LOG4CXX_STR(" msgs"));

--- a/src/test/cpp/varia/levelrangefiltertestcase.cpp
+++ b/src/test/cpp/varia/levelrangefiltertestcase.cpp
@@ -86,8 +86,7 @@ public:
 		int passCount = 0;
 		LogString sbuf(LOG4CXX_STR("pass "));
 
-		Pool pool;
-		StringHelper::toString(passCount, pool, sbuf);
+		StringHelper::toString(passCount, sbuf);
 
 		sbuf.append(LOG4CXX_STR("; no min or max set"));
 		common(sbuf);
@@ -96,7 +95,7 @@ public:
 		// test with a min set
 		rangeFilter->setLevelMin(Level::getWarn());
 		sbuf.assign(LOG4CXX_STR("pass "));
-		StringHelper::toString(passCount, pool, sbuf);
+		StringHelper::toString(passCount, sbuf);
 		sbuf.append(LOG4CXX_STR("; min set to WARN, max not set"));
 		common(sbuf);
 		passCount++;
@@ -109,7 +108,7 @@ public:
 		//test with max set
 		rangeFilter->setLevelMax(Level::getWarn());
 		sbuf.assign(LOG4CXX_STR("pass "));
-		StringHelper::toString(passCount, pool, sbuf);
+		StringHelper::toString(passCount, sbuf);
 		sbuf.append(LOG4CXX_STR("; min not set, max set to WARN"));
 		common(sbuf);
 		passCount++;
@@ -134,7 +133,7 @@ public:
 				rangeFilter->setLevelMax(levelArray[y]);
 
 				sbuf.assign(LOG4CXX_STR("pass "));
-				StringHelper::toString(passCount, pool, sbuf);
+				StringHelper::toString(passCount, sbuf);
 				sbuf.append(LOG4CXX_STR("; filter set to accept between "));
 				sbuf.append(levelArray[x]->toString());
 				sbuf.append(LOG4CXX_STR(" and "));
@@ -173,8 +172,7 @@ public:
 		int passCount = 0;
 		LogString sbuf(LOG4CXX_STR("pass "));
 
-		Pool pool;
-		StringHelper::toString(passCount, pool, sbuf);
+		StringHelper::toString(passCount, sbuf);
 
 		// test with no min or max set
 		sbuf.append(LOG4CXX_STR("; no min or max set"));
@@ -185,7 +183,7 @@ public:
 		rangeFilter->setLevelMin(Level::getWarn());
 		sbuf.assign(LOG4CXX_STR("pass "));
 
-		StringHelper::toString(passCount, pool, sbuf);
+		StringHelper::toString(passCount, sbuf);
 		sbuf.append(LOG4CXX_STR("; min set to WARN, max not set"));
 		common(sbuf);
 		passCount++;
@@ -199,7 +197,7 @@ public:
 		rangeFilter->setLevelMax(Level::getWarn());
 		sbuf.assign(LOG4CXX_STR("pass "));
 
-		StringHelper::toString(passCount, pool, sbuf);
+		StringHelper::toString(passCount, sbuf);
 
 		sbuf.append(LOG4CXX_STR("; min not set, max set to WARN"));
 		common(sbuf);
@@ -224,7 +222,7 @@ public:
 				rangeFilter->setLevelMax(levelArray[y]);
 
 				sbuf.assign(LOG4CXX_STR("pass "));
-				StringHelper::toString(passCount, pool, sbuf);
+				StringHelper::toString(passCount, sbuf);
 				sbuf.append(LOG4CXX_STR("; filter set to accept between "));
 				sbuf.append(levelArray[x]->toString());
 				sbuf.append(LOG4CXX_STR(" and "));


### PR DESCRIPTION
This PR removes the unused Pool parameter in calls to `StringHelper::toString` functions.