### PR TITLE
Simplify converter interfaces in a future ABI version

### DIFF
--- a/src/main/cpp/cacheddateformat.cpp
+++ b/src/main/cpp/cacheddateformat.cpp
@@ -151,8 +151,7 @@ CachedDateFormat::~CachedDateFormat() {}
  */
 int CachedDateFormat::findMillisecondStart(
 	log4cxx_time_t time, const LogString& formatted,
-	const DateFormatPtr& formatter,
-	Pool& pool)
+	const DateFormatPtr& formatter)
 {
 
 	log4cxx_time_t slotBegin = (time / 1000000) * 1000000;
@@ -175,7 +174,7 @@ int CachedDateFormat::findMillisecondStart(
 	}
 
 	LogString plusMagic;
-	formatter->format(plusMagic, slotBegin + magic, pool);
+	formatter->format(plusMagic, slotBegin + magic);
 
 	/**
 	 *   If the string lengths differ then
@@ -199,7 +198,7 @@ int CachedDateFormat::findMillisecondStart(
 				millisecondFormat(millis, formattedMillis, 0);
 
 				LogString plusZero;
-				formatter->format(plusZero, slotBegin, pool);
+				formatter->format(plusZero, slotBegin);
 
 				// Test if the next 1..3 characters match the magic string, main problem is that magic
 				// available millis in formatted can overlap. Therefore the current i is not always the
@@ -232,7 +231,15 @@ int CachedDateFormat::findMillisecondStart(
 
 	return NO_MILLISECONDS;
 }
-
+#if LOG4CXX_ABI_VERSION <= 15
+int CachedDateFormat::findMillisecondStart(
+	log4cxx_time_t time, const LogString& formatted,
+	const DateFormatPtr& formatter,
+	Pool& pool)
+{
+	return findMillisecondStart(time, formatted, formatter);
+}
+#endif
 
 /**
  * Formats a millisecond count into a date/time string.
@@ -240,16 +247,16 @@ int CachedDateFormat::findMillisecondStart(
  *  @param now Number of milliseconds after midnight 1 Jan 1970 GMT.
  *  @param sbuf the string buffer to write to
  */
-void CachedDateFormat::format(LogString& buf, log4cxx_time_t now, Pool& p) const
+void CachedDateFormat::format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const
 {
 
 	//
 	// If the current requested time is identical to the previously
 	//     requested time, then append the cache contents.
 	//
-	if (now == m_priv->previousTime)
+	if (tm == m_priv->previousTime)
 	{
-		buf.append(m_priv->cache);
+		toAppendTo.append(m_priv->cache);
 		return;
 	}
 
@@ -262,23 +269,23 @@ void CachedDateFormat::format(LogString& buf, log4cxx_time_t now, Pool& p) const
 		//    Check if the cache is still valid.
 		//    If the requested time is within the same integral second
 		//       as the last request and a shorter expiration was not requested.
-		if (now < m_priv->slotBegin + m_priv->expiration
-			&& now >= m_priv->slotBegin
-			&& now < m_priv->slotBegin + 1000000L)
+		if (tm < m_priv->slotBegin + m_priv->expiration
+			&& tm >= m_priv->slotBegin
+			&& tm < m_priv->slotBegin + 1000000L)
 		{
 			//
 			//    if there was a millisecond field then update it
 			//
 			if (m_priv->millisecondStart >= 0)
 			{
-				millisecondFormat((int) ((now - m_priv->slotBegin) / 1000), m_priv->cache, m_priv->millisecondStart);
+				millisecondFormat((int) ((tm - m_priv->slotBegin) / 1000), m_priv->cache, m_priv->millisecondStart);
 			}
 
 			//
 			//   update the previously requested time
 			//      (the slot begin should be unchanged)
-			m_priv->previousTime = now;
-			buf.append(m_priv->cache);
+			m_priv->previousTime = tm;
+			toAppendTo.append(m_priv->cache);
 
 			return;
 		}
@@ -288,9 +295,9 @@ void CachedDateFormat::format(LogString& buf, log4cxx_time_t now, Pool& p) const
 	//  could not use previous value.
 	//    Call underlying formatter to format date.
 	m_priv->cache.erase(m_priv->cache.begin(), m_priv->cache.end());
-	m_priv->formatter->format(m_priv->cache, now, p);
-	buf.append(m_priv->cache);
-	m_priv->previousTime = now;
+	m_priv->formatter->format(m_priv->cache, tm);
+	toAppendTo.append(m_priv->cache);
+	m_priv->previousTime = tm;
 	m_priv->slotBegin = (m_priv->previousTime / 1000000) * 1000000;
 
 	if (m_priv->slotBegin > m_priv->previousTime)
@@ -304,7 +311,7 @@ void CachedDateFormat::format(LogString& buf, log4cxx_time_t now, Pool& p) const
 	//
 	if (m_priv->millisecondStart >= 0)
 	{
-		m_priv->millisecondStart = findMillisecondStart(now, m_priv->cache, m_priv->formatter, p);
+		m_priv->millisecondStart = findMillisecondStart(tm, m_priv->cache, m_priv->formatter);
 	}
 }
 
@@ -340,9 +347,9 @@ void CachedDateFormat::setTimeZone(const TimeZonePtr& timeZone)
 
 
 
-void CachedDateFormat::numberFormat(LogString& s, int n, Pool& p) const
+void CachedDateFormat::numberFormat( LOG4CXX_FORMAT_NUMBER_FORMAL_PARAMETERS ) const
 {
-	m_priv->formatter->numberFormat(s, n, p);
+	m_priv->formatter->numberFormat(toAppendTo, n);
 }
 
 

--- a/src/main/cpp/classnamepatternconverter.cpp
+++ b/src/main/cpp/classnamepatternconverter.cpp
@@ -40,10 +40,7 @@ PatternConverterPtr ClassNamePatternConverter::newInstance(
 	return std::make_shared<ClassNamePatternConverter>(options);
 }
 
-void ClassNamePatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& /* p */) const
+void ClassNamePatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	int initialLength = (int)toAppendTo.length();
 	append(toAppendTo, event->getLocationInformation().getClassName());

--- a/src/main/cpp/colorendpatternconverter.cpp
+++ b/src/main/cpp/colorendpatternconverter.cpp
@@ -41,10 +41,7 @@ PatternConverterPtr ColorEndPatternConverter::newInstance(
 	return instance;
 }
 
-void ColorEndPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& p) const
+void ColorEndPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 
 	// Reset all colors on the output(code 0)

--- a/src/main/cpp/colorstartpatternconverter.cpp
+++ b/src/main/cpp/colorstartpatternconverter.cpp
@@ -158,10 +158,7 @@ PatternConverterPtr ColorStartPatternConverter::newInstance(
 	return instance;
 }
 
-void ColorStartPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& p) const
+void ColorStartPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 
 	LOG4CXX_NS::LevelPtr lvl = event->getLevel();

--- a/src/main/cpp/dateformat.cpp
+++ b/src/main/cpp/dateformat.cpp
@@ -18,6 +18,7 @@
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/dateformat.h>
 #include <log4cxx/helpers/stringhelper.h>
+#include <log4cxx/helpers/pool.h>
 
 
 using namespace LOG4CXX_NS;
@@ -36,3 +37,20 @@ void DateFormat::numberFormat(LogString& s, int n, Pool& p) const
 
 DateFormat::DateFormat() {}
 
+void DateFormat::numberFormat(LogString& toAppendTo, int n) const
+{
+	StringHelper::toString(n, toAppendTo);
+}
+
+#if LOG4CXX_ABI_VERSION <= 15
+void DateFormat::format(LogString& toAppendTo, log4cxx_time_t tm) const
+{
+	helpers::Pool p;
+	format(toAppendTo, tm, p);
+}
+#else
+void DateFormat::format(LogString& toAppendTo, log4cxx_time_t tm, Pool& p) const
+{
+	format(toAppendTo, tm);
+}
+#endif

--- a/src/main/cpp/datepatternconverter.cpp
+++ b/src/main/cpp/datepatternconverter.cpp
@@ -144,39 +144,27 @@ PatternConverterPtr DatePatternConverter::newInstance(
 	return std::make_shared<DatePatternConverter>(options);
 }
 
-void DatePatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& p) const
+void DatePatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
-	priv->df->format(toAppendTo, event->getTimeStamp(), p);
+	priv->df->format(toAppendTo, event->getTimeStamp());
 }
 
 /**
  * {@inheritDoc}
  */
-void DatePatternConverter::format(
-	const ObjectPtr& obj,
-	LogString& toAppendTo,
-	Pool& p) const
+void DatePatternConverter::format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const
 {
-	DatePtr date = LOG4CXX_NS::cast<Date>(obj);
-
-	if (date != NULL)
+	if (auto date = LOG4CXX_NS::cast<Date>(obj))
 	{
-		format(date, toAppendTo, p);
+		format(date, toAppendTo);
 	}
-	else
+	else if (auto event = LOG4CXX_NS::cast<LoggingEvent>(obj))
 	{
-		LoggingEventPtr event = LOG4CXX_NS::cast<LoggingEvent>(obj);
-
-		if (event != NULL)
-		{
-			format(event, toAppendTo, p);
-		}
+		format( LOG4CXX_FORMAT_EVENT_PARAMETERS );
 	}
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
 /**
  * Append formatted date to string buffer.
  * @param date date
@@ -188,4 +176,9 @@ void DatePatternConverter::format(
 	Pool& p) const
 {
 	priv->df->format(toAppendTo, date->getTime(), p);
+}
+#endif
+void DatePatternConverter::format(const DatePtr& date, LogString& toAppendTo) const
+{
+	priv->df->format(toAppendTo, date->getTime());
 }

--- a/src/main/cpp/dbappender.cpp
+++ b/src/main/cpp/dbappender.cpp
@@ -236,10 +236,9 @@ void DBAppender::append( LOG4CXX_APPEND_FORMAL_PARAMETERS ){
         return;
     }
 
-    helpers::Pool tempPool;
     for(auto& converter : _priv->converters){
-        LogString str_data;
-        converter->format(event, str_data, tempPool);
+		LogString str_data;
+		converter->format(event, str_data);
 		LOG4CXX_ENCODE_CHAR(new_str_data, str_data);
 		ls_args.push_back(new_str_data);
     }

--- a/src/main/cpp/filelocationpatternconverter.cpp
+++ b/src/main/cpp/filelocationpatternconverter.cpp
@@ -38,10 +38,7 @@ PatternConverterPtr FileLocationPatternConverter::newInstance(
 	return std::make_shared<FileLocationPatternConverter>();
 }
 
-void FileLocationPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& /* p */ ) const
+void FileLocationPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	append(toAppendTo, event->getLocationInformation().getFileName());
 }

