### PR TITLE
Simplify the helpers::File interface in the next ABI version

### DIFF
--- a/src/main/cpp/bytebuffer.cpp
+++ b/src/main/cpp/bytebuffer.cpp
@@ -16,8 +16,9 @@
  */
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/bytebuffer.h>
+#if LOG4CXX_ABI_VERSION <= 15
 #include <log4cxx/helpers/exception.h>
-#include <log4cxx/helpers/pool.h>
+#endif
 #include <cstring>
 
 using namespace LOG4CXX_NS;

--- a/src/main/cpp/defaultconfigurator.cpp
+++ b/src/main/cpp/defaultconfigurator.cpp
@@ -17,7 +17,6 @@
 #include <log4cxx/logstring.h>
 #include <log4cxx/defaultconfigurator.h>
 #include <log4cxx/logmanager.h>
-#include <log4cxx/helpers/pool.h>
 #include <log4cxx/spi/loggerrepository.h>
 #include <log4cxx/file.h>
 #include <log4cxx/helpers/loglog.h>
@@ -58,7 +57,6 @@ void DefaultConfigurator::configure(LoggerRepositoryPtr repository)
 {
 
 	LogString configurationFileName = getConfigurationFileName();
-	Pool pool;
 	File configuration;
 
 	if (configurationFileName.empty())
@@ -80,7 +78,7 @@ void DefaultConfigurator::configure(LoggerRepositoryPtr repository)
 				debugMsg.append(names[i]);
 				LogLog::debug(debugMsg);
 			}
-			if (candidate.exists(pool))
+			if (candidate.exists())
 			{
 				configuration = candidate;
 				break;
@@ -92,7 +90,7 @@ void DefaultConfigurator::configure(LoggerRepositoryPtr repository)
 		configuration.setPath(configurationFileName);
 	}
 
