### PR TITLE
Simplify the OptionHandler::activateOptions() usage in a future ABI version

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -112,6 +112,7 @@ target_sources(log4cxx
   defaultconfigurator.cpp
   defaultloggerfactory.cpp
   defaultrepositoryselector.cpp
+  errorhandler.cpp
   exception.cpp
   fallbackerrorhandler.cpp
   file.cpp
@@ -172,6 +173,7 @@ target_sources(log4cxx
   odbcappender.cpp
   onlyonceerrorhandler.cpp
   optionconverter.cpp
+  optionhandler.cpp
   outputdebugstringappender.cpp
   outputstream.cpp
   outputstreamwriter.cpp

--- a/src/main/cpp/appenderskeleton.cpp
+++ b/src/main/cpp/appenderskeleton.cpp
@@ -51,6 +51,14 @@ AppenderSkeleton::AppenderSkeleton(const LayoutPtr& layout)
 AppenderSkeleton::~AppenderSkeleton() {}
 
 #if LOG4CXX_ABI_VERSION <= 15
+void AppenderSkeleton::activateOptions(helpers::Pool& /* pool */) {}
+void AppenderSkeleton::activateOptions() { helpers::Pool p; activateOptions(p); }
+#else
+void AppenderSkeleton::activateOptions(helpers::Pool& ) { activateOptions(); }
+void AppenderSkeleton::activateOptions() {};
+#endif
+
+#if LOG4CXX_ABI_VERSION <= 15
 void AppenderSkeleton::finalize()
 {
 	// An appender might be closed then garbage collected. There is no

--- a/src/main/cpp/appenderskeleton.cpp
+++ b/src/main/cpp/appenderskeleton.cpp
@@ -50,12 +50,17 @@ AppenderSkeleton::AppenderSkeleton(const LayoutPtr& layout)
 
 AppenderSkeleton::~AppenderSkeleton() {}
 
-#if LOG4CXX_ABI_VERSION <= 15
-void AppenderSkeleton::activateOptions(helpers::Pool& /* pool */) {}
-void AppenderSkeleton::activateOptions() { helpers::Pool p; activateOptions(p); }
-#else
-void AppenderSkeleton::activateOptions(helpers::Pool& ) { activateOptions(); }
-void AppenderSkeleton::activateOptions() {};
+void AppenderSkeleton::activateOptions(helpers::Pool& /* pool */)
+{
+}
+
+#if 15 < LOG4CXX_ABI_VERSION
+void AppenderSkeleton::activateOptions()
+{
+	// Ensure any ABI 15 overriden activateOptions is invoked
+	helpers::Pool p;
+	activateOptions(p);
+}
 #endif
 
 #if LOG4CXX_ABI_VERSION <= 15

--- a/src/main/cpp/errorhandler.cpp
+++ b/src/main/cpp/errorhandler.cpp
@@ -14,26 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#include <log4cxx/rolling/triggeringpolicy.h>
+#include <log4cxx/spi/errorhandler.h>
 
 using namespace LOG4CXX_NS;
-using namespace LOG4CXX_NS::rolling;
 using namespace LOG4CXX_NS::helpers;
 
-IMPLEMENT_LOG4CXX_OBJECT(TriggeringPolicy)
-
-TriggeringPolicy::~TriggeringPolicy()
-{
-}
-
 #if 15 < LOG4CXX_ABI_VERSION
-void TriggeringPolicy::activateOptions(Pool&)
+void spi::ErrorHandler::activateOptions(Pool&)
 {
 	activateOptions();
 }
 
-void TriggeringPolicy::activateOptions()
+void spi::ErrorHandler::activateOptions()
 {
 }
 #endif

--- a/src/main/cpp/errorhandler.cpp
+++ b/src/main/cpp/errorhandler.cpp
@@ -22,10 +22,12 @@ using namespace LOG4CXX_NS::helpers;
 #if 15 < LOG4CXX_ABI_VERSION
 void spi::ErrorHandler::activateOptions(Pool&)
 {
-	activateOptions();
 }
 
 void spi::ErrorHandler::activateOptions()
 {
+	// Ensure any ABI 15 overriden activateOptions is invoked
+	helpers::Pool p;
+	activateOptions(p);
 }
 #endif

--- a/src/main/cpp/filter.cpp
+++ b/src/main/cpp/filter.cpp
@@ -45,9 +45,26 @@ void Filter::setNext(const FilterPtr& newNext)
 	m_priv->next = newNext;
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
 void Filter::activateOptions(Pool&)
 {
 }
+
+void Filter::activateOptions()
+{
+	helpers::Pool p;
+	activateOptions(p);
+}
+#else
+void Filter::activateOptions(Pool&)
+{
+	activateOptions();
+}
+
+void Filter::activateOptions()
+{
+}
+#endif
 
 void Filter::setOption(const LogString&, const LogString&)
 {

--- a/src/main/cpp/filter.cpp
+++ b/src/main/cpp/filter.cpp
@@ -45,24 +45,16 @@ void Filter::setNext(const FilterPtr& newNext)
 	m_priv->next = newNext;
 }
 
-#if LOG4CXX_ABI_VERSION <= 15
 void Filter::activateOptions(Pool&)
 {
 }
 
+#if 15 < LOG4CXX_ABI_VERSION
 void Filter::activateOptions()
 {
+	// Ensure any ABI 15 overriden activateOptions is invoked
 	helpers::Pool p;
 	activateOptions(p);
-}
-#else
-void Filter::activateOptions(Pool&)
-{
-	activateOptions();
-}
-
-void Filter::activateOptions()
-{
 }
 #endif
 

--- a/src/main/cpp/layout.cpp
+++ b/src/main/cpp/layout.cpp
@@ -50,3 +50,14 @@ size_t Layout::getFormattedEventCharacterCount() const
 	format(text, exampleEvent, pool);
 	return text.size();
 }
+
+#if 15 < LOG4CXX_ABI_VERSION
+void Layout::activateOptions(Pool&)
+{
+	activateOptions();
+}
+
+void Layout::activateOptions()
+{
+}
+#endif

--- a/src/main/cpp/layout.cpp
+++ b/src/main/cpp/layout.cpp
@@ -54,10 +54,12 @@ size_t Layout::getFormattedEventCharacterCount() const
 #if 15 < LOG4CXX_ABI_VERSION
 void Layout::activateOptions(Pool&)
 {
-	activateOptions();
 }
 
 void Layout::activateOptions()
 {
+	// Ensure any ABI 15 overriden activateOptions is invoked
+	Pool p;
+	activateOptions(p);
 }
 #endif

--- a/src/main/cpp/optionhandler.cpp
+++ b/src/main/cpp/optionhandler.cpp
@@ -14,26 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#include <log4cxx/rolling/triggeringpolicy.h>
+#include <log4cxx/spi/optionhandler.h>
 
 using namespace LOG4CXX_NS;
-using namespace LOG4CXX_NS::rolling;
 using namespace LOG4CXX_NS::helpers;
 
-IMPLEMENT_LOG4CXX_OBJECT(TriggeringPolicy)
-
-TriggeringPolicy::~TriggeringPolicy()
-{
-}
-
 #if 15 < LOG4CXX_ABI_VERSION
-void TriggeringPolicy::activateOptions(Pool&)
+void spi::OptionHandler::activateOptions(Pool&)
 {
 	activateOptions();
 }
-
-void TriggeringPolicy::activateOptions()
+#else
+void spi::OptionHandler::activateOptions()
 {
+	 helpers::Pool p;
+	 activateOptions(p);
 }
 #endif

--- a/src/main/cpp/optionhandler.cpp
+++ b/src/main/cpp/optionhandler.cpp
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 #include <log4cxx/spi/optionhandler.h>
+#if LOG4CXX_ABI_VERSION <= 15
+#include <log4cxx/helpers/pool.h>
+#endif
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;

--- a/src/main/cpp/optionhandler.cpp
+++ b/src/main/cpp/optionhandler.cpp
@@ -15,22 +15,19 @@
  * limitations under the License.
  */
 #include <log4cxx/spi/optionhandler.h>
-#if LOG4CXX_ABI_VERSION <= 15
 #include <log4cxx/helpers/pool.h>
-#endif
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
 
-#if 15 < LOG4CXX_ABI_VERSION
 void spi::OptionHandler::activateOptions(Pool&)
 {
-	activateOptions();
 }
-#else
+
 void spi::OptionHandler::activateOptions()
 {
+	// Ensure any ABI 15 overriden activateOptions is invoked
 	 helpers::Pool p;
 	 activateOptions(p);
 }
-#endif
+

--- a/src/main/cpp/rollingpolicybase.cpp
+++ b/src/main/cpp/rollingpolicybase.cpp
@@ -48,15 +48,15 @@ RollingPolicyBase::~RollingPolicyBase()
 }
 
 #if 15 < LOG4CXX_ABI_VERSION
-void RollingPolicyBase::activateOptions(Pool&)
-{
-	activateOptions();
-}
-
 void RollingPolicyBase::activateOptions()
-#else
-void RollingPolicyBase::activateOptions(LOG4CXX_NS::helpers::Pool& /* pool */)
+{
+	// Ensure any ABI 15 overriden activateOptions is invoked
+	 helpers::Pool p;
+	 activateOptions(p);
+}
 #endif
+
+void RollingPolicyBase::activateOptions(LOG4CXX_NS::helpers::Pool& /* pool */)
 {
 	if (m_priv->fileNamePatternStr.length() > 0)
 	{

--- a/src/main/cpp/rollingpolicybase.cpp
+++ b/src/main/cpp/rollingpolicybase.cpp
@@ -47,7 +47,16 @@ RollingPolicyBase::~RollingPolicyBase()
 {
 }
 
+#if 15 < LOG4CXX_ABI_VERSION
+void RollingPolicyBase::activateOptions(Pool&)
+{
+	activateOptions();
+}
+
+void RollingPolicyBase::activateOptions()
+#else
 void RollingPolicyBase::activateOptions(LOG4CXX_NS::helpers::Pool& /* pool */)
+#endif
 {
 	if (m_priv->fileNamePatternStr.length() > 0)
 	{

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -54,7 +54,7 @@ struct TimeBasedRollingPolicy::TimeBasedRollingPolicyPrivate{
 		/**
 		 * Time for next determination if time for rollover.
 		 */
-		log4cxx_time_t nextCheck;
+		log4cxx_time_t nextCheck{0};
 
 		/**
 		 * File name at last rollover.
@@ -64,7 +64,7 @@ struct TimeBasedRollingPolicy::TimeBasedRollingPolicyPrivate{
 		/**
 		 * Length of any file type suffix (.gz, .zip).
 		 */
-		int suffixLength;
+		int suffixLength{0};
 
 		/**
 		 * mmap pointer
@@ -266,6 +266,14 @@ TimeBasedRollingPolicy::TimeBasedRollingPolicy() :
 }
 
 TimeBasedRollingPolicy::~TimeBasedRollingPolicy(){}
+
+#if 15 < LOG4CXX_ABI_VERSION
+void TimeBasedRollingPolicy::activateOptions()
+{
+	Pool p;
+	activateOptions(p);
+}
+#endif
 
 void TimeBasedRollingPolicy::activateOptions(LOG4CXX_NS::helpers::Pool& pool)
 {

--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -270,6 +270,7 @@ TimeBasedRollingPolicy::~TimeBasedRollingPolicy(){}
 #if 15 < LOG4CXX_ABI_VERSION
 void TimeBasedRollingPolicy::activateOptions()
 {
+	// Ensure any ABI 15 overriden activateOptions is invoked
 	Pool p;
 	activateOptions(p);
 }

--- a/src/main/cpp/triggeringpolicy.cpp
+++ b/src/main/cpp/triggeringpolicy.cpp
@@ -30,10 +30,12 @@ TriggeringPolicy::~TriggeringPolicy()
 #if 15 < LOG4CXX_ABI_VERSION
 void TriggeringPolicy::activateOptions(Pool&)
 {
-	activateOptions();
 }
 
 void TriggeringPolicy::activateOptions()
 {
+	// Ensure any ABI 15 overriden activateOptions is invoked
+	 helpers::Pool p;
+	 activateOptions(p);
 }
 #endif

--- a/src/main/include/log4cxx/appenderskeleton.h
+++ b/src/main/include/log4cxx/appenderskeleton.h
@@ -82,18 +82,37 @@ class LOG4CXX_EXPORT AppenderSkeleton :
 		[[ deprecated( "The derived appender destructor needs to implement its cleanup" ) ]]
 		void finalize();
 #endif
+#if LOG4CXX_ABI_VERSION <= 15
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+
+		@deprecated The \c pool parameter is not required and will be removed in a future version.
+		*/
+		void activateOptions(helpers::Pool& pool) override;
 		/**
 		\copybrief spi::OptionHandler::activateOptions()
 
 		No action is performed in this implementation.
 		*/
-#if LOG4CXX_ABI_VERSION <= 15
-		[[deprecated("Override activateOptions() without parameters instead")]]
-		void activateOptions(helpers::Pool& /* pool */) override {}
-		void activateOptions() { helpers::Pool p; activateOptions(p); }
+		void activateOptions();
 #else
-		void activateOptions(helpers::Pool& ) override { activateOptions(); }
-		void activateOptions() override {};
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+
+		@deprecated This function is deprecated and will be removed in a future version.
+		*/
+		[[deprecated("Override activateOptions() without parameters instead")]]
+		void activateOptions(helpers::Pool& ) override;
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+		*/
+		void activateOptions() override;
 #endif
 
 		/**

--- a/src/main/include/log4cxx/appenderskeleton.h
+++ b/src/main/include/log4cxx/appenderskeleton.h
@@ -87,7 +87,14 @@ class LOG4CXX_EXPORT AppenderSkeleton :
 
 		No action is performed in this implementation.
 		*/
+#if LOG4CXX_ABI_VERSION <= 15
+		[[deprecated("Override activateOptions() without parameters instead")]]
 		void activateOptions(helpers::Pool& /* pool */) override {}
+		void activateOptions() { helpers::Pool p; activateOptions(p); }
+#else
+		void activateOptions(helpers::Pool& ) override { activateOptions(); }
+		void activateOptions() override {};
+#endif
 
 		/**
 		\copybrief spi::OptionHandler::setOption()

--- a/src/main/include/log4cxx/appenderskeleton.h
+++ b/src/main/include/log4cxx/appenderskeleton.h
@@ -91,12 +91,6 @@ class LOG4CXX_EXPORT AppenderSkeleton :
 		@deprecated The \c pool parameter is not required and will be removed in a future version.
 		*/
 		void activateOptions(helpers::Pool& pool) override;
-		/**
-		\copybrief spi::OptionHandler::activateOptions()
-
-		No action is performed in this implementation.
-		*/
-		void activateOptions();
 #else
 		/**
 		\copybrief spi::OptionHandler::activateOptions()

--- a/src/main/include/log4cxx/layout.h
+++ b/src/main/include/log4cxx/layout.h
@@ -76,6 +76,16 @@ class LOG4CXX_EXPORT Layout :
 		*/
 		virtual bool ignoresThrowable() const = 0;
 
+#if 15 < LOG4CXX_ABI_VERSION
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+		*/
+		void activateOptions(helpers::Pool& ) override;
+		void activateOptions() override;
+#endif
+
 	protected:
 		/**
 		 * The expected length of a formatted event excluding the message text

--- a/src/main/include/log4cxx/layout.h
+++ b/src/main/include/log4cxx/layout.h
@@ -82,8 +82,16 @@ class LOG4CXX_EXPORT Layout :
 
 		No action is performed in this implementation.
 		*/
-		void activateOptions(helpers::Pool& ) override;
 		void activateOptions() override;
+
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+		@deprecated This function is deprecated and will be removed in a future version.
+		*/
+		[[deprecated("Override activateOptions() without parameters instead")]]
+		void activateOptions(helpers::Pool& ) override;
 #endif
 
 	protected:

--- a/src/main/include/log4cxx/rolling/rollingpolicybase.h
+++ b/src/main/include/log4cxx/rolling/rollingpolicybase.h
@@ -63,6 +63,15 @@ class LOG4CXX_EXPORT RollingPolicyBase :
 
 		\sa RollingPolicy::activateOptions()
 		*/
+
+#if 15 < LOG4CXX_ABI_VERSION
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+		*/
+		void activateOptions() override;
+#endif
 		void activateOptions(helpers::Pool& p) override;
 
 		/**

--- a/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
+++ b/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
@@ -161,6 +161,9 @@ class LOG4CXX_EXPORT TimeBasedRollingPolicy : public virtual RollingPolicyBase,
 
 		\sa RollingPolicyBase::activateOptions()
 		*/
+#if 15 < LOG4CXX_ABI_VERSION
+		void activateOptions() override;
+#endif
 		void activateOptions(helpers::Pool& ) override;
 
 		void setMultiprocess(bool multiprocess);

--- a/src/main/include/log4cxx/rolling/triggeringpolicy.h
+++ b/src/main/include/log4cxx/rolling/triggeringpolicy.h
@@ -70,6 +70,15 @@ class LOG4CXX_EXPORT TriggeringPolicy :
 			const LogString& filename,
 			size_t fileLength) = 0;
 
+#if 15 < LOG4CXX_ABI_VERSION
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+		*/
+		void activateOptions(helpers::Pool& ) override;
+		void activateOptions() override;
+#endif
 };
 
 LOG4CXX_PTR_DEF(TriggeringPolicy);

--- a/src/main/include/log4cxx/spi/errorhandler.h
+++ b/src/main/include/log4cxx/spi/errorhandler.h
@@ -128,6 +128,14 @@ class LOG4CXX_EXPORT ErrorHandler : public virtual OptionHandler
 		Has an error been reported?
 		*/
 		virtual bool errorReported() const = 0;
+
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+		*/
+		void activateOptions(helpers::Pool& ) override;
+		void activateOptions() override;
 #endif
 };
 

--- a/src/main/include/log4cxx/spi/filter.h
+++ b/src/main/include/log4cxx/spi/filter.h
@@ -107,7 +107,14 @@ class LOG4CXX_EXPORT Filter : public virtual OptionHandler
 
 		No action is performed in this implementation.
 		*/
-		void activateOptions(helpers::Pool& p) override;
+#if LOG4CXX_ABI_VERSION <= 15
+		[[deprecated("Override activateOptions() without parameters instead")]]
+		void activateOptions(helpers::Pool& /* pool */) override;
+		void activateOptions();
+#else
+		void activateOptions(helpers::Pool& ) override;
+		void activateOptions() override;
+#endif
 
 		/**
 		\copybrief spi::OptionHandler::setOption()

--- a/src/main/include/log4cxx/spi/filter.h
+++ b/src/main/include/log4cxx/spi/filter.h
@@ -111,13 +111,14 @@ class LOG4CXX_EXPORT Filter : public virtual OptionHandler
 		@deprecated The \c pool parameter is not required and will be removed in a future version.
 		*/
 		void activateOptions(helpers::Pool& /* pool */) override;
+#else
 		/**
 		\copybrief spi::OptionHandler::activateOptions()
 
 		No action is performed in this implementation.
 		*/
-		void activateOptions();
-#else
+		void activateOptions() override;
+
 		/**
 		\copybrief spi::OptionHandler::activateOptions()
 
@@ -127,13 +128,6 @@ class LOG4CXX_EXPORT Filter : public virtual OptionHandler
 		*/
 		[[deprecated("Override activateOptions() without parameters instead")]]
 		void activateOptions(helpers::Pool& ) override;
-
-		/**
-		\copybrief spi::OptionHandler::activateOptions()
-
-		No action is performed in this implementation.
-		*/
-		void activateOptions() override;
 #endif
 
 		/**

--- a/src/main/include/log4cxx/spi/filter.h
+++ b/src/main/include/log4cxx/spi/filter.h
@@ -102,17 +102,37 @@ class LOG4CXX_EXPORT Filter : public virtual OptionHandler
 
 		};
 
+#if LOG4CXX_ABI_VERSION <= 15
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+
+		@deprecated The \c pool parameter is not required and will be removed in a future version.
+		*/
+		void activateOptions(helpers::Pool& /* pool */) override;
 		/**
 		\copybrief spi::OptionHandler::activateOptions()
 
 		No action is performed in this implementation.
 		*/
-#if LOG4CXX_ABI_VERSION <= 15
-		[[deprecated("Override activateOptions() without parameters instead")]]
-		void activateOptions(helpers::Pool& /* pool */) override;
 		void activateOptions();
 #else
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+
+		@deprecated This function is deprecated and will be removed in a future version.
+		*/
+		[[deprecated("Override activateOptions() without parameters instead")]]
 		void activateOptions(helpers::Pool& ) override;
+
+		/**
+		\copybrief spi::OptionHandler::activateOptions()
+
+		No action is performed in this implementation.
+		*/
 		void activateOptions() override;
 #endif
 

--- a/src/main/include/log4cxx/spi/optionhandler.h
+++ b/src/main/include/log4cxx/spi/optionhandler.h
@@ -20,6 +20,9 @@
 
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/object.h>
+#if LOG4CXX_ABI_VERSION <= 15
+#include <log4cxx/helpers/pool.h>
+#endif
 
 namespace LOG4CXX_NS
 {
@@ -49,8 +52,13 @@ class LOG4CXX_EXPORT OptionHandler : public virtual helpers::Object
 		the <code>File</code> and <b>Append</b> options both of
 		which are ambigous until the other is also set.
 		*/
+#if LOG4CXX_ABI_VERSION <= 15
 		virtual void activateOptions(helpers::Pool& p) = 0;
-
+		void activateOptions();
+#else
+		virtual void activateOptions(helpers::Pool& );
+		virtual void activateOptions() = 0;
+#endif
 
 		/**
 		Set <code>option</code> to <code>value</code>.

--- a/src/main/include/log4cxx/spi/optionhandler.h
+++ b/src/main/include/log4cxx/spi/optionhandler.h
@@ -50,11 +50,18 @@ class LOG4CXX_EXPORT OptionHandler : public virtual helpers::Object
 		which are ambigous until the other is also set.
 		*/
 #if LOG4CXX_ABI_VERSION <= 15
-		virtual void activateOptions(helpers::Pool& p) = 0;
 		void activateOptions();
+		/**
+		@deprecated The \c pool parameter is not required and will be removed in a future version.
+		*/
+		virtual void activateOptions(helpers::Pool& p) = 0;
 #else
-		virtual void activateOptions(helpers::Pool& );
 		virtual void activateOptions() = 0;
+		/**
+		@deprecated This function is deprecated and will be removed in a future version.
+		*/
+		[[deprecated("Override activateOptions() without parameters instead")]]
+		virtual void activateOptions(helpers::Pool& );
 #endif
 
 		/**

--- a/src/main/include/log4cxx/spi/optionhandler.h
+++ b/src/main/include/log4cxx/spi/optionhandler.h
@@ -20,9 +20,6 @@
 
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/object.h>
-#if LOG4CXX_ABI_VERSION <= 15
-#include <log4cxx/helpers/pool.h>
-#endif
 
 namespace LOG4CXX_NS
 {


### PR DESCRIPTION
This PR provides an argument-free `activateOptions()` interface without breaking code that uses the argumented version.

A subsequent commit is required to replace argumented  `activateOptions()` calls with argument-free version.