--- a/src/main/cpp/fulllocationpatternconverter.cpp
+++ b/src/main/cpp/fulllocationpatternconverter.cpp
@@ -40,10 +40,7 @@ PatternConverterPtr FullLocationPatternConverter::newInstance(
 	return std::make_shared<FullLocationPatternConverter>();
 }
 
-void FullLocationPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& p) const
+void FullLocationPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	append(toAppendTo, event->getLocationInformation().getFileName());
 	toAppendTo.append(1, (logchar) 0x28 /* '(' */);

--- a/src/main/cpp/htmllayout.cpp
+++ b/src/main/cpp/htmllayout.cpp
@@ -91,7 +91,7 @@ void HTMLLayout::format(LogString& output,
 	output.append(LOG4CXX_EOL);
 	output.append(LOG4CXX_STR("<td>"));
 
-	m_priv->dateFormat.format(output, event->getTimeStamp(), p);
+	m_priv->dateFormat.format(output, event->getTimeStamp());
 
 
 	output.append(LOG4CXX_STR("</td>"));
@@ -207,7 +207,7 @@ void HTMLLayout::appendHeader(LogString& output, Pool& p)
 	output.append(LOG4CXX_EOL);
 	output.append(LOG4CXX_STR("Log session start time "));
 
-	m_priv->dateFormat.format(output, Date::currentTime(), p);
+	m_priv->dateFormat.format(output, Date::currentTime());
 
 	output.append(LOG4CXX_STR("<br>"));
 	output.append(LOG4CXX_EOL);

--- a/src/main/cpp/integerpatternconverter.cpp
+++ b/src/main/cpp/integerpatternconverter.cpp
@@ -38,10 +38,7 @@ PatternConverterPtr IntegerPatternConverter::newInstance(
 	return std::make_shared<IntegerPatternConverter>();
 }
 
-void IntegerPatternConverter::format(
-	const ObjectPtr& obj,
-	LogString& toAppendTo,
-	Pool& p) const
+void IntegerPatternConverter::format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const
 {
 	IntegerPtr i = LOG4CXX_NS::cast<Integer>(obj);
 

--- a/src/main/cpp/jsonlayout.cpp
+++ b/src/main/cpp/jsonlayout.cpp
@@ -143,7 +143,7 @@ void JSONLayout::format(LogString& output,
 	}
 
 	output.append(LOG4CXX_STR("\"timestamp\": \""));
-	m_priv->dateFormat.format(output, event->getTimeStamp(), p);
+	m_priv->dateFormat.format(output, event->getTimeStamp());
 	output.append(LOG4CXX_STR("\","));
 	output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
 

--- a/src/main/cpp/levelpatternconverter.cpp
+++ b/src/main/cpp/levelpatternconverter.cpp
@@ -41,10 +41,7 @@ PatternConverterPtr LevelPatternConverter::newInstance(
 	return std::make_shared<LevelPatternConverter>();
 }
 
-void LevelPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	LOG4CXX_NS::helpers::Pool& /* p */) const
+void LevelPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	toAppendTo.append(event->getLevel()->toString());
 }

--- a/src/main/cpp/linelocationpatternconverter.cpp
+++ b/src/main/cpp/linelocationpatternconverter.cpp
@@ -40,10 +40,7 @@ PatternConverterPtr LineLocationPatternConverter::newInstance(
 	return std::make_shared<LineLocationPatternConverter>();
 }
 
-void LineLocationPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& p) const
+void LineLocationPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	StringHelper::toString(
 		event->getLocationInformation().getLineNumber(),

--- a/src/main/cpp/lineseparatorpatternconverter.cpp
+++ b/src/main/cpp/lineseparatorpatternconverter.cpp
@@ -39,18 +39,12 @@ PatternConverterPtr LineSeparatorPatternConverter::newInstance(
 	return std::make_shared<LineSeparatorPatternConverter>();
 }
 
-void LineSeparatorPatternConverter::format(
-	const LoggingEventPtr& /* event */,
-	LogString& toAppendTo,
-	Pool& /* p */) const
+void LineSeparatorPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	toAppendTo.append(LOG4CXX_EOL);
 }
 
-void LineSeparatorPatternConverter::format(
-	const ObjectPtr& /* event */,
-	LogString& toAppendTo,
-	Pool& /* p */) const
+void LineSeparatorPatternConverter::format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const
 {
 	toAppendTo.append(LOG4CXX_EOL);
 }

--- a/src/main/cpp/literalpatternconverter.cpp
+++ b/src/main/cpp/literalpatternconverter.cpp
@@ -60,18 +60,12 @@ PatternConverterPtr LiteralPatternConverter::newInstance(
 	return std::make_shared<LiteralPatternConverter>(literal);
 }
 
-void LiteralPatternConverter::format(
-	const LoggingEventPtr& /* event */,
-	LogString& toAppendTo,
-	Pool& /* p */) const
+void LiteralPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	toAppendTo.append(priv->literal);
 }
 
-void LiteralPatternConverter::format(
-	const ObjectPtr& /* event */,
-	LogString& toAppendTo,
-	Pool& /* p */)  const
+void LiteralPatternConverter::format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS )  const
 {
 	toAppendTo.append(priv->literal);
 }

--- a/src/main/cpp/loggerpatternconverter.cpp
+++ b/src/main/cpp/loggerpatternconverter.cpp
@@ -40,10 +40,7 @@ PatternConverterPtr LoggerPatternConverter::newInstance(
 	return std::make_shared<LoggerPatternConverter>(options);
 }
 
-void LoggerPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& /* p */ ) const
+void LoggerPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	int initialLength = (int)toAppendTo.length();
 	toAppendTo.append(event->getLoggerName());

--- a/src/main/cpp/loggingeventpatternconverter.cpp
+++ b/src/main/cpp/loggingeventpatternconverter.cpp
@@ -40,15 +40,11 @@ LoggingEventPatternConverter::LoggingEventPatternConverter(std::unique_ptr<Patte
 
 }
 
-void LoggingEventPatternConverter::format(const ObjectPtr& obj,
-	LogString& output,
-	LOG4CXX_NS::helpers::Pool& p) const
+void LoggingEventPatternConverter::format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const
 {
-	LoggingEventPtr le = LOG4CXX_NS::cast<LoggingEvent>(obj);
-
-	if (le != NULL)
+	if (auto event = LOG4CXX_NS::cast<LoggingEvent>(obj))
 	{
-		format(le, output, p);
+		format( LOG4CXX_FORMAT_EVENT_PARAMETERS );
 	}
 }
 
@@ -56,3 +52,16 @@ bool LoggingEventPatternConverter::handlesThrowable() const
 {
 	return false;
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+void LoggingEventPatternConverter::format(const spi::LoggingEventPtr& event, LogString& toAppendTo) const
+{
+	helpers::Pool p;
+	format(event, toAppendTo, p);
+}
+#else
+void LoggingEventPatternConverter::format(const spi::LoggingEventPtr& event, LogString& toAppendTo, helpers::Pool&) const
+{
+	format(event, toAppendTo);
+}
+#endif

--- a/src/main/cpp/mdcpatternconverter.cpp
+++ b/src/main/cpp/mdcpatternconverter.cpp
@@ -42,11 +42,7 @@ PatternConverterPtr MDCPatternConverter::newInstance(
 	return std::make_shared<MDCPatternConverter>(LogString(), options.front());
 }
 
-void MDCPatternConverter::format
-	( const spi::LoggingEventPtr& event
-	, LogString&                  toAppendTo
-	, helpers::Pool&           /* p */
-	) const
+void MDCPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	size_t startIndex = toAppendTo.size();
 	auto& info = getFormattingInfo();

--- a/src/main/cpp/messagepatternconverter.cpp
+++ b/src/main/cpp/messagepatternconverter.cpp
@@ -42,11 +42,7 @@ class QuotedMessagePatternConverter : public LoggingEventPatternConverter
 		using LoggingEventPatternConverter::format;
 
 		// Duplicate any quote character in the event message
-		void format
-			( const spi::LoggingEventPtr& event
-			, LogString&                  toAppendTo
-			, helpers::Pool&              p
-			) const override
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override
 		{
 			auto& input = event->getRenderedMessage();
 			size_t endIndex, startIndex = 0;
@@ -77,11 +73,7 @@ PatternConverterPtr MessagePatternConverter::newInstance(
 	return std::make_shared<QuotedMessagePatternConverter>(options.front().front());
 }
 
-void MessagePatternConverter::format
-	( const spi::LoggingEventPtr& event
-	, LogString&                  toAppendTo
-	, helpers::Pool&           /* p */
-	) const
+void MessagePatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	auto& msg = event->getRenderedMessage();
 	auto& info = getFormattingInfo();

--- a/src/main/cpp/methodlocationpatternconverter.cpp
+++ b/src/main/cpp/methodlocationpatternconverter.cpp
@@ -39,10 +39,7 @@ PatternConverterPtr MethodLocationPatternConverter::newInstance(
 	return std::make_shared<MethodLocationPatternConverter>();
 }
 
-void MethodLocationPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& /* p */ ) const
+void MethodLocationPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	append(toAppendTo, event->getLocationInformation().getMethodName());
 }

--- a/src/main/cpp/ndcpatternconverter.cpp
+++ b/src/main/cpp/ndcpatternconverter.cpp
@@ -39,10 +39,7 @@ PatternConverterPtr NDCPatternConverter::newInstance(
 	return std::make_shared<NDCPatternConverter>();
 }
 
-void NDCPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& /* p */) const
+void NDCPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	LogString value;
 	if (event->getNDC(value))

--- a/src/main/cpp/patternconverter.cpp
+++ b/src/main/cpp/patternconverter.cpp
@@ -17,6 +17,7 @@
 
 #include <log4cxx/logstring.h>
 #include <log4cxx/pattern/patternconverter.h>
+#include <log4cxx/helpers/pool.h>
 #include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/private/patternconverter_priv.h>
 