-	if (configuration.exists(pool))
+	if (configuration.exists())
 	{
 		if (LogLog::isDebugEnabled())
 		{
@@ -192,7 +190,6 @@ DefaultConfigurator::configureFromFile(const std::vector<LogString>& directories
 	auto result = std::tuple<ConfigurationStatus, LogString>
 		{ ConfigurationStatus::NotConfigured, LogString() };
 	auto r = LogManager::getLoggerRepository();
-	Pool pool;
 
 	for (auto& dir : directories )
 	{
@@ -204,7 +201,7 @@ DefaultConfigurator::configureFromFile(const std::vector<LogString>& directories
 
 			if (LogLog::isDebugEnabled())
 				LogLog::debug(LOG4CXX_STR("Checking file ") + candidate_str);
-			if (candidate.exists(pool))
+			if (candidate.exists())
 			{
 				std::get<1>(result) = candidate_str;
 				configure(r);

--- a/src/main/cpp/domconfigurator.cpp
+++ b/src/main/cpp/domconfigurator.cpp
@@ -975,7 +975,7 @@ spi::ConfigurationStatus DOMConfigurator::doConfigure
 		);
 
 	apr_file_t* fd;
-	log4cxx_status_t rv = filename.open(&fd, APR_READ, APR_OS_DEFAULT, m_priv->p);
+	log4cxx_status_t rv = apr_file_open(&fd, filename.getAPRPath(), APR_READ, APR_OS_DEFAULT, m_priv->p.getAPRPool());
 
 	if (rv != APR_SUCCESS)
 	{

--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -156,6 +156,12 @@ IOException::IOException(const LogString& type, log4cxx_status_t stat)
 {
 }
 
+#if !LOG4CXX_LOGCHAR_IS_UTF8
+IOException::IOException(const char* type, log4cxx_status_t stat)
+	: Exception(makeMessage(type, stat).c_str())
+{
+}
+#endif
 
 IOException::IOException(const char* msg1)
 	: Exception(msg1)
@@ -203,6 +209,25 @@ LogString Exception::makeMessage(const LogString& type, log4cxx_status_t stat)
 	return s;
 }
 
+#if !LOG4CXX_LOGCHAR_IS_UTF8
+std::string Exception::makeMessage(const char* type, log4cxx_status_t stat)
+{
+	std::string s = type;
+	char err_buff[1024] = {0};
+	apr_strerror(stat, err_buff, sizeof(err_buff));
+	if (0 == err_buff[0] || 0 == strncmp(err_buff, "APR does not understand", 23))
+	{
+		s.append(": error code ");
+		s.append(std::to_string(stat));
+	}
+	else
+	{
+		s.append(" - ");
+		s.append(err_buff);
+	}
+	return s;
+}
+#endif
 
 MissingResourceException::MissingResourceException(const LogString& key)
 	: Exception(formatMessage(key))

--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -157,6 +157,11 @@ IOException::IOException(const LogString& type, log4cxx_status_t stat)
 }
 
 
+IOException::IOException(const char* msg1)
+	: Exception(msg1)
+{
+}
+
 IOException::IOException(const LogString& msg1)
 	: Exception(msg1)
 {

--- a/src/main/cpp/file.cpp
+++ b/src/main/cpp/file.cpp
@@ -28,24 +28,22 @@ using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
 
 struct File::FilePrivate{
-	FilePrivate() :
-		autoDelete(false)
+	FilePrivate()
 	{}
 
-	FilePrivate(LogString path) :
-		path(path),
-		autoDelete(false)
+	FilePrivate(const LogString& path)
+		: path(path)
 	{}
 
-	FilePrivate(LogString path, bool autoDelete) :
-		path(path),
-		autoDelete(autoDelete)
+	FilePrivate(const LogString& path, bool autoDelete)
+		: path(path)
+		, autoDelete(autoDelete)
 	{}
 
 	LogString path;
-	bool autoDelete;
+	bool autoDelete{ false };
 	Pool p;
-	char* apr_path{0};
+	char* apr_path{ nullptr };
 	char* getPath();
 	static char* convertBackSlashes(char*);
 };
@@ -153,6 +151,7 @@ LogString File::getPath() const
 File& File::setPath(const LogString& newName)
 {
 	m_priv->path.assign(newName);
+	m_priv->apr_path = nullptr;
 	return *this;
 }
 

--- a/src/main/cpp/file.cpp
+++ b/src/main/cpp/file.cpp
@@ -44,6 +44,10 @@ struct File::FilePrivate{
 
 	LogString path;
 	bool autoDelete;
+	Pool p;
+	char* apr_path{0};
+	char* getPath();
+	static char* convertBackSlashes(char*);
 };
 
 File::File() :
@@ -136,8 +140,7 @@ File& File::operator=(const File& src)
 File::~File()
 {
 	if(m_priv->autoDelete){
-		Pool p;
-		deleteFile(p);
+		deleteFile();
 	}
 }
 
@@ -166,41 +169,45 @@ LogString File::getName() const
 	return m_priv->path;
 }
 
-char* File::getPath(Pool& p) const
+char* File::FilePrivate::getPath()
 {
+	if (this->apr_path)
+		return this->apr_path;
 	int style = APR_FILEPATH_ENCODING_UNKNOWN;
-	apr_filepath_encoding(&style, p.getAPRPool());
-	char* retval = NULL;
+	apr_filepath_encoding(&style, this->p.getAPRPool());
 
 	if (style == APR_FILEPATH_ENCODING_UTF8)
 	{
-		retval = Transcoder::encodeUTF8(m_priv->path, p);
+		this->apr_path = Transcoder::encodeUTF8(this->path, this->p);
 	}
 	else
 	{
-		retval = Transcoder::encode(m_priv->path, p);
+		this->apr_path = Transcoder::encode(this->path, this->p);
 	}
 
-	return retval;
+	return convertBackSlashes(this->apr_path);
 }
 
-log4cxx_status_t File::open(apr_file_t** file, int flags,
-	int perm, Pool& p) const
+const char* File::getAPRPath() const
 {
-	return apr_file_open(file, getPath(p), flags, perm, p.getAPRPool());
+	return m_priv->getPath();
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
+log4cxx_status_t File::open(apr_file_t** file, int flags, int perm, helpers::Pool& p) const
+{
+	return apr_file_open(file, m_priv->getPath(), flags, perm, p.getAPRPool());
+}
+#endif
 
-
-bool File::exists(Pool& p) const
+bool File::exists() const
 {
 	apr_finfo_t finfo;
-	apr_status_t rv = apr_stat(&finfo, getPath(p),
-			0, p.getAPRPool());
+	apr_status_t rv = apr_stat(&finfo, m_priv->getPath(), 0, m_priv->p.getAPRPool());
 	return rv == APR_SUCCESS;
 }
 
-char* File::convertBackSlashes(char* src)
+char* File::FilePrivate::convertBackSlashes(char* src)
 {
 	for (char* c = src; *c != 0; c++)
 	{
@@ -213,27 +220,23 @@ char* File::convertBackSlashes(char* src)
 	return src;
 }
 
-bool File::deleteFile(Pool& p) const
+bool File::deleteFile() const
 {
-	apr_status_t rv = apr_file_remove(convertBackSlashes(getPath(p)),
-			p.getAPRPool());
+	apr_status_t rv = apr_file_remove(m_priv->getPath(), m_priv->p.getAPRPool());
 	return rv == APR_SUCCESS;
 }
 
-bool File::renameTo(const File& dest, Pool& p) const
+bool File::renameTo(const File& dest) const
 {
-	apr_status_t rv = apr_file_rename(convertBackSlashes(getPath(p)),
-			convertBackSlashes(dest.getPath(p)),
-			p.getAPRPool());
+	apr_status_t rv = apr_file_rename(m_priv->getPath(), dest.m_priv->getPath(), m_priv->p.getAPRPool());
 	return rv == APR_SUCCESS;
 }
 
 
-size_t File::length(Pool& pool) const
+size_t File::length() const
 {
 	apr_finfo_t finfo;
-	apr_status_t rv = apr_stat(&finfo, getPath(pool),
-			APR_FINFO_SIZE, pool.getAPRPool());
+	apr_status_t rv = apr_stat(&finfo, m_priv->getPath(), APR_FINFO_SIZE, m_priv->p.getAPRPool());
 
 	if (rv == APR_SUCCESS)
 	{
@@ -244,11 +247,10 @@ size_t File::length(Pool& pool) const
 }
 
 
-log4cxx_time_t File::lastModified(Pool& pool) const
+log4cxx_time_t File::lastModified() const
 {
 	apr_finfo_t finfo;
-	apr_status_t rv = apr_stat(&finfo, getPath(pool),
-			APR_FINFO_MTIME, pool.getAPRPool());
+	apr_status_t rv = apr_stat(&finfo, m_priv->getPath(), APR_FINFO_MTIME, m_priv->p.getAPRPool());
 
 	if (rv == APR_SUCCESS)
 	{
@@ -259,20 +261,18 @@ log4cxx_time_t File::lastModified(Pool& pool) const
 }
 
 
-std::vector<LogString> File::list(Pool& p) const
+std::vector<LogString> File::list() const
 {
 	apr_dir_t* dir;
 	apr_finfo_t entry;
 	std::vector<LogString> filenames;
 
-	apr_status_t stat = apr_dir_open(&dir,
-			convertBackSlashes(getPath(p)),
-			p.getAPRPool());
+	apr_status_t stat = apr_dir_open(&dir, m_priv->getPath(), m_priv->p.getAPRPool());
 
 	if (stat == APR_SUCCESS)
 	{
 		int style = APR_FILEPATH_ENCODING_UNKNOWN;
-		apr_filepath_encoding(&style, p.getAPRPool());
+		apr_filepath_encoding(&style, m_priv->p.getAPRPool());
 		stat = apr_dir_read(&entry, APR_FINFO_DIRENT, dir);
 
 		while (stat == APR_SUCCESS)
@@ -302,7 +302,7 @@ std::vector<LogString> File::list(Pool& p) const
 	return filenames;
 }
 
-LogString File::getParent(Pool&) const
+LogString File::getParent() const
 {
 	LogString::size_type slashPos = m_priv->path.rfind(LOG4CXX_STR('/'));
 	LogString::size_type backPos = m_priv->path.rfind(LOG4CXX_STR('\\'));
@@ -329,10 +329,9 @@ LogString File::getParent(Pool&) const
 	return parent;
 }
 
-bool File::mkdirs(Pool& p) const
+bool File::mkdirs() const
 {
-	apr_status_t stat = apr_dir_make_recursive(convertBackSlashes(getPath(p)),
-			APR_OS_DEFAULT, p.getAPRPool());
+	apr_status_t stat = apr_dir_make_recursive(m_priv->getPath(), APR_OS_DEFAULT, m_priv->p.getAPRPool());
 	return stat == APR_SUCCESS;
 }
 
@@ -343,3 +342,14 @@ void File::setAutoDelete(bool autoDelete){
 bool File::getAutoDelete() const{
 	return m_priv->autoDelete;
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+bool File::exists(helpers::Pool& p) const { return exists(); }
+size_t File::length(helpers::Pool& p) const { return length(); }
+log4cxx_time_t File::lastModified(helpers::Pool& p) const { return lastModified(); }
+std::vector<LogString> File::list(helpers::Pool& p) const { return list(); }
+bool File::deleteFile(helpers::Pool& p) const { return deleteFile(); }
+bool File::renameTo(const File& dest, helpers::Pool& p) const { return renameTo(dest); }
+LogString File::getParent(helpers::Pool& p) const { return getParent(); }
+bool File::mkdirs(helpers::Pool& p) const { return mkdirs(); }
+#endif

--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -310,7 +310,7 @@ void FileAppender::setFileInternal(
 		{
 			File outFile;
 			outFile.setPath(filename);
-			writeBOM = !outFile.exists(p);
+			writeBOM = !outFile.exists();
 		}
 		else
 		{
@@ -326,14 +326,14 @@ void FileAppender::setFileInternal(
 	}
 	catch (IOException&)
 	{
-		LogString parentName = File().setPath(filename).getParent(p);
+		LogString parentName = File().setPath(filename).getParent();
 
 		if (!parentName.empty())
 		{
 			File parentDir;
 			parentDir.setPath(parentName);
 
-			if (!parentDir.exists(p) && parentDir.mkdirs(p))
+			if (!parentDir.exists() && parentDir.mkdirs())
 			{
 				outStream = std::make_shared<FileOutputStream>(filename, append1);
 			}

--- a/src/main/cpp/fileinputstream.cpp
+++ b/src/main/cpp/fileinputstream.cpp
@@ -29,12 +29,11 @@ struct FileInputStream::FileInputStreamPrivate
 {
 	FileInputStreamPrivate(const File& aFile)
 		: path(aFile)
-		, fileptr(nullptr)
 		{}
 
 	File path;
 	Pool pool;
-	apr_file_t* fileptr;
+	apr_file_t* fileptr{ nullptr };
 	void open();
 };
 

--- a/src/main/cpp/fileinputstream.cpp
+++ b/src/main/cpp/fileinputstream.cpp
@@ -27,52 +27,49 @@ using namespace LOG4CXX_NS::helpers;
 
 struct FileInputStream::FileInputStreamPrivate
 {
-	FileInputStreamPrivate() : fileptr(nullptr) {}
+	FileInputStreamPrivate(const File& aFile)
+		: path(aFile)
+		, fileptr(nullptr)
+		{}
 
+	File path;
 	Pool pool;
 	apr_file_t* fileptr;
+	void open();
 };
 
 IMPLEMENT_LOG4CXX_OBJECT(FileInputStream)
 
 FileInputStream::FileInputStream(const LogString& filename) :
-	m_priv(std::make_unique<FileInputStreamPrivate>())
+	m_priv(std::make_unique<FileInputStreamPrivate>(filename))
 {
-	open(filename);
+	m_priv->open();
 }
 
 FileInputStream::FileInputStream(const logchar* filename) :
-	m_priv(std::make_unique<FileInputStreamPrivate>())
+	m_priv(std::make_unique<FileInputStreamPrivate>(filename))
 {
-	LogString fn(filename);
-	open(fn);
+	m_priv->open();
 }
 
 
-void FileInputStream::open(const LogString& filename)
+void FileInputStream::FileInputStreamPrivate::open()
 {
 	apr_fileperms_t perm = APR_OS_DEFAULT;
 	apr_int32_t flags = APR_READ;
-	apr_status_t stat = File().setPath(filename).open(&m_priv->fileptr, flags, perm, m_priv->pool);
+	apr_status_t stat = apr_file_open(&this->fileptr, this->path.getAPRPath(), flags, perm, this->pool.getAPRPool());
 
 	if (stat != APR_SUCCESS)
 	{
-		throw IOException(filename, stat);
+		throw IOException(this->path.getAPRPath(), stat);
 	}
 }
 
 
 FileInputStream::FileInputStream(const File& aFile) :
-	m_priv(std::make_unique<FileInputStreamPrivate>())
+	m_priv(std::make_unique<FileInputStreamPrivate>(aFile))
 {
-	apr_fileperms_t perm = APR_OS_DEFAULT;
-	apr_int32_t flags = APR_READ;
-	apr_status_t stat = aFile.open(&m_priv->fileptr, flags, perm, m_priv->pool);
-
-	if (stat != APR_SUCCESS)
-	{
-		throw IOException(aFile.getName(), stat);
-	}
+	m_priv->open();
 }
 
 

--- a/src/main/cpp/fileoutputstream.cpp
+++ b/src/main/cpp/fileoutputstream.cpp
@@ -27,28 +27,32 @@ using namespace LOG4CXX_NS::helpers;
 
 struct FileOutputStream::FileOutputStreamPrivate
 {
-	FileOutputStreamPrivate() : fileptr(nullptr) {}
+	FileOutputStreamPrivate(const LogString& filename)
+		: fileptr(nullptr)
+		, path(filename)
+		{}
 
+	File path;
 	Pool pool;
 	apr_file_t* fileptr;
+	void open(bool append);
 };
 
 IMPLEMENT_LOG4CXX_OBJECT(FileOutputStream)
 
-FileOutputStream::FileOutputStream(const LogString& filename,
-	bool append) : m_priv(std::make_unique<FileOutputStreamPrivate>())
+FileOutputStream::FileOutputStream(const LogString& filename, bool append)
+	: m_priv(std::make_unique<FileOutputStreamPrivate>(filename))
 {
-	m_priv->fileptr = open(filename, append, m_priv->pool);
+	m_priv->open(append);
 }
 
-FileOutputStream::FileOutputStream(const logchar* filename,
-	bool append) : m_priv(std::make_unique<FileOutputStreamPrivate>())
+FileOutputStream::FileOutputStream(const logchar* filename,	bool append)
+	: m_priv(std::make_unique<FileOutputStreamPrivate>(filename))
 {
-	m_priv->fileptr = open(filename, append, m_priv->pool);
+	m_priv->open(append);
 }
 
-apr_file_t* FileOutputStream::open(const LogString& filename,
-	bool append, Pool& pool)
+void FileOutputStream::FileOutputStreamPrivate::open(bool append)
 {
 	apr_fileperms_t perm = APR_OS_DEFAULT;
 	apr_int32_t flags = APR_WRITE | APR_CREATE;
@@ -62,17 +66,12 @@ apr_file_t* FileOutputStream::open(const LogString& filename,
 		flags |= APR_TRUNCATE;
 	}
 
-	File fn;
-	fn.setPath(filename);
-	apr_file_t* fileptr = 0;
-	apr_status_t stat = fn.open(&fileptr, flags, perm, pool);
+	apr_status_t stat = apr_file_open(&this->fileptr, this->path.getAPRPath(), flags, perm, this->pool.getAPRPool());
 
 	if (stat != APR_SUCCESS)
 	{
-		throw IOException(filename, stat);
+		throw IOException(this->path.getAPRPath(), stat);
 	}
-
-	return fileptr;
 }
 
 FileOutputStream::~FileOutputStream()

--- a/src/main/cpp/fileoutputstream.cpp
+++ b/src/main/cpp/fileoutputstream.cpp
@@ -28,13 +28,12 @@ using namespace LOG4CXX_NS::helpers;
 struct FileOutputStream::FileOutputStreamPrivate
 {
 	FileOutputStreamPrivate(const LogString& filename)
-		: fileptr(nullptr)
-		, path(filename)
+		: path(filename)
 		{}
 
 	File path;
 	Pool pool;
-	apr_file_t* fileptr;
+	apr_file_t* fileptr{ nullptr };
 	void open(bool append);
 };
 

--- a/src/main/cpp/filerenameaction.cpp
+++ b/src/main/cpp/filerenameaction.cpp
@@ -46,7 +46,7 @@ FileRenameAction::FileRenameAction(const File& toRename,
 {
 }
 
-bool FileRenameAction::execute(LOG4CXX_NS::helpers::Pool& pool1) const
+bool FileRenameAction::execute(Pool&) const
 {
-	return priv->source.renameTo(priv->destination, pool1);
+	return priv->source.renameTo(priv->destination);
 }

--- a/src/main/cpp/filewatchdog.cpp
+++ b/src/main/cpp/filewatchdog.cpp
@@ -102,9 +102,8 @@ void FileWatchdog::checkAndConfigure()
 		msg += LOG4CXX_STR("]");
 		LogLog::debug(msg);
 	}
-	Pool pool1;
 
-	if (!m_priv->file.exists(pool1))
+	if (!m_priv->file.exists())
 	{
 		if (!m_priv->warnedAlready)
 		{
@@ -116,7 +115,7 @@ void FileWatchdog::checkAndConfigure()
 	}
 	else
 	{
-		auto thisMod = m_priv->file.lastModified(pool1);
+		auto thisMod = m_priv->file.lastModified();
 
 		if (thisMod > m_priv->lastModif)
 		{

--- a/src/main/cpp/fixedwindowrollingpolicy.cpp
+++ b/src/main/cpp/fixedwindowrollingpolicy.cpp
@@ -191,8 +191,8 @@ RolloverDescriptionPtr FixedWindowRollingPolicy::rollover(
 
 	if(getCreateIntermediateDirectories()){
 		File compressedFile(compressedName);
-		File compressedParent (compressedFile.getParent(pool));
-		compressedParent.mkdirs(pool);
+		File compressedParent (compressedFile.getParent());
+		compressedParent.mkdirs();
 	}
 
 	if (StringHelper::endsWith(renameTo, LOG4CXX_STR(".gz")))
@@ -282,21 +282,21 @@ bool FixedWindowRollingPolicy::purge(int lowIndex, int highIndex, Pool& p) const
 		toRenameBase.setPath(lowFilename.substr(0, lowFilename.length() - suffixLength));
 		File* toRename = &toRenameCompressed;
 		bool isBase = false;
-		bool exists = toRenameCompressed.exists(p);
+		bool exists = toRenameCompressed.exists();
 
 		if (suffixLength > 0)
 		{
 			if (exists)
 			{
-				if (toRenameBase.exists(p))
+				if (toRenameBase.exists())
 				{
-					toRenameBase.deleteFile(p);
+					toRenameBase.deleteFile();
 				}
 			}
 			else
 			{
 				toRename = &toRenameBase;
-				exists = toRenameBase.exists(p);
+				exists = toRenameBase.exists();
 				isBase = true;
 			}
 		}
@@ -309,7 +309,7 @@ bool FixedWindowRollingPolicy::purge(int lowIndex, int highIndex, Pool& p) const
 			//        if that fails then abandon purge
 			if (i == highIndex)
 			{
-				if (!toRename->deleteFile(p))
+				if (!toRename->deleteFile())
 				{
 					return false;
 				}

--- a/src/main/cpp/gzcompressaction.cpp
+++ b/src/main/cpp/gzcompressaction.cpp
@@ -56,7 +56,7 @@ GZCompressAction::~GZCompressAction() {}
 
 bool GZCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 {
-	if (priv->source.exists(p))
+	if (priv->source.exists())
 	{
 		apr_pool_t* aprpool = p.getAPRPool();
 		apr_procattr_t* attr;
@@ -87,7 +87,7 @@ bool GZCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 		apr_file_t* child_out;
 		apr_int32_t flags = APR_FOPEN_READ | APR_FOPEN_WRITE |
 			APR_FOPEN_CREATE | APR_FOPEN_TRUNCATE;
-		stat = priv->destination.open(&child_out, flags, APR_OS_DEFAULT, p);
+		stat = apr_file_open(&child_out, priv->destination.getAPRPath(), flags, APR_OS_DEFAULT, aprpool);
 
 		if (stat != APR_SUCCESS)
 		{
@@ -159,7 +159,7 @@ bool GZCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 
 		if (priv->deleteSource)
 		{
-			priv->source.deleteFile(p);
+			priv->source.deleteFile();
 		}
 
 		return true;

--- a/src/main/cpp/multiprocessrollingfileappender.cpp
+++ b/src/main/cpp/multiprocessrollingfileappender.cpp
@@ -286,7 +286,7 @@ bool MultiprocessRollingFileAppender::synchronizedRollover(Pool& p, const Trigge
 					appendToExisting = rollover1->getAppend();
 					if (appendToExisting)
 					{
-						_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length(p);
+						_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length();
 					}
 					else
 					{
@@ -336,7 +336,7 @@ bool MultiprocessRollingFileAppender::synchronizedRollover(Pool& p, const Trigge
 				{
 					if (rollover1->getAppend())
 					{
-						_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length(p);
+						_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length();
 					}
 					else
 					{

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -244,7 +244,7 @@ void RollingFileAppender::activateOptions(Pool& p)
 
 			if (getAppend())
 			{
-				_priv->fileLength = activeFile.length(p);
+				_priv->fileLength = activeFile.length();
 			}
 			else
 			{
@@ -325,7 +325,7 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 								appendToExisting = rollover1->getAppend();
 								if (appendToExisting)
 								{
-									_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length(p);
+									_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length();
 								}
 								else
 								{
@@ -386,7 +386,7 @@ bool RollingFileAppender::rolloverInternal(Pool& p)
 							{
 								if (rollover1->getAppend())
 								{
-									_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length(p);
+									_priv->fileLength = File().setPath(rollover1->getActiveFileName()).length();
 								}
 								else
 								{

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -335,7 +335,7 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::initialize(
 	File currentFile(currentActiveFile);
 
 	LogString buf;
-	ObjectPtr obj = std::make_shared<Date>(currentFile.exists(pool) ? currentFile.lastModified(pool) : n);
+	ObjectPtr obj = std::make_shared<Date>(currentFile.exists() ? currentFile.lastModified() : n);
 	formatFileName(obj, buf, pool);
 	m_priv->lastFileName = buf;
 
@@ -435,8 +435,8 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::rollover(
 
 	if(getCreateIntermediateDirectories()){
 		File compressedFile(m_priv->lastFileName);
-		File compressedParent (compressedFile.getParent(pool));
-		compressedParent.mkdirs(pool);
+		File compressedParent (compressedFile.getParent());
+		compressedParent.mkdirs();
 	}
 
 	//

--- a/src/main/cpp/zipcompressaction.cpp
+++ b/src/main/cpp/zipcompressaction.cpp
@@ -54,7 +54,7 @@ ZipCompressAction::ZipCompressAction(const File& src,
 
 bool ZipCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 {
-	if (!priv->source.exists(p))
+	if (!priv->source.exists())
 	{
 		return false;
 	}
@@ -108,9 +108,9 @@ bool ZipCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 	args[i++] = Transcoder::encode(priv->source.getPath(), p);
 	args[i++] = NULL;
 
-	if (priv->destination.exists(p))
+	if (priv->destination.exists())
 	{
-		priv->destination.deleteFile(p);
+		priv->destination.deleteFile();
 	}
 
 	apr_proc_t pid;
@@ -142,7 +142,7 @@ bool ZipCompressAction::execute(LOG4CXX_NS::helpers::Pool& p) const
 
 	if (priv->deleteSource)
 	{
-		priv->source.deleteFile(p);
+		priv->source.deleteFile();
 	}
 
 	return true;

--- a/src/main/include/log4cxx/file.h
+++ b/src/main/include/log4cxx/file.h
@@ -177,7 +177,7 @@ class LOG4CXX_EXPORT File
 		bool mkdirs() const;
 
 		/**
-		 * Use \c newValue for whateher the file is to be deleted when this object is destroyed.
+		 * Use \c newValue for whether the file is to be deleted when this object is destroyed.
 		 * @param autoDelete If true, delete file upon destruction.
 		 */
 		void setAutoDelete(bool newValue);

--- a/src/main/include/log4cxx/file.h
+++ b/src/main/include/log4cxx/file.h
@@ -100,103 +100,127 @@ class LOG4CXX_EXPORT File
 
 		/**
 		 *  Determines if file exists.
-		 *  @param p pool.
 		 *  @return true if file exists.
 		 */
-		bool exists(LOG4CXX_NS::helpers::Pool& p) const;
+		bool exists() const;
 		/**
-		 *  Determines length of file.  May not be accurate if file is current open.
-		 *  @param p pool.
+		 *  Provides the length of the file.  May not be accurate if file is current open.
 		 *  @return length of file.
 		 */
-		size_t length(LOG4CXX_NS::helpers::Pool& p) const;
+		size_t length() const;
 		/**
-		 *  Determines last modification date.
-		 *  @param p pool.
-		 *  @return length of file.
+		 *  Provides the last modification date.
+		 *  @return the filesystem time of last modification.
 		 */
-		log4cxx_time_t lastModified(LOG4CXX_NS::helpers::Pool& p) const;
+		log4cxx_time_t lastModified() const;
 		/**
-		 *  Get final portion of file path.
+		 *  Provides the final portion of file path.
 		 *  @return file name.
 		 */
 		LogString getName() const;
 		/**
-		 *  Get file path.
+		 *  Provides the file path.
 		 *  @return file path.
 		 */
 		LogString getPath() const;
 		/**
-		 *  Set file path
+		 *  Provides the file path.
+		 *  @return file path.
 		 */
-		File& setPath(const LogString&);
-
+		const char* getAPRPath() const;
 		/**
-		 *  Open file.  See apr_file_open for details.
-		 *  @param file APR file handle.
+		 *  Use \c newValue as the file path
+		 */
+		File& setPath(const LogString& newVAlue);
+
+#if LOG4CXX_ABI_VERSION <= 15
+		/**
+		 *  Open this file.
+		 *  See <a href="https://apr.apache.org/docs/apr/1.7/group__apr__file__io.html#gabda14cbf242fb4fe99055434213e5446">apr_file_open</a> for details.
+		 *  @param file allocated APR file handle.
 		 *  @param flags flags.
 		 *  @param perm permissions.
-		 *  @param p pool.
 		 *  @return APR_SUCCESS if successful.
+		 * @deprecated This function is deprecated and will be removed in a future version.
 		 */
-		log4cxx_status_t open(apr_file_t** file, int flags,
-			int perm, LOG4CXX_NS::helpers::Pool& p) const;
+		[[ deprecated( "open is no longer supported" ) ]]
+		log4cxx_status_t open(apr_file_t** file, int flags,	int perm, helpers::Pool& p) const;
+#endif
 
 		/**
 		 *   List files if current file is a directory.
-		 *   @param p pool.
 		 *   @return list of files in this directory, operation of non-directory returns empty list.
 		 */
-		std::vector<LogString> list(LOG4CXX_NS::helpers::Pool& p) const;
+		std::vector<LogString> list() const;
 
 		/**
-		 *   Delete file.
-		 *   @param p pool.
+		 *   Delete this file.
 		 *   @return true if file successfully deleted.
 		 */
-		bool deleteFile(LOG4CXX_NS::helpers::Pool& p) const;
+		bool deleteFile() const;
 		/**
-		 *   Rename file.
+		 *   Rename this file.
 		 *   @param dest new path for file.
-		 *   @param p pool.
 		 *   @return true if file successfully renamed.
 		 */
-		bool renameTo(const File& dest, LOG4CXX_NS::helpers::Pool& p) const;
+		bool renameTo(const File& dest) const;
 
 		/**
-		 *   Get path of parent directory.
-		 *   @param p pool.
+		 *   Provides the path of parent directory.
 		 *   @return path of parent directory.
 		 */
-		LogString getParent(LOG4CXX_NS::helpers::Pool& p) const;
+		LogString getParent() const;
 		/**
-		 *  Make directories recursively.
-		 *  @param p pool.
+		 *  Create the directories required for this file path.
 		 *  @return true if all requested directories existed or have been created.
 		 */
-		bool mkdirs(LOG4CXX_NS::helpers::Pool& p) const;
+		bool mkdirs() const;
 
 		/**
-		 * Set the file to be deleted when this object is destroyed.
-		 * @param autoDelete If true, delete file upon destruction.  If true, do not delete file.
+		 * Use \c newValue for whateher the file is to be deleted when this object is destroyed.
+		 * @param autoDelete If true, delete file upon destruction.
 		 */
-		void setAutoDelete(bool autoDelete);
+		void setAutoDelete(bool newValue);
 
 		/**
-		 * Return the value of the autodelete setting.  If true, this file will be deleted when the
+		 * Provides the value of the autodelete setting.  If true, this file will be deleted when the
 		 * destructor is called.
 		 *
 		 * @return True if the file is deleted upon destruction.
 		 */
 		bool getAutoDelete() const;
 
+#if LOG4CXX_ABI_VERSION <= 15
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		bool exists(helpers::Pool& p) const;
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		size_t length(helpers::Pool& p) const;
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		log4cxx_time_t lastModified(helpers::Pool& p) const;
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		std::vector<LogString> list(helpers::Pool& p) const;
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		bool deleteFile(helpers::Pool& p) const;
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		bool renameTo(const File& dest, helpers::Pool& p) const;
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		LogString getParent(helpers::Pool& p) const;
+		/// @deprecated This function is deprecated and will be removed in a future version.
+		[[ deprecated( "Pool is no longer required" ) ]]
+		bool mkdirs(helpers::Pool& p) const;
+#endif
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(FilePrivate, m_priv)
-		static char* convertBackSlashes(char*);
-		char* getPath(LOG4CXX_NS::helpers::Pool& p) const;
 };
 } // namespace log4cxx
 
-#define LOG4CXX_FILE(name) LOG4CXX_NS::File(name)
+#define LOG4CXX_FILE(name) File(name)
 
 #endif // _LOG4CXX_FILE_H

--- a/src/main/include/log4cxx/helpers/exception.h
+++ b/src/main/include/log4cxx/helpers/exception.h
@@ -43,6 +43,9 @@ class LOG4CXX_EXPORT Exception : public ::std::exception
 		Exception& operator=(const Exception& src);
 		const char* what() const throw();
 		static LogString makeMessage(const LogString& type, log4cxx_status_t stat);
+#if !LOG4CXX_LOGCHAR_IS_UTF8
+		static std::string makeMessage(const char* type, log4cxx_status_t stat);
+#endif
 	private:
 		enum { MSG_SIZE = 128 };
 		char msg[MSG_SIZE + 1];
@@ -95,6 +98,9 @@ class LOG4CXX_EXPORT IOException : public Exception
 		IOException(const LogString& msg);
 		IOException(const char* msg);
 		IOException(const LogString& type, log4cxx_status_t stat);
+#if !LOG4CXX_LOGCHAR_IS_UTF8
+		IOException(const char* msg, log4cxx_status_t stat);
+#endif
 		IOException(const IOException& src);
 		IOException& operator=(const IOException&);
 	private:

--- a/src/main/include/log4cxx/helpers/exception.h
+++ b/src/main/include/log4cxx/helpers/exception.h
@@ -93,6 +93,7 @@ class LOG4CXX_EXPORT IOException : public Exception
 		IOException();
 		IOException(log4cxx_status_t stat);
 		IOException(const LogString& msg);
+		IOException(const char* msg);
 		IOException(const LogString& type, log4cxx_status_t stat);
 		IOException(const IOException& src);
 		IOException& operator=(const IOException&);

--- a/src/main/include/log4cxx/helpers/fileinputstream.h
+++ b/src/main/include/log4cxx/helpers/fileinputstream.h
@@ -84,7 +84,6 @@ class LOG4CXX_EXPORT FileInputStream : public InputStream
 		FileInputStream(FileInputStream&&) = delete;
 
 		FileInputStream& operator=(const FileInputStream&) = delete;
-		void open(const LogString&);
 
 };
 

--- a/src/main/include/log4cxx/helpers/fileoutputstream.h
+++ b/src/main/include/log4cxx/helpers/fileoutputstream.h
@@ -57,8 +57,6 @@ class LOG4CXX_EXPORT FileOutputStream : public OutputStream
 		FileOutputStream(const FileOutputStream&) = delete;
 		FileOutputStream(FileOutputStream&&) = delete;
 		FileOutputStream& operator=(const FileOutputStream&) = delete;
-		static apr_file_t* open(const LogString& fn, bool append,
-			LOG4CXX_NS::helpers::Pool& p);
 };
 
 LOG4CXX_PTR_DEF(FileOutputStream);

--- a/src/test/cpp/autoconfiguretestcase.cpp
+++ b/src/test/cpp/autoconfiguretestcase.cpp
@@ -129,7 +129,7 @@ public:
 	void test1()
 	{
 		LOGUNIT_ASSERT_EQUAL(m_status, spi::ConfigurationStatus::Configured);
-		LOGUNIT_ASSERT(File(m_configFile).exists(m_pool));
+		LOGUNIT_ASSERT(File(m_configFile).exists());
 		auto debugLogger1 = LogManager::getLogger(LOG4CXX_STR("AutoConfig.test1"));
 		LOGUNIT_ASSERT(debugLogger1);
 		LOGUNIT_ASSERT(!debugLogger1->isDebugEnabled());
@@ -141,7 +141,7 @@ public:
 	void test2()
 	{
 		LOGUNIT_ASSERT_EQUAL(m_status, spi::ConfigurationStatus::Configured);
-		LOGUNIT_ASSERT(File(m_configFile).exists(m_pool));
+		LOGUNIT_ASSERT(File(m_configFile).exists());
 		// wait 2 sec to ensure the modification time is different to that held in the WatchDog
 		apr_sleep(2000000);
 		auto debugLogger = LogManager::getLogger(LOG4CXX_STR("AutoConfig.test3"));

--- a/src/test/cpp/fileappendertest.cpp
+++ b/src/test/cpp/fileappendertest.cpp
@@ -87,18 +87,18 @@ public:
 	void testDirectoryCreation()
 	{
 		File newFile(LOG4CXX_STR("output/newdir/temp.log"));
-		Pool p;
-		newFile.deleteFile(p);
+		newFile.deleteFile();
 
 		File newDir(LOG4CXX_STR("output/newdir"));
-		newDir.deleteFile(p);
+		newDir.deleteFile();
 
 		FileAppenderPtr wa(new FileAppender());
 		wa->setFile(LOG4CXX_STR("output/newdir/temp.log"));
 		wa->setLayout(PatternLayoutPtr(new PatternLayout(LOG4CXX_STR("%m%n"))));
+		Pool p;
 		wa->activateOptions(p);
 
-		LOGUNIT_ASSERT(File(LOG4CXX_STR("output/newdir/temp.log")).exists(p));
+		LOGUNIT_ASSERT(File(LOG4CXX_STR("output/newdir/temp.log")).exists());
 	}
 
 	/**
@@ -138,12 +138,11 @@ public:
 		auto appender = log4cxx::cast<FileAppender>(logger->getAppender(LOG4CXX_STR("FileAppender")));
 		LOGUNIT_ASSERT(appender);
 		File file(appender->getFile());
-		Pool p;
-		size_t initialLength = file.length(p);
+		size_t initialLength = file.length();
 
 		// wait 1.2 sec and check the buffer is flushed
 		apr_sleep(1200000);
-		size_t flushedLength = file.length(p);
+		size_t flushedLength = file.length();
 
 		// Check the file extended
 		if (helpers::LogLog::isDebugEnabled())

--- a/src/test/cpp/filetestcase.cpp
+++ b/src/test/cpp/filetestcase.cpp
@@ -85,8 +85,7 @@ public:
 	void defaultExists()
 	{
 		File defFile;
-		Pool pool;
-		bool exists = defFile.exists(pool);
+		bool exists = defFile.exists();
 		LOGUNIT_ASSERT_EQUAL(false, exists);
 	}
 
@@ -116,8 +115,7 @@ public:
 	void wcharConstructor()
 	{
 		File propFile(L"input/patternLayout1.properties");
-		Pool pool;
-		bool exists = propFile.exists(pool);
+		bool exists = propFile.exists();
 		LOGUNIT_ASSERT_EQUAL(true, exists);
 	}
 #endif
@@ -150,8 +148,7 @@ public:
 	{
 		File propFile("input/patternLayout1.properties");
 		File copy(propFile);
-		Pool pool;
-		bool exists = copy.exists(pool);
+		bool exists = copy.exists();
 		LOGUNIT_ASSERT_EQUAL(true, exists);
 	}
 
@@ -159,8 +156,7 @@ public:
 	{
 		File propFile("input/patternLayout1.properties");
 		File copy = propFile;
-		Pool pool;
-		bool exists = copy.exists(pool);
+		bool exists = copy.exists();
 		LOGUNIT_ASSERT_EQUAL(true, exists);
 	}
 
@@ -178,8 +174,7 @@ public:
 	void propertyExists()
 	{
 		File propFile("input/patternLayout1.properties");
-		Pool pool;
-		bool exists = propFile.exists(pool);
+		bool exists = propFile.exists();
 		LOGUNIT_ASSERT_EQUAL(true, exists);
 	}
 
@@ -209,8 +204,7 @@ public:
 	void deleteBackslashedFileName()
 	{
 		File file("output\\bogus.txt");
-		Pool pool;
-		/*bool deleted = */file.deleteFile(pool);
+		file.deleteFile();
 	}
 
 	class MockInputStream : public InputStream

--- a/src/test/cpp/net/telnetappendertestcase.cpp
+++ b/src/test/cpp/net/telnetappendertestcase.cpp
@@ -143,7 +143,7 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 		{
 			auto thisProgram = GetExecutableFileName();
 			helpers::Pool p;
-			bool thisProgramExists = File(thisProgram).exists(p);
+			bool thisProgramExists = File(thisProgram).exists();
 			LOGUNIT_ASSERT(thisProgramExists);
 			const char* args[] = {thisProgram.c_str(), "testActivateWriteClose", 0};
 			apr_procattr_t* attr = NULL;

--- a/src/test/cpp/rolling/manualrollingtest.cpp
+++ b/src/test/cpp/rolling/manualrollingtest.cpp
@@ -130,9 +130,9 @@ public:
 
 		common(rfa, p, logger);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test1.0").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test1.1").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test1.2").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test1.0").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test1.1").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test1.2").exists());
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/manual-test1.0"),
 				File("witness/rolling/sbr-test2.log")));
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/manual-test1.1"),
@@ -159,9 +159,9 @@ public:
 
 		common(rfa, p, logger);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test2.log").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test2.log.1").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test2.log.2").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test2.log").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test2.log.1").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test2.log.2").exists());
 
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/manual-test2.log"),
 				File("witness/rolling/sbr-test2.log")));
@@ -194,13 +194,13 @@ public:
 
 		common(rfa, p, logger);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test3.log").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test3.0.gz").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test3.1.gz").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test3.log").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test3.0.gz").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test3.1.gz").exists());
 
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/manual-test3.log"),  File("witness/rolling/sbr-test3.log")));
-		LOGUNIT_ASSERT_EQUAL(File("witness/rolling/sbr-test3.0.gz").length(p), File("output/manual-test3.0.gz").length(p));
-		LOGUNIT_ASSERT_EQUAL(File("witness/rolling/sbr-test3.1.gz").length(p), File("output/manual-test3.1.gz").length(p));
+		LOGUNIT_ASSERT_EQUAL(File("witness/rolling/sbr-test3.0.gz").length(), File("output/manual-test3.0.gz").length());
+		LOGUNIT_ASSERT_EQUAL(File("witness/rolling/sbr-test3.1.gz").length(), File("output/manual-test3.1.gz").length());
 	}
 
 	/**
@@ -232,7 +232,7 @@ public:
 
 		common(rfa, p, logger);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test4.log").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test4.log").exists());
 
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/manual-test4.log"),
 				File("witness/rolling/sbr-test4.log")));
@@ -275,16 +275,16 @@ public:
 
 		os0.close(p);
 
-		if (File("output/manual-test5.3").exists(p))
+		if (File("output/manual-test5.3").exists())
 		{
 			//
 			//    looks like platform where open files can be renamed
 			//
-			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.log").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.0").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.1").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.2").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.3").exists(p));
+			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.log").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.0").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.1").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.2").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.3").exists());
 
 			LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/manual-test5.log"),
 					File("witness/rolling/sbr-test2.log")));
@@ -301,9 +301,9 @@ public:
 			//    so initial log file should have all log content
 			//    open file should be unaffected
 			//    stray file should have only been moved one slot.
-			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.log").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.0").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.2").exists(p));
+			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.log").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.0").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test5.2").exists());
 
 			LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/manual-test5.log"),
 					File("witness/rolling/sbr-test4.log")));
@@ -344,8 +344,8 @@ public:
 
 		common(rfa, p, logger);
 
-		LOGUNIT_ASSERT_EQUAL(true, File(filenamePatternPrefix + LOG4CXX_STR("/file-0.gz")).exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File(filenamePatternPrefix + LOG4CXX_STR("/file-1.gz")).exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File(filenamePatternPrefix + LOG4CXX_STR("/file-0.gz")).exists());
+		LOGUNIT_ASSERT_EQUAL(true, File(filenamePatternPrefix + LOG4CXX_STR("/file-1.gz")).exists());
 	}
 
 };

--- a/src/test/cpp/rolling/rollingfileappenderpropertiestest.cpp
+++ b/src/test/cpp/rolling/rollingfileappenderpropertiestest.cpp
@@ -101,9 +101,8 @@ public:
 			}
 		}
 
-		Pool p;
-		LOGUNIT_ASSERT_EQUAL(true, File("output/obsoleteRFA-test1.log").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/obsoleteRFA-test1.log.1").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/obsoleteRFA-test1.log").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/obsoleteRFA-test1.log.1").exists());
 	}
 
 	/**
@@ -144,8 +143,8 @@ public:
 			}
 		}
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/obsoleteRFA-test2.log").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/obsoleteRFA-test2.log.1").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/obsoleteRFA-test2.log").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/obsoleteRFA-test2.log.1").exists());
 	}
 
 	/**
@@ -242,8 +241,7 @@ public:
 private:
 	static int getFileCount(const char* dir, const LogString & initial)
 	{
-		Pool p;
-		std::vector<LogString> files(File(dir).list(p));
+		std::vector<LogString> files(File(dir).list());
 		int count = 0;
 
 		for (size_t i = 0; i < files.size(); i++)

--- a/src/test/cpp/rolling/sizebasedrollingtest.cpp
+++ b/src/test/cpp/rolling/sizebasedrollingtest.cpp
@@ -129,9 +129,9 @@ public:
 
 		common(logger, 0);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test1.0").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test1.1").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test1.2").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test1.0").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test1.1").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test1.2").exists());
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sizeBased-test1.0"),
 				File("witness/rolling/sbr-test2.log")));
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sizeBased-test1.1"),
@@ -169,9 +169,9 @@ public:
 
 		common(logger, 0);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test2.log").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test2.0").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test2.1").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test2.log").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test2.0").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test2.1").exists());
 
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sizeBased-test2.log"),
 				File("witness/rolling/sbr-test2.log")));
@@ -207,13 +207,13 @@ public:
 
 		common(logger, 100);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test3.log").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test3.0.gz").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test3.1.gz").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test3.log").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test3.0.gz").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test3.1.gz").exists());
 
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sbr-test3.log"),  File("witness/rolling/sbr-test3.log")));
-		LOGUNIT_ASSERT_EQUAL(File("witness/rolling/sbr-test3.0.gz").length(p), File("output/sbr-test3.0.gz").length(p));
-		LOGUNIT_ASSERT_EQUAL(File("witness/rolling/sbr-test3.1.gz").length(p), File("output/sbr-test3.1.gz").length(p));
+		LOGUNIT_ASSERT_EQUAL(File("witness/rolling/sbr-test3.0.gz").length(), File("output/sbr-test3.0.gz").length());
+		LOGUNIT_ASSERT_EQUAL(File("witness/rolling/sbr-test3.1.gz").length(), File("output/sbr-test3.1.gz").length());
 	}
 
 	/**
@@ -248,7 +248,7 @@ public:
 
 		common(logger, 0);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test4.log").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test4.log").exists());
 
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sizeBased-test4.log"),
 				File("witness/rolling/sbr-test4.log")));
@@ -294,16 +294,16 @@ public:
 
 		os0.close(p);
 
-		if (File("output/sizeBased-test5.3").exists(p))
+		if (File("output/sizeBased-test5.3").exists())
 		{
 			//
 			//    looks like platform where open files can be renamed
 			//
-			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.log").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.0").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.1").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.2").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.3").exists(p));
+			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.log").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.0").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.1").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.2").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.3").exists());
 
 			LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sizeBased-test5.log"),
 					File("witness/rolling/sbr-test2.log")));
@@ -320,9 +320,9 @@ public:
 			//    so initial log file should have all log content
 			//    open file should be unaffected
 			//    stray file should have only been moved one slot.
-			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.log").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.0").exists(p));
-			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.2").exists(p));
+			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.log").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.0").exists());
+			LOGUNIT_ASSERT_EQUAL(true, File("output/sizeBased-test5.2").exists());
 
 			LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sizeBased-test5.log"),
 					File("witness/rolling/sbr-test4.log")));
@@ -355,9 +355,9 @@ public:
 
 		common(logger, 100);
 
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test6.log").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test6.0.zip").exists(p));
-		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test6.1.zip").exists(p));
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test6.log").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test6.0.zip").exists());
+		LOGUNIT_ASSERT_EQUAL(true, File("output/sbr-test6.1.zip").exists());
 
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sbr-test6.log"),  File("witness/rolling/sbr-test3.log")));
 	}

--- a/src/test/cpp/rolling/timebasedrollingtest.cpp
+++ b/src/test/cpp/rolling/timebasedrollingtest.cpp
@@ -297,7 +297,7 @@ private:
 		for (size_t i = 0; i < N - 1; ++i)
 		{
 			//std::wcerr << L"Check: " << fnames[i] << L"\n";
-			LOGUNIT_ASSERT_EQUAL_SRCL(true, File(fnames[i]).exists(pool), srcLine);
+			LOGUNIT_ASSERT_EQUAL_SRCL(true, File(fnames[i]).exists(), srcLine);
 		}
 
 		this->compareWitness(pool, prefix, fnames[witnessIdx], witnessIdx, srcLine);
@@ -347,7 +347,7 @@ private:
 			Pool&		pool,
 			LogString	path)
 	{
-		File(path).deleteFile(pool);
+		File(path).deleteFile();
 	}
 
 	/**

--- a/src/test/cpp/util/transformer.cpp
+++ b/src/test/cpp/util/transformer.cpp
@@ -78,11 +78,11 @@ void Transformer::copyFile(const File& in, const File& out)
 	//
 	apr_file_t* child_out;
 	apr_int32_t flags = APR_FOPEN_WRITE | APR_FOPEN_CREATE | APR_FOPEN_TRUNCATE;
-	apr_status_t stat = out.open(&child_out, flags, APR_OS_DEFAULT, p);
+	apr_status_t stat = apr_file_open(&child_out, out.getAPRPath(), flags, APR_OS_DEFAULT, pool);
 	assert(stat == APR_SUCCESS);
 
 	apr_file_t* in_file;
-	stat = in.open(&in_file, APR_FOPEN_READ, APR_OS_DEFAULT, p);
+	stat = apr_file_open(&in_file, in.getAPRPath(), APR_FOPEN_READ, APR_OS_DEFAULT, pool);
 	assert(stat == APR_SUCCESS);
 	apr_size_t bufsize = 32000;
 	void* buf = apr_palloc(pool, bufsize);
@@ -221,7 +221,7 @@ void Transformer::transform(const File& in, const File& out,
 		apr_file_t* child_out;
 		apr_int32_t flags = APR_FOPEN_READ | APR_FOPEN_WRITE |
 			APR_FOPEN_CREATE | APR_FOPEN_TRUNCATE;
-		stat = out.open(&child_out, flags, APR_OS_DEFAULT, p);
+		stat = apr_file_open(&child_out, out.getAPRPath(), flags, APR_OS_DEFAULT, pool);
 		assert(stat == APR_SUCCESS);
 
 		stat =  apr_procattr_child_out_set(attr, child_out, NULL);

--- a/src/test/cpp/xml/domtestcase.cpp
+++ b/src/test/cpp/xml/domtestcase.cpp
@@ -98,9 +98,8 @@ public:
 		auto fa = LOG4CXX_NS::cast<FileAppender>(root->getAppender(LOG4CXX_STR("A1")));
 		LOGUNIT_ASSERT(fa);
 		File logFile{ fa->getFile() };
-		Pool p;
 		LOGUNIT_ASSERT(!output_dir.empty());
-		LOGUNIT_ASSERT_EQUAL(output_dir, logFile.getParent(p));
+		LOGUNIT_ASSERT_EQUAL(output_dir, logFile.getParent());
 		common();
 
 		ControlFilter cf1;
@@ -217,10 +216,8 @@ public:
 #else
 		const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, static_cast<logchar>(0xB3), 0 };
 #endif
-		File file;
-		file.setPath(fname);
-		Pool p;
-		bool exists = file.exists(p);
+		;
+		bool exists = File(fname).exists();
 		LOGUNIT_ASSERT(exists);
 	}
 
@@ -237,10 +234,7 @@ public:
 #else
 		const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, static_cast<logchar>(0x3195), 0 };
 #endif
-		File file;
-		file.setPath(fname);
-		Pool p;
-		bool exists = file.exists(p);
+		bool exists = File(fname).exists();
 		LOGUNIT_ASSERT(exists);
 	}
 


### PR DESCRIPTION
This PR removes the Pool parameter from all calls to `helper::File` methods.