### PR TITLE
Generate fewer virtual base table pointers in the next ABI version

### DIFF
--- a/src/main/cpp/fmtlayout.cpp
+++ b/src/main/cpp/fmtlayout.cpp
@@ -61,8 +61,7 @@ FMTLayout::~FMTLayout(){}
 void FMTLayout::setConversionPattern(const LogString& pattern)
 {
 	m_priv->conversionPattern = pattern;
-	helpers::Pool pool;
-	activateOptions(pool);
+	activateOptions();
 }
 
 LogString FMTLayout::getConversionPattern() const

--- a/src/main/cpp/smtpappender.cpp
+++ b/src/main/cpp/smtpappender.cpp
@@ -342,9 +342,13 @@ class SMTPMessage
 };
 #endif
 
-class LOG4CXX_EXPORT DefaultEvaluator :
-	public virtual spi::TriggeringEventEvaluator,
-	public virtual helpers::Object
+class LOG4CXX_EXPORT DefaultEvaluator
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual spi::TriggeringEventEvaluator
+	, public virtual helpers::Object
+#else
+	: public spi::TriggeringEventEvaluator
+#endif
 {
 	public:
 		DECLARE_LOG4CXX_OBJECT(DefaultEvaluator)

--- a/src/main/include/log4cxx/appender.h
+++ b/src/main/include/log4cxx/appender.h
@@ -46,8 +46,12 @@ typedef std::shared_ptr<Layout> LayoutPtr;
 Implement this interface for your own strategies for outputting log
 statements.
 */
-class LOG4CXX_EXPORT Appender :
-	public virtual spi::OptionHandler
+class LOG4CXX_EXPORT Appender
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual spi::OptionHandler
+#else
+	: public spi::OptionHandler
+#endif
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(Appender)

--- a/src/main/include/log4cxx/appenderskeleton.h
+++ b/src/main/include/log4cxx/appenderskeleton.h
@@ -35,9 +35,13 @@ namespace LOG4CXX_NS
 *  This class provides the code for common functionality, such as
 *  support for threshold filtering and support for general filters.
 * */
-class LOG4CXX_EXPORT AppenderSkeleton :
-	public virtual Appender,
-	public virtual helpers::Object
+class LOG4CXX_EXPORT AppenderSkeleton
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual Appender
+	, public virtual helpers::Object
+#else
+	: public Appender
+#endif
 {
 	protected:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(AppenderSkeletonPrivate, m_priv)

--- a/src/main/include/log4cxx/helpers/onlyonceerrorhandler.h
+++ b/src/main/include/log4cxx/helpers/onlyonceerrorhandler.h
@@ -35,9 +35,13 @@ first error in an appender and ignoring all following errors.
 <p>This policy aims at protecting an otherwise working application
 from being flooded with error messages when logging fails
 */
-class LOG4CXX_EXPORT OnlyOnceErrorHandler :
-	public virtual spi::ErrorHandler,
-	public virtual Object
+class LOG4CXX_EXPORT OnlyOnceErrorHandler
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual spi::ErrorHandler
+	, public virtual helpers::Object
+#else
+	: public spi::ErrorHandler
+#endif
 {
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(OnlyOnceErrorHandlerPrivate, m_priv)

--- a/src/main/include/log4cxx/helpers/xml.h
+++ b/src/main/include/log4cxx/helpers/xml.h
@@ -47,7 +47,12 @@ class LOG4CXX_EXPORT DOMException : public RuntimeException
 The XMLDOMNode interface is the primary datatype for the entire Document
 Object Model.
 */
-class LOG4CXX_EXPORT XMLDOMNode : virtual public Object
+class LOG4CXX_EXPORT XMLDOMNode
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual Object
+#else
+	: public Object
+#endif
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(XMLDOMNode)
@@ -68,7 +73,12 @@ LOG4CXX_PTR_DEF(XMLDOMNode);
 /**
 The XMLDOMElement interface represents an element in an XML document
 */
-class LOG4CXX_EXPORT XMLDOMElement : virtual public XMLDOMNode
+class LOG4CXX_EXPORT XMLDOMElement
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual XMLDOMNode
+#else
+	: public XMLDOMNode
+#endif
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(XMLDOMElement)
@@ -83,7 +93,12 @@ The XMLDOMDocument interface represents an entire XML document.
 Conceptually, it is the root of the document tree, and provides the
 primary access to the document's data.
 */
-class LOG4CXX_EXPORT XMLDOMDocument : virtual public XMLDOMNode
+class LOG4CXX_EXPORT XMLDOMDocument
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual XMLDOMNode
+#else
+	: public XMLDOMNode
+#endif
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(XMLDOMDocument)
@@ -104,7 +119,12 @@ XMLDOMNodeList objects in the DOM are live.
 The items in the XMLDOMNodeList are accessible via an integral index,
 starting from 0.
 */
-class LOG4CXX_EXPORT XMLDOMNodeList : virtual public Object
+class LOG4CXX_EXPORT XMLDOMNodeList
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual Object
+#else
+	: public Object
+#endif
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(XMLDOMNodeList)

--- a/src/main/include/log4cxx/layout.h
+++ b/src/main/include/log4cxx/layout.h
@@ -28,9 +28,13 @@ namespace LOG4CXX_NS
 /**
 Extend this abstract class to create your own log layout format.
 */
-class LOG4CXX_EXPORT Layout :
-	public virtual spi::OptionHandler,
-	public virtual helpers::Object
+class LOG4CXX_EXPORT Layout
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual spi::OptionHandler
+	, public virtual helpers::Object
+#else
+	: public spi::OptionHandler
+#endif
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(Layout)

--- a/src/main/include/log4cxx/rolling/rollingpolicybase.h
+++ b/src/main/include/log4cxx/rolling/rollingpolicybase.h
@@ -39,9 +39,13 @@ LOG4CXX_LIST_DEF(PatternConverterList, LOG4CXX_NS::pattern::PatternConverterPtr)
  *
  *
  */
-class LOG4CXX_EXPORT RollingPolicyBase :
-	public virtual RollingPolicy,
-	public virtual helpers::Object
+class LOG4CXX_EXPORT RollingPolicyBase
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual RollingPolicy
+	, public virtual helpers::Object
+#else
+	: public RollingPolicy
+#endif
 {
 	protected:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(RollingPolicyBase)

--- a/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
+++ b/src/main/include/log4cxx/rolling/timebasedrollingpolicy.h
@@ -137,8 +137,14 @@ namespace rolling
  * the {@link #activateOptions} method of the owning
  * <code>RollingFileAppender</code>.
  */
-class LOG4CXX_EXPORT TimeBasedRollingPolicy : public virtual RollingPolicyBase,
-	public virtual TriggeringPolicy
+class LOG4CXX_EXPORT TimeBasedRollingPolicy
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual RollingPolicyBase
+	, public virtual TriggeringPolicy
+#else
+	: public RollingPolicyBase
+	, public virtual TriggeringPolicy
+#endif
 {
 		DECLARE_LOG4CXX_OBJECT(TimeBasedRollingPolicy)
 		BEGIN_LOG4CXX_CAST_MAP()

--- a/src/main/include/log4cxx/rolling/triggeringpolicy.h
+++ b/src/main/include/log4cxx/rolling/triggeringpolicy.h
@@ -41,9 +41,13 @@ namespace rolling
  *
  * */
 
-class LOG4CXX_EXPORT TriggeringPolicy :
-	public virtual spi::OptionHandler,
-	public virtual helpers::Object
+class LOG4CXX_EXPORT TriggeringPolicy
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual spi::OptionHandler
+	, public virtual helpers::Object
+#else
+	: public spi::OptionHandler
+#endif
 {
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(TriggeringPolicy)
 		BEGIN_LOG4CXX_CAST_MAP()

--- a/src/main/include/log4cxx/spi/defaultrepositoryselector.h
+++ b/src/main/include/log4cxx/spi/defaultrepositoryselector.h
@@ -27,9 +27,13 @@ namespace LOG4CXX_NS
 {
 namespace spi
 {
-class LOG4CXX_EXPORT DefaultRepositorySelector :
-	public virtual RepositorySelector,
-	public virtual helpers::Object
+class LOG4CXX_EXPORT DefaultRepositorySelector
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual RepositorySelector
+	, public virtual helpers::Object
+#else
+	: public RepositorySelector
+#endif
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(DefaultRepositorySelector)

--- a/src/main/include/log4cxx/spi/errorhandler.h
+++ b/src/main/include/log4cxx/spi/errorhandler.h
@@ -55,7 +55,12 @@ definition errors are hard to predict and to reproduce.
 that errors are not properly handled. You are most welcome to
 suggest new error handling policies or criticize existing policies.
 */
-class LOG4CXX_EXPORT ErrorHandler : public virtual OptionHandler
+class LOG4CXX_EXPORT ErrorHandler
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual OptionHandler
+#else
+	: public OptionHandler
+#endif
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(ErrorHandler)

--- a/src/main/include/log4cxx/spi/filter.h
+++ b/src/main/include/log4cxx/spi/filter.h
@@ -64,7 +64,12 @@ Linux ipchains.
 
 <p>Note that filtering is only supported by the DOMConfigurator.
 */
-class LOG4CXX_EXPORT Filter : public virtual OptionHandler
+class LOG4CXX_EXPORT Filter
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual OptionHandler
+#else
+	: public OptionHandler
+#endif
 {
 	protected:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(FilterPrivate, m_priv)

--- a/src/main/include/log4cxx/varia/fallbackerrorhandler.h
+++ b/src/main/include/log4cxx/varia/fallbackerrorhandler.h
@@ -40,8 +40,12 @@ Here is a sample configuration file that installs this error handler:
 \anchor fallback-ref-example
 \include async-fall-back-example.xml
 */
-class LOG4CXX_EXPORT FallbackErrorHandler :
-	public virtual spi::ErrorHandler
+class LOG4CXX_EXPORT FallbackErrorHandler
+#if LOG4CXX_ABI_VERSION <= 15
+	: public virtual spi::ErrorHandler
+#else
+	: public spi::ErrorHandler
+#endif
 {
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(FallbackErrorHandlerPrivate, m_priv)

--- a/src/test/cpp/customlogger/xlogger.h
+++ b/src/test/cpp/customlogger/xlogger.h
@@ -31,9 +31,8 @@ class LocationInfo;
 }
 // Any sub-class of Logger must also have its own implementation of
 // LoggerFactory.
-class XFactory :
-	public virtual spi::LoggerFactory,
-	public virtual helpers::Object
+class XFactory
+	: public spi::LoggerFactory
 {
 	public:
 		DECLARE_ABSTRACT_LOG4CXX_OBJECT(XFactory)

--- a/src/test/cpp/net/smtpappendertestcase.cpp
+++ b/src/test/cpp/net/smtpappendertestcase.cpp
@@ -31,7 +31,7 @@ namespace net
 {
 
 class MockTriggeringEventEvaluator :
-	public virtual spi::TriggeringEventEvaluator
+	public spi::TriggeringEventEvaluator
 {
 	public:
 		DECLARE_LOG4CXX_OBJECT(MockTriggeringEventEvaluator)

--- a/src/test/cpp/optionhandlertest.cpp
+++ b/src/test/cpp/optionhandlertest.cpp
@@ -95,6 +95,7 @@ private:
 class ABI_15_Specialized_Appender : public BaseAppender
 {
 public:
+	using spi::OptionHandler::activateOptions;
 	// void activateOptions(helpers::Pool& p) override --> compiler error: 'ABI_15_Specialized_Appender::activateOptions': method with override specifier 'override' did not override any base class methods
 	//                                                                     'log4cxx::spi::OptionHandler::activateOptions': Use activateOptions() without parameters instead
 	void activateOptions(helpers::Pool& p)
@@ -138,7 +139,9 @@ LOGUNIT_CLASS(OptionHandlerTest)
 	LOGUNIT_TEST_SUITE(OptionHandlerTest);
 	LOGUNIT_TEST(ABI_15_AppenderTest);
 	LOGUNIT_TEST(ABI_15_Specialized_AppenderTest);
-#if 15 < LOG4CXX_ABI_VERSION
+#if LOG4CXX_ABI_VERSION <= 15
+	LOGUNIT_TEST(ABI_15_Specialized_Appender_unagumented_activate_Test);
+#else
 	LOGUNIT_TEST(ABI_16_AppenderTest);
 #endif
 	LOGUNIT_TEST_SUITE_END();
@@ -166,7 +169,19 @@ public:
 		LOGUNIT_ASSERT(a15s.isActivated());
 	}
 
-#if 15 < LOG4CXX_ABI_VERSION
+#if LOG4CXX_ABI_VERSION <= 15
+	/**
+	 * Checks all levels of the appender heirarchy are activated
+	 */
+	void ABI_15_Specialized_Appender_unagumented_activate_Test()
+	{
+		helpers::Pool p;
+		ABI_15_Specialized_Appender a15s;
+		a15s.activateOptions();
+		LOGUNIT_ASSERT(a15s.isActivated());
+	}
+
+#else
 	/**
 	 * Checks all levels of the appender heirarchy are activated
 	 */


### PR DESCRIPTION
This PR restricts the use of virtual inheritance to where it is required to solve the "diamond problem".

Microsoft compiler-generated code for ABI 16 did not invoke the virtual `activateOptions` in the `ABI_15_Specialized_Appender` in the `OptionHandlerTest`, instead using the `append` virtual function pointer.