@@ -67,3 +68,16 @@ void PatternConverter::setFormattingInfo(const FormattingInfoPtr& newValue)
 {
 	m_priv->info = newValue;
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+void PatternConverter::format(const helpers::ObjectPtr& obj, LogString& toAppendTo) const
+{
+	helpers::Pool p;
+	format(obj, toAppendTo, p);
+}
+#else
+void PatternConverter::format(const helpers::ObjectPtr& obj, LogString& toAppendTo, helpers::Pool&) const
+{
+	format(obj, toAppendTo);
+}
+#endif

--- a/src/main/cpp/patternlayout.cpp
+++ b/src/main/cpp/patternlayout.cpp
@@ -121,7 +121,7 @@ void PatternLayout::format(LogString& output,
 	for (auto item : m_priv->patternConverters)
 	{
 		auto startField = output.length();
-		item->format(event, output, pool);
+		item->format(event, output);
 		if (startField < INT_MAX)
 			item->getFormattingInfo().format(static_cast<int>(startField), output);
 	}

--- a/src/main/cpp/propertiespatternconverter.cpp
+++ b/src/main/cpp/propertiespatternconverter.cpp
@@ -66,10 +66,7 @@ PatternConverterPtr PropertiesPatternConverter::newInstance(
 	return std::make_shared<PropertiesPatternConverter>(converterName, options[0]);
 }
 
-void PropertiesPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& /* p */) const
+void PropertiesPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	if (priv->option.length() == 0)
 	{

--- a/src/main/cpp/relativetimedateformat.cpp
+++ b/src/main/cpp/relativetimedateformat.cpp
@@ -26,11 +26,8 @@ LOG4CXX_NS::helpers::RelativeTimeDateFormat::RelativeTimeDateFormat()
 {
 }
 
-void LOG4CXX_NS::helpers::RelativeTimeDateFormat::format(
-	LogString& s,
-	log4cxx_time_t date,
-	Pool& p) const
+void LOG4CXX_NS::helpers::RelativeTimeDateFormat::format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const
 {
-	int64_t interval = (date - startTime) / int64_t(1000);
-	StringHelper::toString(interval, s);
+	int64_t interval = (tm - startTime) / int64_t(1000);
+	StringHelper::toString(interval, toAppendTo);
 }

--- a/src/main/cpp/relativetimepatternconverter.cpp
+++ b/src/main/cpp/relativetimepatternconverter.cpp
@@ -41,10 +41,7 @@ PatternConverterPtr RelativeTimePatternConverter::newInstance(
 	return def;
 }
 
-void RelativeTimePatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& p) const
+void RelativeTimePatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	log4cxx_time_t delta = (event->getTimeStamp() - LoggingEvent::getStartTime()) / 1000;
 	StringHelper::toString(delta, toAppendTo);

--- a/src/main/cpp/rollingpolicybase.cpp
+++ b/src/main/cpp/rollingpolicybase.cpp
@@ -122,7 +122,7 @@ void RollingPolicyBase::formatFileName(
 	for (auto item : m_priv->patternConverters)
 	{
 		auto startField = toAppendTo.length();
-		item->format(obj, toAppendTo, pool);
+		item->format(obj, toAppendTo);
 		item->getFormattingInfo().format((int)startField, toAppendTo);
 	}
 }

--- a/src/main/cpp/shortfilelocationpatternconverter.cpp
+++ b/src/main/cpp/shortfilelocationpatternconverter.cpp
@@ -37,9 +37,6 @@ PatternConverterPtr ShortFileLocationPatternConverter::newInstance(
   return PatternConverterPtr(new ShortFileLocationPatternConverter());
 }
 
-void ShortFileLocationPatternConverter::format(
-    const LoggingEventPtr &event,
-    LogString &toAppendTo,
-    Pool & /* p */ ) const {
+void ShortFileLocationPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const {
   append(toAppendTo, event->getLocationInformation().getShortFileName());
 }

--- a/src/main/cpp/simpledateformat.cpp
+++ b/src/main/cpp/simpledateformat.cpp
@@ -838,16 +838,17 @@ SimpleDateFormat::~SimpleDateFormat()
 }
 
 
-void SimpleDateFormat::format( LogString& s, log4cxx_time_t time, Pool& p ) const
+void SimpleDateFormat::format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const
 {
+	helpers::Pool tempPool;
 	apr_time_exp_t exploded;
-	apr_status_t stat = m_priv->timeZone->explode( & exploded, time );
+	apr_status_t stat = m_priv->timeZone->explode( & exploded, tm );
 
 	if ( stat == APR_SUCCESS )
 	{
 		for ( PatternTokenList::const_iterator iter = m_priv->pattern.begin(); iter != m_priv->pattern.end(); iter++ )
 		{
-			( * iter )->format( s, exploded, p );
+			( * iter )->format( toAppendTo, exploded, tempPool );
 		}
 	}
 }

--- a/src/main/cpp/strftimedateformat.cpp
+++ b/src/main/cpp/strftimedateformat.cpp
@@ -48,10 +48,10 @@ StrftimeDateFormat::~StrftimeDateFormat()
 }
 
 
-void StrftimeDateFormat::format(LogString& s, log4cxx_time_t time, Pool& /* p */ ) const
+void StrftimeDateFormat::format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const
 {
 	apr_time_exp_t exploded;
-	apr_status_t stat = m_priv->timeZone->explode(&exploded, time);
+	apr_status_t stat = m_priv->timeZone->explode(&exploded, tm);
 
 	if (stat == APR_SUCCESS)
 	{
@@ -62,7 +62,7 @@ void StrftimeDateFormat::format(LogString& s, log4cxx_time_t time, Pool& /* p */
 
 		if (stat == APR_SUCCESS)
 		{
-			LOG4CXX_NS::helpers::Transcoder::decode(std::string(buf, bufLen), s);
+			LOG4CXX_NS::helpers::Transcoder::decode(std::string(buf, bufLen), toAppendTo);
 		}
 	}
 }

--- a/src/main/cpp/threadpatternconverter.cpp
+++ b/src/main/cpp/threadpatternconverter.cpp
@@ -39,10 +39,7 @@ PatternConverterPtr ThreadPatternConverter::newInstance(
 	return std::make_shared<ThreadPatternConverter>();
 }
 
-void ThreadPatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& /* p */) const
+void ThreadPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	toAppendTo.append(event->getThreadName());
 }

--- a/src/main/cpp/threadusernamepatternconverter.cpp
+++ b/src/main/cpp/threadusernamepatternconverter.cpp
@@ -39,10 +39,7 @@ PatternConverterPtr ThreadUsernamePatternConverter::newInstance(
 	return std::make_shared<ThreadUsernamePatternConverter>();
 }
 
-void ThreadUsernamePatternConverter::format(
-	const LoggingEventPtr& event,
-	LogString& toAppendTo,
-	Pool& /* p */) const
+void ThreadUsernamePatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 	toAppendTo.append(event->getThreadUserName());
 }

--- a/src/main/cpp/throwableinformationpatternconverter.cpp
+++ b/src/main/cpp/throwableinformationpatternconverter.cpp
@@ -62,10 +62,7 @@ PatternConverterPtr ThrowableInformationPatternConverter::newInstance(
 	return std::make_shared<ThrowableInformationPatternConverter>(false);
 }
 
-void ThrowableInformationPatternConverter::format(
-	const LoggingEventPtr& /* event */,
-	LogString& /* toAppendTo */,
-	Pool& /* p */) const
+void ThrowableInformationPatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
 }
 

--- a/src/main/include/log4cxx/helpers/cacheddateformat.h
+++ b/src/main/include/log4cxx/helpers/cacheddateformat.h
@@ -24,7 +24,7 @@ namespace LOG4CXX_NS
 {
 namespace pattern
 {
-class LOG4CXX_EXPORT CachedDateFormat : public LOG4CXX_NS::helpers::DateFormat
+class LOG4CXX_EXPORT CachedDateFormat : public helpers::DateFormat
 {
 	public:
 		enum
@@ -93,7 +93,7 @@ class LOG4CXX_EXPORT CachedDateFormat : public LOG4CXX_NS::helpers::DateFormat
 		 *      caching algorithm, use a value of 0 to totally disable
 		 *      caching or 1 to only use cache for duplicate requests.
 		 */
-		CachedDateFormat(const LOG4CXX_NS::helpers::DateFormatPtr& dateFormat, int expiration);
+		CachedDateFormat(const helpers::DateFormatPtr& dateFormat, int expiration);
 		~CachedDateFormat();
 
 		/**
@@ -101,16 +101,21 @@ class LOG4CXX_EXPORT CachedDateFormat : public LOG4CXX_NS::helpers::DateFormat
 		 * @param time long time, must be integral number of seconds
 		 * @param formatted String corresponding formatted string
 		 * @param formatter DateFormat date format
-		 * @param pool pool.
 		 * @return int position in string of first digit of milliseconds,
 		 *    -1 indicates no millisecond field, -2 indicates unrecognized
 		 *    field (likely RelativeTimeDateFormat)
 		 */
 		static int findMillisecondStart(
 			log4cxx_time_t time, const LogString& formatted,
+			const helpers::DateFormatPtr& formatter);
+#if LOG4CXX_ABI_VERSION <= 15
+		[[deprecated("Use findMillisecondStart() without a Pool parameter instead")]]
+		static int findMillisecondStart(
+			log4cxx_time_t time, const LogString& formatted,
 			const LOG4CXX_NS::helpers::DateFormatPtr& formatter,
 			LOG4CXX_NS::helpers::Pool& pool);
-
+#endif
+		using DateFormat::format;
 		/**
 		 * Formats a Date into a date/time string.
 		 *
@@ -118,9 +123,7 @@ class LOG4CXX_EXPORT CachedDateFormat : public LOG4CXX_NS::helpers::DateFormat
 		 *  @param sbuf the string buffer to write to.
 		 *  @param p memory pool.
 		 */
-		virtual void format(LogString& sbuf,
-			log4cxx_time_t date,
-			LOG4CXX_NS::helpers::Pool& p) const;
+		virtual void format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const;
 
 	private:
 		/**
@@ -143,7 +146,7 @@ class LOG4CXX_EXPORT CachedDateFormat : public LOG4CXX_NS::helpers::DateFormat
 		 * will likely cause caching to misbehave.
 		 * @param zone TimeZone new timezone
 		 */
-		virtual void setTimeZone(const LOG4CXX_NS::helpers::TimeZonePtr& zone);
+		virtual void setTimeZone(const helpers::TimeZonePtr& zone);
 
 		/**
 		* Format an integer consistent with the format method.
@@ -151,9 +154,7 @@ class LOG4CXX_EXPORT CachedDateFormat : public LOG4CXX_NS::helpers::DateFormat
 		* @param n integer value.
 		* @param p memory pool used during formatting.
 		*/
-		virtual void numberFormat(LogString& s,
-			int n,
-			LOG4CXX_NS::helpers::Pool& p) const;
+		void numberFormat( LOG4CXX_FORMAT_NUMBER_FORMAL_PARAMETERS ) const override;
 
 		/**
 		 * Gets maximum cache validity for the specified SimpleDateTime

--- a/src/main/include/log4cxx/helpers/cacheddateformat.h
+++ b/src/main/include/log4cxx/helpers/cacheddateformat.h
@@ -121,9 +121,8 @@ class LOG4CXX_EXPORT CachedDateFormat : public helpers::DateFormat
 		 *
 		 *  @param date the date to format.
 		 *  @param sbuf the string buffer to write to.
-		 *  @param p memory pool.
 		 */
-		virtual void format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const;
+		void format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const override;
 
 	private:
 		/**
@@ -146,7 +145,7 @@ class LOG4CXX_EXPORT CachedDateFormat : public helpers::DateFormat
 		 * will likely cause caching to misbehave.
 		 * @param zone TimeZone new timezone
 		 */
-		virtual void setTimeZone(const helpers::TimeZonePtr& zone);
+		void setTimeZone(const helpers::TimeZonePtr& zone) override;
 
 		/**
 		* Format an integer consistent with the format method.

--- a/src/main/include/log4cxx/helpers/dateformat.h
+++ b/src/main/include/log4cxx/helpers/dateformat.h
@@ -45,11 +45,27 @@ class LOG4CXX_EXPORT DateFormat : public Object
 
 		/**
 		* Formats an log4cxx_time_t into a date/time string.
-		* @param s string to which the date/time string is appended.
+		* @param toAppendTo string to which the date/time string is appended.
 		* @param tm date to be formatted.
 		* @param p memory pool used during formatting.
 		*/
-		virtual void format(LogString& s, log4cxx_time_t tm, LOG4CXX_NS::helpers::Pool& p) const = 0;
+#if LOG4CXX_ABI_VERSION <= 15
+#define LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS LogString& toAppendTo, log4cxx_time_t tm, helpers::Pool& p
+		void format(LogString& toAppendTo, log4cxx_time_t tm) const;
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to format() without a helpers::Pool parameter.
+		*/
+		virtual void format(LogString& toAppendTo, log4cxx_time_t tm, LOG4CXX_NS::helpers::Pool& p) const = 0;
+#else
+#define LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS LogString& toAppendTo, log4cxx_time_t tm
+		virtual void format(LogString& toAppendTo, log4cxx_time_t tm) const = 0;
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use format() without a Pool parameter instead")]]
+		void format(LogString& toAppendTo, log4cxx_time_t tm, helpers::Pool& p) const;
+#endif
 
 		/**
 		* Sets the time zone.
@@ -59,14 +75,29 @@ class LOG4CXX_EXPORT DateFormat : public Object
 
 		/**
 		* Format an integer consistent with the format method.
-		* @param s string to which the numeric string is appended.
+		* @param toAppendTo string to which the numeric string is appended.
 		* @param n integer value.
 		* @param p memory pool used during formatting.
 		* @remarks This method is used by CachedDateFormat to
 		* format the milliseconds.
 		*/
-		virtual void numberFormat(LogString& s, int n, LOG4CXX_NS::helpers::Pool& p) const;
-
+#if LOG4CXX_ABI_VERSION <= 15
+		void numberFormat(LogString& toAppendTo, int n) const;
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use numberFormat() without a Pool parameter instead")]]
+		virtual void numberFormat(LogString& toAppendTo, int n, LOG4CXX_NS::helpers::Pool& p) const;
+#define LOG4CXX_FORMAT_NUMBER_FORMAL_PARAMETERS LogString& toAppendTo, int n, helpers::Pool& p
+#else
+		virtual void numberFormat(LogString& toAppendTo, int n) const;
+#define LOG4CXX_FORMAT_NUMBER_FORMAL_PARAMETERS LogString& toAppendTo, int n
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use numberFormat() without a Pool parameter instead")]]
+		void numberFormat(LogString& toAppendTo, int n, helpers::Pool& p) const;
+#endif
 
 	protected:
 		/**

--- a/src/main/include/log4cxx/helpers/relativetimedateformat.h
+++ b/src/main/include/log4cxx/helpers/relativetimedateformat.h
@@ -33,9 +33,9 @@ class LOG4CXX_EXPORT RelativeTimeDateFormat : public DateFormat
 {
 	public:
 		RelativeTimeDateFormat();
-		virtual void format(LogString& s,
-			log4cxx_time_t tm,
-			LOG4CXX_NS::helpers::Pool& p) const;
+
+		using DateFormat::format;
+		void format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const override;
 
 	private:
 		log4cxx_time_t startTime;

--- a/src/main/include/log4cxx/helpers/simpledateformat.h
+++ b/src/main/include/log4cxx/helpers/simpledateformat.h
@@ -84,9 +84,8 @@ class LOG4CXX_EXPORT SimpleDateFormat : public DateFormat
 		SimpleDateFormat(const LogString& pattern, const std::locale* locale);
 		~SimpleDateFormat();
 
-		virtual void format(LogString& s,
-			log4cxx_time_t tm,
-			LOG4CXX_NS::helpers::Pool& p) const;
+		using DateFormat::format;
+		void format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const override;
 
 		/**
 		 * Set time zone.

--- a/src/main/include/log4cxx/helpers/simpledateformat.h
+++ b/src/main/include/log4cxx/helpers/simpledateformat.h
@@ -91,7 +91,7 @@ class LOG4CXX_EXPORT SimpleDateFormat : public DateFormat
 		 * Set time zone.
 		 * @param zone new time zone.
 		 */
-		void setTimeZone(const TimeZonePtr& zone);
+		void setTimeZone(const TimeZonePtr& zone) override;
 
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(SimpleDateFormatPrivate, m_priv)

--- a/src/main/include/log4cxx/helpers/strftimedateformat.h
+++ b/src/main/include/log4cxx/helpers/strftimedateformat.h
@@ -49,7 +49,7 @@ class LOG4CXX_EXPORT StrftimeDateFormat : public DateFormat
 		*    Set time zone.
 		* @param zone new time zone.
 		*/
-		void setTimeZone(const TimeZonePtr& zone);
+		void setTimeZone(const TimeZonePtr& zone) override;
 
 
 	private:

--- a/src/main/include/log4cxx/helpers/strftimedateformat.h
+++ b/src/main/include/log4cxx/helpers/strftimedateformat.h
@@ -42,9 +42,8 @@ class LOG4CXX_EXPORT StrftimeDateFormat : public DateFormat
 		StrftimeDateFormat(const LogString& pattern);
 		~StrftimeDateFormat();
 
-		virtual void format(LogString& s,
-			log4cxx_time_t tm,
-			LOG4CXX_NS::helpers::Pool& p) const;
+		using DateFormat::format;
+		void format( LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS ) const override;
 
 		/**
 		*    Set time zone.

--- a/src/main/include/log4cxx/pattern/classnamepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/classnamepatternconverter.h
@@ -57,9 +57,7 @@ class LOG4CXX_EXPORT ClassNamePatternConverter : public NamePatternConverter
 
 		using NamePatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/colorendpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/colorendpatternconverter.h
@@ -54,9 +54,7 @@ class LOG4CXX_EXPORT ColorEndPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/colorstartpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/colorstartpatternconverter.h
@@ -56,9 +56,7 @@ class LOG4CXX_EXPORT ColorStartPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 
 		void setFatalColor(const LogString& color);
 		void setErrorColor(const LogString& color);

--- a/src/main/include/log4cxx/pattern/datepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/datepatternconverter.h
@@ -75,28 +75,28 @@ class LOG4CXX_EXPORT DatePatternConverter : public LoggingEventPatternConverter
 		static PatternConverterPtr newInstance(
 			const std::vector<LogString>& options);
 
+		using LoggingEventPatternConverter::format;
 		/**
 		 * Append to \c output a textual version of the timestamp in \c event.
 		 */
-		void format(const spi::LoggingEventPtr& event,
-			LogString& output,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 
 		/**
 		 * Append to \c output a textual version of the date or timestamp in \c obj.
 		 *
 		 * Nothing is added to \c output if \c obj does not point to a Date or spi::LoggingEvent.
 		 */
-		void format(const helpers::ObjectPtr& obj,
-			LogString& output,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const override;
 
 		/**
 		 * Append to \c toAppendTo a textual version of \c date.
 		 */
+		void format(const helpers::DatePtr& date, LogString& toAppendTo) const;
+#if LOG4CXX_ABI_VERSION <= 15
 		void format(const helpers::DatePtr& date,
 			LogString& toAppendTo,
 			helpers::Pool& p) const;
+#endif
 };
 
 LOG4CXX_PTR_DEF(DatePatternConverter);

--- a/src/main/include/log4cxx/pattern/filelocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/filelocationpatternconverter.h
@@ -54,9 +54,7 @@ class LOG4CXX_EXPORT FileLocationPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/fulllocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/fulllocationpatternconverter.h
@@ -54,9 +54,7 @@ class LOG4CXX_EXPORT FullLocationPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/integerpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/integerpatternconverter.h
@@ -51,9 +51,8 @@ class LOG4CXX_EXPORT IntegerPatternConverter : public PatternConverter
 		static PatternConverterPtr newInstance(
 			const std::vector<LogString>& options);
 
-		void format(const helpers::ObjectPtr& obj,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		using PatternConverter::format;
+		void format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const override;
 };
 
 LOG4CXX_PTR_DEF(IntegerPatternConverter);

--- a/src/main/include/log4cxx/pattern/levelpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/levelpatternconverter.h
@@ -53,9 +53,7 @@ class LOG4CXX_EXPORT LevelPatternConverter : public LoggingEventPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 
 		LogString getStyleClass(const 	helpers::ObjectPtr& e) const override;
 };

--- a/src/main/include/log4cxx/pattern/linelocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/linelocationpatternconverter.h
@@ -54,9 +54,7 @@ class LOG4CXX_EXPORT LineLocationPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/lineseparatorpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/lineseparatorpatternconverter.h
@@ -54,13 +54,9 @@ class LOG4CXX_EXPORT LineSeparatorPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 
-		void format(const helpers::ObjectPtr& obj,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/literalpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/literalpatternconverter.h
@@ -49,13 +49,9 @@ class LOG4CXX_EXPORT LiteralPatternConverter : public LoggingEventPatternConvert
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 
-		void format(const helpers::ObjectPtr& obj,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/loggerpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/loggerpatternconverter.h
@@ -54,9 +54,7 @@ class LOG4CXX_EXPORT LoggerPatternConverter : public NamePatternConverter
 
 		using NamePatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/loggingeventpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/loggingeventpatternconverter.h
@@ -57,9 +57,8 @@ class LOG4CXX_EXPORT LoggingEventPatternConverter : public PatternConverter
 		using PatternConverter::format;
 		/**
 		 * Formats an event into a string buffer.
-		 * @param event event to format, may not be null.
+		 * @param event holds the attributes, may not be null.
 		 * @param toAppendTo string buffer to which the formatted event will be appended.  May not be null.
-		 * @param p pool for memory allocations needing during format.
 		 */
 #if LOG4CXX_ABI_VERSION <= 15
 		void format(const spi::LoggingEventPtr& event, LogString& toAppendTo) const;

--- a/src/main/include/log4cxx/pattern/loggingeventpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/loggingeventpatternconverter.h
@@ -54,20 +54,37 @@ class LOG4CXX_EXPORT LoggingEventPatternConverter : public PatternConverter
 		LOG4CXX_CAST_ENTRY_CHAIN(PatternConverter)
 		END_LOG4CXX_CAST_MAP()
 
+		using PatternConverter::format;
 		/**
 		 * Formats an event into a string buffer.
 		 * @param event event to format, may not be null.
 		 * @param toAppendTo string buffer to which the formatted event will be appended.  May not be null.
 		 * @param p pool for memory allocations needing during format.
 		 */
+#if LOG4CXX_ABI_VERSION <= 15
+		void format(const spi::LoggingEventPtr& event, LogString& toAppendTo) const;
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to format() without a helpers::Pool parameter.
+		*/
 		virtual void format(
 			const spi::LoggingEventPtr& event,
 			LogString& toAppendTo,
 			helpers::Pool& p) const = 0;
+#define LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS const spi::LoggingEventPtr& event, LogString& toAppendTo, helpers::Pool& p
+#define LOG4CXX_FORMAT_EVENT_PARAMETERS event, toAppendTo, p
+#else
+		virtual void format(const spi::LoggingEventPtr& event, LogString& toAppendTo) const = 0;
+#define LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS const spi::LoggingEventPtr& event, LogString& toAppendTo
+#define LOG4CXX_FORMAT_EVENT_PARAMETERS event, toAppendTo
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use format() without a Pool parameter instead")]]
+		void format(const spi::LoggingEventPtr& event, LogString& toAppendTo, helpers::Pool& p) const;
+#endif
 
-		void format(const helpers::ObjectPtr& obj,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS ) const override;
 
 		/**
 		 * Normally pattern converters are not meant to handle Exceptions although

--- a/src/main/include/log4cxx/pattern/mdcpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/mdcpatternconverter.h
@@ -52,11 +52,7 @@ class LOG4CXX_EXPORT MDCPatternConverter : public LoggingEventPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format
-			( const spi::LoggingEventPtr& event
-			, LogString&                  toAppendTo
-			, helpers::Pool&              p
-			) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 }
 }

--- a/src/main/include/log4cxx/pattern/messagepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/messagepatternconverter.h
@@ -53,9 +53,7 @@ class LOG4CXX_EXPORT MessagePatternConverter : public LoggingEventPatternConvert
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 }
 }

--- a/src/main/include/log4cxx/pattern/methodlocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/methodlocationpatternconverter.h
@@ -54,9 +54,7 @@ class LOG4CXX_EXPORT MethodLocationPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 }
 }

--- a/src/main/include/log4cxx/pattern/ndcpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/ndcpatternconverter.h
@@ -53,9 +53,7 @@ class LOG4CXX_EXPORT NDCPatternConverter : public LoggingEventPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 }
 }

--- a/src/main/include/log4cxx/pattern/patternconverter.h
+++ b/src/main/include/log4cxx/pattern/patternconverter.h
@@ -68,9 +68,8 @@ class LOG4CXX_EXPORT PatternConverter : public virtual helpers::Object
 
 		/**
 		 * Formats an object into a string buffer.
-		 * @param obj event to format, may not be null.
+		 * @param obj holds the attributes, may not be null.
 		 * @param toAppendTo string buffer to which the formatted event will be appended.  May not be null.
-		 * @param p pool for any allocations necessary during formatting.
 		 */
 #if LOG4CXX_ABI_VERSION <= 15
 		void format(const helpers::ObjectPtr& obj, LogString& toAppendTo) const;

--- a/src/main/include/log4cxx/pattern/patternconverter.h
+++ b/src/main/include/log4cxx/pattern/patternconverter.h
@@ -72,9 +72,25 @@ class LOG4CXX_EXPORT PatternConverter : public virtual helpers::Object
 		 * @param toAppendTo string buffer to which the formatted event will be appended.  May not be null.
 		 * @param p pool for any allocations necessary during formatting.
 		 */
+#if LOG4CXX_ABI_VERSION <= 15
+		void format(const helpers::ObjectPtr& obj, LogString& toAppendTo) const;
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to format() without a helpers::Pool parameter.
+		*/
 		virtual void format(const helpers::ObjectPtr& obj,
 			LogString& toAppendTo,
 			helpers::Pool& p) const = 0;
+#define LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS const helpers::ObjectPtr& obj, LogString& toAppendTo, helpers::Pool& p
+#else
+		virtual void format(const helpers::ObjectPtr& obj, LogString& toAppendTo) const = 0;
+#define LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS const helpers::ObjectPtr& obj, LogString& toAppendTo
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use format() without a Pool parameter instead")]]
+		virtual void format(const helpers::ObjectPtr& obj, LogString& toAppendTo, helpers::Pool& p) const;
+#endif
 
 		/**
 		 * This method returns the name of the conversion pattern.

--- a/src/main/include/log4cxx/pattern/propertiespatternconverter.h
+++ b/src/main/include/log4cxx/pattern/propertiespatternconverter.h
@@ -66,9 +66,7 @@ class LOG4CXX_EXPORT PropertiesPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			LOG4CXX_NS::helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 }
 }

--- a/src/main/include/log4cxx/pattern/relativetimepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/relativetimepatternconverter.h
@@ -57,9 +57,7 @@ class LOG4CXX_EXPORT RelativeTimePatternConverter : public LoggingEventPatternCo
 		using LoggingEventPatternConverter::format;
 
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			LOG4CXX_NS::helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 }
 }

--- a/src/main/include/log4cxx/pattern/shortfilelocationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/shortfilelocationpatternconverter.h
@@ -57,9 +57,7 @@ class LOG4CXX_EXPORT ShortFileLocationPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/threadpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/threadpatternconverter.h
@@ -53,9 +53,7 @@ class LOG4CXX_EXPORT ThreadPatternConverter : public LoggingEventPatternConverte
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 }
 }

--- a/src/main/include/log4cxx/pattern/threadusernamepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/threadusernamepatternconverter.h
@@ -44,7 +44,7 @@ class LOG4CXX_EXPORT ThreadUsernamePatternConverter : public LoggingEventPattern
 
 		using LoggingEventPatternConverter::format;
 
-	    void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/threadusernamepatternconverter.h
+++ b/src/main/include/log4cxx/pattern/threadusernamepatternconverter.h
@@ -42,9 +42,9 @@ class LOG4CXX_EXPORT ThreadUsernamePatternConverter : public LoggingEventPattern
 	    static PatternConverterPtr newInstance(
 	            const std::vector<LogString>& options);
 
-	    void format(const spi::LoggingEventPtr& event,
-	            LogString& toAppendTo,
-	            LOG4CXX_NS::helpers::Pool& p) const override;
+		using LoggingEventPatternConverter::format;
+
+	    void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 
 }

--- a/src/main/include/log4cxx/pattern/throwableinformationpatternconverter.h
+++ b/src/main/include/log4cxx/pattern/throwableinformationpatternconverter.h
@@ -59,9 +59,7 @@ class LOG4CXX_EXPORT ThrowableInformationPatternConverter
 
 		using LoggingEventPatternConverter::format;
 
-		void format(const spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 
 		/**
 		 * This converter obviously handles throwables.

--- a/src/site/doxy/Doxyfile.in
+++ b/src/site/doxy/Doxyfile.in
@@ -2354,6 +2354,11 @@ PREDEFINED             = LOG4CXX_NS=log4cxx \
                          LOG4CXX_ACTIVATE_OPTIONS_PARAMETER=p \
                          LOG4CXX_APPEND_FORMAL_PARAMETERS="const spi::LoggingEventPtr& event, helpers::Pool& p" \
                          LOG4CXX_APPEND_PARAMETERS="event, p" \
+                         LOG4CXX_FORMAT_OBJECT_FORMAL_PARAMETERS="const helpers::ObjectPtr& obj, LogString& toAppendTo, helpers::Pool& p" \
+                         LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS="LogString& toAppendTo, log4cxx_time_t tm, helpers::Pool& p" \
+                         LOG4CXX_FORMAT_NUMBER_FORMAL_PARAMETERS="LogString& toAppendTo, int n, helpers::Pool& p" \
+                         LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS="const spi::LoggingEventPtr& event, LogString& toAppendTo, helpers::Pool& p" \
+                         LOG4CXX_FORMAT_EVENT_PARAMETERS="event, toAppendTo, p" \
                          LOG4CXX_HAS_DOMCONFIGURATOR=1 \
                          LOG4CXX_ASYNC_BUFFER_SUPPORTS_FMT=1 \
                          __LOG4CXX_FUNC__=compiler_dependent

--- a/src/test/cpp/helpers/absolutetimedateformattestcase.cpp
+++ b/src/test/cpp/helpers/absolutetimedateformattestcase.cpp
@@ -68,8 +68,7 @@ private:
 		AbsoluteTimeDateFormat formatter;
 		formatter.setTimeZone(timeZone);
 		LogString actual;
-		Pool p;
-		formatter.format(actual, date, p);
+		formatter.format(actual, date);
 		LOGUNIT_ASSERT_EQUAL(expected, actual);
 	}
 
@@ -176,10 +175,9 @@ public:
 	 */
 	void test8()
 	{
-		Pool p;
 		LogString numb;
 		AbsoluteTimeDateFormat formatter;
-		formatter.numberFormat(numb, 87, p);
+		formatter.numberFormat(numb, 87);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("87"), numb);
 	}
 

--- a/src/test/cpp/helpers/cacheddateformattestcase.cpp
+++ b/src/test/cpp/helpers/cacheddateformattestcase.cpp
@@ -97,27 +97,26 @@ public:
 		gmtFormat.setTimeZone(TimeZone::getGMT());
 
 		apr_time_t jul1 = MICROSECONDS_PER_DAY * 12601L;
-		Pool p;
 
 		LogString actual;
 
-		gmtFormat.format(actual, jul1, p);
+		gmtFormat.format(actual, jul1);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,000"), actual);
 		actual.erase(actual.begin(), actual.end());
 
-		gmtFormat.format(actual, jul1 + 8000, p);
+		gmtFormat.format(actual, jul1 + 8000);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,008"), actual);
 		actual.erase(actual.begin(), actual.end());
 
-		gmtFormat.format(actual, jul1 + 17000, p);
+		gmtFormat.format(actual, jul1 + 17000);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,017"), actual);
 		actual.erase(actual.begin(), actual.end());
 
-		gmtFormat.format(actual, jul1 + 237000, p);
+		gmtFormat.format(actual, jul1 + 237000);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,237"), actual);
 		actual.erase(actual.begin(), actual.end());
 
-		gmtFormat.format(actual, jul1 + 1415000, p);
+		gmtFormat.format(actual, jul1 + 1415000);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:01,415"), actual);
 		actual.erase(actual.begin(), actual.end());
 
@@ -138,17 +137,16 @@ public:
 		CachedDateFormat chicagoFormat(chicagoBase, 1000000);
 		chicagoFormat.setTimeZone(TimeZone::getTimeZone(LOG4CXX_STR("GMT-5")));
 
-		Pool p;
 		LogString actual;
-		gmtFormat.format(actual, jul2, p);
+		gmtFormat.format(actual, jul2);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,000"), actual);
 
 		actual.erase(actual.begin(), actual.end());
-		chicagoFormat.format(actual, jul2, p);
+		chicagoFormat.format(actual, jul2);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("19:00:00,000"), actual);
 
 		actual.erase(actual.begin(), actual.end());
-		gmtFormat.format(actual, jul2, p);
+		gmtFormat.format(actual, jul2);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,000"), actual);
 	}
 
@@ -166,45 +164,40 @@ public:
 
 		apr_time_t ticks = MICROSECONDS_PER_DAY * -7;
 
-		Pool p;
-
 		LogString actual;
-
-
-		gmtFormat.format(actual, ticks, p);
+		gmtFormat.format(actual, ticks);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,000"), actual);
 		actual.erase(actual.begin(), actual.end());
 
 		//
 		//   APR's explode_time method does not properly calculate tm_usec
 		//     prior to 1 Jan 1970 on Unix
-		gmtFormat.format(actual, ticks + 8000, p);
+		gmtFormat.format(actual, ticks + 8000);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,008"), actual);
 		actual.erase(actual.begin(), actual.end());
 
-		gmtFormat.format(actual, ticks + 17000, p);
+		gmtFormat.format(actual, ticks + 17000);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,017"), actual);
 		actual.erase(actual.begin(), actual.end());
 
-		gmtFormat.format(actual, ticks + 237000, p);
+		gmtFormat.format(actual, ticks + 237000);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,237"), actual);
 		actual.erase(actual.begin(), actual.end());
 
-		gmtFormat.format(actual, ticks + 1423000, p);
+		gmtFormat.format(actual, ticks + 1423000);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:01,423"), actual);
 	}
 
 	void assertFormattedEquals(
 		const DateFormatPtr & baseFormat,
 		const CachedDateFormat & cachedFormat,
-		apr_time_t date,
-		Pool & p)
+		apr_time_t date)
 	{
 		LogString expected;
 		LogString actual;
 
-		baseFormat->format(expected, date, p);
-		cachedFormat.format(actual, date, p);
+		baseFormat->format(expected, date);
+		cachedFormat.format(actual, date);
 
 
 		LOGUNIT_ASSERT_EQUAL(expected, actual);
@@ -228,13 +221,11 @@ public:
 		//   use a date in 2000 to attempt to confuse the millisecond locator
 		apr_time_t ticks = MICROSECONDS_PER_DAY * 11141;
 
-		Pool p;
-
-		assertFormattedEquals(baseFormat, cachedFormat, ticks, p);
-		assertFormattedEquals(baseFormat, cachedFormat, ticks + 8000, p);
-		assertFormattedEquals(baseFormat, cachedFormat, ticks + 17000, p);
-		assertFormattedEquals(baseFormat, cachedFormat, ticks + 237000, p);
-		assertFormattedEquals(baseFormat, cachedFormat, ticks + 1415000, p);
+		assertFormattedEquals(baseFormat, cachedFormat, ticks);
+		assertFormattedEquals(baseFormat, cachedFormat, ticks + 8000);
+		assertFormattedEquals(baseFormat, cachedFormat, ticks + 17000);
+		assertFormattedEquals(baseFormat, cachedFormat, ticks + 237000);
+		assertFormattedEquals(baseFormat, cachedFormat, ticks + 1415000);
 	}
 
 
@@ -257,11 +248,11 @@ public:
 
 			Pool p;
 
-			assertFormattedEquals(baseFormat, cachedFormat, ticks, p);
-			assertFormattedEquals(baseFormat, cachedFormat, ticks + 8000, p);
-			assertFormattedEquals(baseFormat, cachedFormat, ticks + 17000, p);
-			assertFormattedEquals(baseFormat, cachedFormat, ticks + 237000, p);
-			assertFormattedEquals(baseFormat, cachedFormat, ticks + 1415000, p);
+			assertFormattedEquals(baseFormat, cachedFormat, ticks);
+			assertFormattedEquals(baseFormat, cachedFormat, ticks + 8000);
+			assertFormattedEquals(baseFormat, cachedFormat, ticks + 17000);
+			assertFormattedEquals(baseFormat, cachedFormat, ticks + 237000);
+			assertFormattedEquals(baseFormat, cachedFormat, ticks + 1415000);
 		}
 	}
 #endif
@@ -272,9 +263,8 @@ public:
 	void test6()
 	{
 		LogString numb;
-		Pool p;
 		AbsoluteTimeDateFormat formatter;
-		formatter.numberFormat(numb, 87, p);
+		formatter.numberFormat(numb, 87);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("87"), numb);
 	}
 
@@ -289,15 +279,13 @@ public:
 		CachedDateFormat cachedFormat(baseFormat, 1000000);
 		apr_time_t jul4 = MICROSECONDS_PER_DAY * 12603;
 
-		Pool p;
-
 		LogString actual;
-		cachedFormat.format(actual, jul4, p);
+		cachedFormat.format(actual, jul4);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("2004-07-04 00:00:00,000"), actual);
 
 		cachedFormat.setTimeZone(TimeZone::getTimeZone(LOG4CXX_STR("GMT-6")));
 		actual.erase(actual.begin(), actual.end());
-		cachedFormat.format(actual, jul4, p);
+		cachedFormat.format(actual, jul4);
 
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("2004-07-03 18:00:00,000"), actual);
 	}
@@ -331,10 +319,8 @@ public:
 		const apr_status_t statOK = 0;
 		LOGUNIT_ASSERT_EQUAL(statOK, stat);
 
-		Pool p;
-
 		LogString s;
-		cachedFormat->format(s, dec12, p);
+		cachedFormat->format(s, dec12);
 
 		LOGUNIT_ASSERT_EQUAL(
 			(LogString) LOG4CXX_STR("2004-December-12 20:00:37,23 +0100"), s);
@@ -352,7 +338,7 @@ public:
 		LOGUNIT_ASSERT_EQUAL(statOK, stat);
 
 		s.erase(s.begin(), s.end());
-		cachedFormat->format(s, jan1, p);
+		cachedFormat->format(s, jan1);
 
 		LOGUNIT_ASSERT_EQUAL(
 			(LogString) LOG4CXX_STR("2005-January-01 00:00:13,905 +0100"), s);
@@ -390,10 +376,8 @@ public:
 		const apr_status_t statOK = 0;
 		LOGUNIT_ASSERT_EQUAL(statOK, stat);
 
-		Pool p;
-
 		LogString s;
-		cachedFormat->format(s, oct5, p);
+		cachedFormat->format(s, oct5);
 
 		LOGUNIT_ASSERT_EQUAL(
 			(LogString) LOG4CXX_STR("October 023 Tuesday"), s);
@@ -409,14 +393,14 @@ public:
 		LOGUNIT_ASSERT_EQUAL(statOK, stat);
 
 		s.erase(s.begin(), s.end());
-		cachedFormat->format(s, nov1, p);
+		cachedFormat->format(s, nov1);
 
 		LOGUNIT_ASSERT_EQUAL(
 			(LogString) LOG4CXX_STR("November 023 Monday"), s);
 
 		nov1 += 961000;
 		s.erase(s.begin(), s.end());
-		cachedFormat->format(s, nov1, p);
+		cachedFormat->format(s, nov1);
 
 		LOGUNIT_ASSERT_EQUAL(
 			(LogString) LOG4CXX_STR("November 984 Monday"), s);
@@ -442,10 +426,8 @@ public:
 		apr_time_t ticks = MICROSECONDS_PER_DAY * 11142L;
 		apr_time_t jul2 = ticks + 120000;
 
-		Pool p;
-
 		LogString s;
-		gmtFormat->format(s, jul2, p);
+		gmtFormat->format(s, jul2);
 
 		LOGUNIT_ASSERT_EQUAL(
 			(LogString) LOG4CXX_STR("00,1200"), s);
@@ -453,7 +435,7 @@ public:
 		jul2 = ticks + 87000;
 
 		s.erase(s.begin(), s.end());
-		gmtFormat->format(s, jul2, p);
+		gmtFormat->format(s, jul2);
 
 		LOGUNIT_ASSERT_EQUAL(
 			(LogString) LOG4CXX_STR("00,870"), s);
@@ -466,11 +448,10 @@ public:
 	{
 		DateFormatPtr df    = DateFormatPtr(new SimpleDateFormat(LOG4CXX_STR("yyyy-MM-dd HH:mm:ss,SSS")));
 		apr_time_t    ticks = 11142L * MICROSECONDS_PER_DAY;
-		Pool p;
 		LogString formatted;
 
-		df->format(formatted, ticks, p);
-		int msStart = CachedDateFormat::findMillisecondStart(ticks, formatted, df, p);
+		df->format(formatted, ticks);
+		int msStart = CachedDateFormat::findMillisecondStart(ticks, formatted, df);
 		LOGUNIT_ASSERT_EQUAL(20, msStart);
 
 		// Test for for milliseconds overlapping with the magic ones as per LOGCXX-420.
@@ -487,16 +468,16 @@ public:
 		LOGUNIT_ASSERT_EQUAL(0, apr_time_exp_gmt_get(&ticks, &c));
 
 		formatted.clear();
-		df->format(formatted, ticks, p);
-		msStart = CachedDateFormat::findMillisecondStart(ticks, formatted, df, p);
+		df->format(formatted, ticks);
+		msStart = CachedDateFormat::findMillisecondStart(ticks, formatted, df);
 		LOGUNIT_ASSERT_EQUAL(20, msStart);
 
 		c.tm_usec = 609000;
 		LOGUNIT_ASSERT_EQUAL(0, apr_time_exp_gmt_get(&ticks, &c));
 
 		formatted.clear();
-		df->format(formatted, ticks, p);
-		msStart = CachedDateFormat::findMillisecondStart(ticks, formatted, df, p);
+		df->format(formatted, ticks);
+		msStart = CachedDateFormat::findMillisecondStart(ticks, formatted, df);
 		LOGUNIT_ASSERT_EQUAL(20, msStart);
 	}
 
@@ -508,13 +489,11 @@ public:
 		DateFormatPtr df = DateFormatPtr(new SimpleDateFormat(LOG4CXX_STR("yyyy-MM-dd")));
 		apr_time_t ticks = 11142L * MICROSECONDS_PER_DAY;
 
-		Pool p;
-
 		LogString formatted;
-		df->format(formatted, ticks, p);
+		df->format(formatted, ticks);
 
 		int millisecondStart = CachedDateFormat::findMillisecondStart(ticks,
-				formatted, df, p);
+				formatted, df);
 		LOGUNIT_ASSERT_EQUAL((int) CachedDateFormat::NO_MILLISECONDS, millisecondStart);
 	}
 
@@ -526,12 +505,11 @@ public:
 		DateFormatPtr df = DateFormatPtr(new SimpleDateFormat(LOG4CXX_STR("HH:mm:ss,SSS")));
 		apr_time_t ticks = 11142L * MICROSECONDS_PER_DAY;
 
-		Pool p;
 		LogString formatted;
-		df->format(formatted, ticks, p);
+		df->format(formatted, ticks);
 
 		int millisecondStart = CachedDateFormat::findMillisecondStart(ticks,
-				formatted, df, p);
+				formatted, df);
 		LOGUNIT_ASSERT_EQUAL(9, millisecondStart);
 	}
 
@@ -543,12 +521,11 @@ public:
 		DateFormatPtr df = DateFormatPtr(new SimpleDateFormat(LOG4CXX_STR("HH:mm:ss,S")));
 		apr_time_t ticks = 11142L * MICROSECONDS_PER_DAY;
 
-		Pool p;
 		LogString formatted;
-		df->format(formatted, ticks, p);
+		df->format(formatted, ticks);
 
 		int millisecondStart = CachedDateFormat::findMillisecondStart(ticks,
-				formatted, df, p);
+				formatted, df);
 		LOGUNIT_ASSERT_EQUAL((int) CachedDateFormat::UNRECOGNIZED_MILLISECONDS, millisecondStart);
 	}
 
@@ -560,12 +537,11 @@ public:
 		DateFormatPtr df = DateFormatPtr(new SimpleDateFormat(LOG4CXX_STR("HH:mm:ss,SS")));
 		apr_time_t ticks = 11142L * MICROSECONDS_PER_DAY;
 
-		Pool p;
 		LogString formatted;
-		df->format(formatted, ticks, p);
+		df->format(formatted, ticks);
 
 		int millisecondStart =
-			CachedDateFormat::findMillisecondStart(ticks, formatted, df, p);
+			CachedDateFormat::findMillisecondStart(ticks, formatted, df);
 		LOGUNIT_ASSERT_EQUAL((int) CachedDateFormat::UNRECOGNIZED_MILLISECONDS, millisecondStart);
 	}
 
@@ -580,22 +556,21 @@ public:
 		simpleFormat->setTimeZone(TimeZone::getGMT());
 		DateFormatPtr cachedFormat = DateFormatPtr(new CachedDateFormat(simpleFormat, 1000000));
 
-		Pool p;
 		LogString s;
-		cachedFormat->format(s, jul2, p);
+		cachedFormat->format(s, jul2);
 
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,000 00:00:00,000"), s);
 		jul2 += 120000;
 
 		s.erase(s.begin(), s.end());
-		simpleFormat->format(s, jul2, p);
+		simpleFormat->format(s, jul2);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,120 00:00:00,120"), s);
 
 		s.erase(s.begin(), s.end());
-		int msStart = CachedDateFormat::findMillisecondStart(jul2, s, simpleFormat, p);
+		int msStart = CachedDateFormat::findMillisecondStart(jul2, s, simpleFormat);
 		LOGUNIT_ASSERT_EQUAL((int) CachedDateFormat::UNRECOGNIZED_MILLISECONDS, msStart);
 
-		cachedFormat->format(s, jul2, p);
+		cachedFormat->format(s, jul2);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("00:00:00,120 00:00:00,120"), s) ;
 
 		int maxValid = CachedDateFormat::getMaximumCacheValidity(badPattern);
@@ -604,14 +579,14 @@ public:
 		// Test overlapping millis with a magic string from CachedDateFormat for LOGCXX-420.
 		s.clear();
 		jul2 += 286000;
-		cachedFormat->format(s, jul2, p);
-		msStart = CachedDateFormat::findMillisecondStart(jul2, s, simpleFormat, p);
+		cachedFormat->format(s, jul2);
+		msStart = CachedDateFormat::findMillisecondStart(jul2, s, simpleFormat);
 		LOGUNIT_ASSERT_EQUAL((int) CachedDateFormat::UNRECOGNIZED_MILLISECONDS, msStart);
 
 		s.clear();
 		jul2 += 203000;
-		cachedFormat->format(s, jul2, p);
-		msStart = CachedDateFormat::findMillisecondStart(jul2, s, simpleFormat, p);
+		cachedFormat->format(s, jul2);
+		msStart = CachedDateFormat::findMillisecondStart(jul2, s, simpleFormat);
 		LOGUNIT_ASSERT_EQUAL((int) CachedDateFormat::UNRECOGNIZED_MILLISECONDS, msStart);
 	}
 
@@ -677,22 +652,21 @@ public:
 		CachedDateFormat isoFormat(baseFormatter, 1000000);
 		isoFormat.setTimeZone(TimeZone::getGMT());
 
-		Pool p;
 		LogString formatted;
 
-		isoFormat.format(formatted, 654000, p);
+		isoFormat.format(formatted, 654000);
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("1970-01-01 00:00:00,654"), formatted);
 
 		formatted.clear();
-		isoFormat.format(formatted, 999000, p);
+		isoFormat.format(formatted, 999000);
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("1970-01-01 00:00:00,999"), formatted);
 
 		formatted.clear();
-		isoFormat.format(formatted, 1654010, p);
+		isoFormat.format(formatted, 1654010);
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("1970-01-01 00:00:01,654"), formatted);
 
 		formatted.clear();
-		isoFormat.format(formatted, 1999010, p);
+		isoFormat.format(formatted, 1999010);
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("1970-01-01 00:00:01,999"), formatted);
 	}
 

--- a/src/test/cpp/helpers/datetimedateformattestcase.cpp
+++ b/src/test/cpp/helpers/datetimedateformattestcase.cpp
@@ -92,8 +92,7 @@ private:
 		DateTimeDateFormat formatter(locale);
 		formatter.setTimeZone(timeZone);
 		LogString actual;
-		Pool p;
-		formatter.format(actual, date, p);
+		formatter.format(actual, date);
 		LOGUNIT_ASSERT_EQUAL( expected, actual );
 	}
 public:
@@ -205,9 +204,8 @@ public:
 		if (localeChange.isEffective())
 		{
 			LogString formatted;
-			Pool p;
 			SimpleDateFormat formatter(LOG4CXX_STR("MMM"));
-			formatter.format(formatted, avr11, p);
+			formatter.format(formatted, avr11);
 
 			std::locale localeFR(LOCALE_FR);
 			struct tm avr11tm = { 0, 0, 0, 11, 03, 104 };
@@ -226,10 +224,9 @@ public:
 		if (localeChange.isEffective())
 		{
 			LogString formatted;
-			Pool p;
 			SimpleDateFormat formatter(LOG4CXX_STR("MMM"));
 			formatter.setTimeZone(TimeZone::getGMT());
-			formatter.format(formatted, apr11, p);
+			formatter.format(formatted, apr11);
 
 			std::locale localeUS(LOCALE_US);
 			struct tm apr11tm = { 0, 0, 0, 11, 03, 104 };

--- a/src/test/cpp/helpers/iso8601dateformattestcase.cpp
+++ b/src/test/cpp/helpers/iso8601dateformattestcase.cpp
@@ -62,8 +62,7 @@ LOGUNIT_CLASS(ISO8601DateFormatTestCase)
 		ISO8601DateFormat formatter;
 		formatter.setTimeZone(timeZone);
 		LogString actual;
-		Pool p;
-		formatter.format(actual, date, p);
+		formatter.format(actual, date);
 		LOGUNIT_ASSERT_EQUAL(expected, actual);
 	}
 
@@ -157,8 +156,7 @@ public:
 	{
 		LogString number;
 		ISO8601DateFormat formatter;
-		Pool p;
-		formatter.numberFormat(number, 87, p);
+		formatter.numberFormat(number, 87);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("87"), number);
 	}
 

--- a/src/test/cpp/helpers/relativetimedateformattestcase.cpp
+++ b/src/test/cpp/helpers/relativetimedateformattestcase.cpp
@@ -56,11 +56,9 @@ public:
 
 		RelativeTimeDateFormat formatter;
 
-		Pool p;
-
 		LogString actual;
 
-		formatter.format(actual, jan2, p);
+		formatter.format(actual, jan2);
 
 		log4cxx_time_t elapsed = log4cxx::helpers::StringHelper::toInt64(actual);
 
@@ -76,9 +74,8 @@ public:
 	void test2()
 	{
 		LogString numb;
-		Pool p;
 		RelativeTimeDateFormat formatter;
-		formatter.numberFormat(numb, 87, p);
+		formatter.numberFormat(numb, 87);
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("87"), numb);
 	}
 

--- a/src/test/cpp/jsonlayouttest.cpp
+++ b/src/test/cpp/jsonlayouttest.cpp
@@ -375,7 +375,7 @@ public:
 
 		LogString timestamp;
 		helpers::ISO8601DateFormat dateFormat;
-		dateFormat.format(timestamp, event1->getTimeStamp(), p);
+		dateFormat.format(timestamp, event1->getTimeStamp());
 
 		NDC::push("one");
 		NDC::push("two");
@@ -423,7 +423,7 @@ public:
 
 		LogString timestamp;
 		helpers::ISO8601DateFormat dateFormat;
-		dateFormat.format(timestamp, event1->getTimeStamp(), p);
+		dateFormat.format(timestamp, event1->getTimeStamp());
 
 		NDC::push("one");
 		NDC::push("two");

--- a/src/test/cpp/pattern/colorstartpatternconvertertest.cpp
+++ b/src/test/cpp/pattern/colorstartpatternconvertertest.cpp
@@ -69,16 +69,15 @@ public:
 	{
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("fg(red)"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("\x1b[;31m"), outputString);
 	}
@@ -87,16 +86,15 @@ public:
 	{
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("bg(red)"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("\x1b[;41m"), outputString);
 	}
@@ -105,16 +103,15 @@ public:
 	{
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("fg(green)|bg(red)"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("\x1b[;32;41m"), outputString);
 	}
@@ -122,16 +119,15 @@ public:
 	void testParseUnbalancedParens1(){
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("fg(green))"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("\x1b[m"), outputString);
 	}
@@ -139,16 +135,15 @@ public:
 	void testParseUnbalancedParens2(){
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("fg(green"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("\x1b[m"), outputString);
 	}
@@ -156,16 +151,15 @@ public:
 	void testParseUnbalancedParens3(){
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("fg(green|bg(red)"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		// The background should be parsed correctly, but since the foreground
 		// is bad it will not work
@@ -175,16 +169,15 @@ public:
 	void testANSICode(){
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("\\x1b[34;40m"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("\x1b[34;40m"), outputString);
 	}
@@ -192,16 +185,15 @@ public:
 	void testInvalidANSICode(){
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("\\x1b"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR(""), outputString);
 	}
@@ -209,16 +201,15 @@ public:
 	void testUnterminatedANSICode(){
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("\\x1b[31"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR(""), outputString);
 	}
@@ -226,16 +217,15 @@ public:
 	void testForegroundBackgroundBlink(){
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("fg(white)|bg(black)|blinking"));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("\x1b[;37;40;5m"), outputString);
 	}
@@ -243,17 +233,16 @@ public:
 	void testClearColor(){
 		ColorStartPatternConverter colorPatternConverter;
 		LogString outputString;
-		Pool p;
-
-		LoggingEventPtr event= LoggingEventPtr(new LoggingEvent(
-												   LOG4CXX_STR("org.foobar"),
-												   Level::getInfo(),
-												   LOG4CXX_STR("msg 1"),
-												   LOG4CXX_LOCATION));
+		auto event = std::make_shared<LoggingEvent>
+			( LOG4CXX_STR("org.foobar")
+			, Level::getInfo()
+			, LOG4CXX_STR("msg 1")
+			, LOG4CXX_LOCATION
+			);
 
 		colorPatternConverter.setInfoColor(LOG4CXX_STR("fg(white)|bg(black)|blinking"));
 		colorPatternConverter.setInfoColor(LOG4CXX_STR(""));
-		colorPatternConverter.format(event, outputString, p);
+		colorPatternConverter.format(event, outputString);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR(""), outputString);
 	}

--- a/src/test/cpp/pattern/num343patternconverter.cpp
+++ b/src/test/cpp/pattern/num343patternconverter.cpp
@@ -37,11 +37,8 @@ PatternConverterPtr Num343PatternConverter::newInstance(
 }
 
 
-void Num343PatternConverter::format(
-	const spi::LoggingEventPtr&,
-	LogString& sbuf,
-	Pool&) const
+void Num343PatternConverter::format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const
 {
-	sbuf.append(LOG4CXX_STR("343"));
+	toAppendTo.append(LOG4CXX_STR("343"));
 }
 

--- a/src/test/cpp/pattern/num343patternconverter.h
+++ b/src/test/cpp/pattern/num343patternconverter.h
@@ -32,10 +32,9 @@ class Num343PatternConverter : public LoggingEventPatternConverter
 			const std::vector<LogString>& options);
 
 	protected:
-		void format(
-			const log4cxx::spi::LoggingEventPtr& event,
-			LogString& toAppendTo,
-			log4cxx::helpers::Pool& pool) const override;
+		using LoggingEventPatternConverter::format;
+
+		void format( LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS ) const override;
 };
 }
 }

--- a/src/test/cpp/pattern/patternparsertestcase.cpp
+++ b/src/test/cpp/pattern/patternparsertestcase.cpp
@@ -230,10 +230,9 @@ public:
 
 	void testBasic2()
 	{
-		Pool pool;
 		RelativeTimeDateFormat relativeFormat;
 		LogString expected;
-		relativeFormat.format(expected, event->getTimeStamp(), pool);
+		relativeFormat.format(expected, event->getTimeStamp());
 
 		expected.append(LOG4CXX_STR(" INFO  ["));
 		expected.append(event->getThreadName());
@@ -247,15 +246,13 @@ public:
 
 	void testMultiOption()
 	{
-		Pool pool;
-
 		SimpleDateFormat dateFormat(LOG4CXX_STR("HH:mm:ss"));
 		LogString localTime;
-		dateFormat.format(localTime, event->getTimeStamp(), pool);
+		dateFormat.format(localTime, event->getTimeStamp());
 
 		dateFormat.setTimeZone(TimeZone::getGMT());
 		LogString utcTime;
-		dateFormat.format(utcTime, event->getTimeStamp(), pool);
+		dateFormat.format(utcTime, event->getTimeStamp());
 
 		LogString expected(utcTime);
 		expected.append(1, LOG4CXX_STR(' '));
@@ -277,10 +274,9 @@ public:
 
 	void testThreadUsername()
 	{
-		Pool pool;
 		RelativeTimeDateFormat relativeFormat;
 		LogString expected;
-		relativeFormat.format(expected, event->getTimeStamp(), pool);
+		relativeFormat.format(expected, event->getTimeStamp());
 
 		expected.append(LOG4CXX_STR(" INFO  ["));
 		expected.append(event->getThreadUserName());

--- a/src/test/cpp/pattern/patternparsertestcase.cpp
+++ b/src/test/cpp/pattern/patternparsertestcase.cpp
@@ -171,13 +171,12 @@ public:
 		const LogString & expected)
 	{
 		auto converters = PatternParser::parse(pattern, patternMap);
-		Pool p;
 		LogString actual;
 
 		for (auto item : converters)
 		{
 			auto fieldStart = static_cast<int>(actual.length());
-			item->format(event, actual, p);
+			item->format(event, actual);
 			item->getFormattingInfo().format(fieldStart, actual);
 		}
 

--- a/src/test/cpp/rolling/filenamepatterntestcase.cpp
+++ b/src/test/cpp/rolling/filenamepatterntestcase.cpp
@@ -71,12 +71,11 @@ public:
 		rules.insert(PatternMap::value_type(LOG4CXX_STR("i"), (PatternConstructor) IntegerPatternConverter::newInstance));
 		auto converters = PatternParser::parse(pattern, rules);
 		LogString result;
-		Pool pool;
 
 		for (auto item :  converters)
 		{
 			LogString::size_type i = result.length();
-			item->format(obj, result, pool);
+			item->format(obj, result);
 			item->getFormattingInfo().format((int)i, result);
 		}
 

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -137,8 +137,7 @@ public:
 
 		// Count rolled files
 		LOG4CXX_DECODE_CHAR(expectedPrefixLS, expectedPrefix);
-		helpers::Pool p;
-		helpers::StrftimeDateFormat(LOG4CXX_STR("%Y-%m-%d")).format(expectedPrefixLS, helpers::Date::currentTime(), p);
+		helpers::StrftimeDateFormat(LOG4CXX_STR("%Y-%m-%d")).format(expectedPrefixLS, helpers::Date::currentTime());
 		LOG4CXX_ENCODE_CHAR(rolledPrefix, expectedPrefixLS);
 		int fileCount = 0;
 		for (auto const& dir_entry : std::filesystem::directory_iterator{"output/rolling"})

--- a/src/test/cpp/rolling/timebasedrollingtest.cpp
+++ b/src/test/cpp/rolling/timebasedrollingtest.cpp
@@ -134,7 +134,7 @@ private:
 		for (size_t i = 0; i < N; ++i)
 		{
 			fnames[i].assign(LogString(LOG4CXX_STR("" DIR_PRE_OUTPUT)) + prefix);
-			sdf.format(fnames[i], now, pool);
+			sdf.format(fnames[i], now);
 			fnames[i].append(ext);
 
 			now += APR_USEC_PER_SEC;


### PR DESCRIPTION
This PR adds methods to the DateFormat, PatternConverter and LoggingEventPatternConverter interfaces without a helpers::Pool parameter.

The objective is to avoid breaking client code that calls the methods with a helpers::Pool parameter.

Users who have extended Log4cxx with their own converter subclass will need to modify code when using the new ABI.