### PR TITLE
Simplify the Layout interface in a future ABI version

### DIFF
--- a/src/main/cpp/fmtlayout.cpp
+++ b/src/main/cpp/fmtlayout.cpp
@@ -84,9 +84,7 @@ void FMTLayout::activateOptions( LOG4CXX_ACTIVATE_OPTIONS_FORMAL_PARAMETERS )
 	m_priv->expectedPatternLength = getFormattedEventCharacterCount() * 2;
 }
 
-void FMTLayout::format(LogString& output,
-	const spi::LoggingEventPtr& event,
-	LOG4CXX_NS::helpers::Pool&) const
+void FMTLayout::format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const
 {
 	auto& lsMsg = event->getRenderedMessage();
 	output.reserve(m_priv->expectedPatternLength + lsMsg.size());

--- a/src/main/cpp/htmllayout.cpp
+++ b/src/main/cpp/htmllayout.cpp
@@ -80,9 +80,7 @@ void HTMLLayout::setOption(const LogString& option,
 	}
 }
 
-void HTMLLayout::format(LogString& output,
-	const spi::LoggingEventPtr& event,
-	Pool& p) const
+void HTMLLayout::format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const
 {
 	auto& lsMsg = event->getRenderedMessage();
 	output.reserve(m_priv->expectedPatternLength + lsMsg.size());
@@ -173,7 +171,7 @@ void HTMLLayout::format(LogString& output,
 	}
 }
 
-void HTMLLayout::appendHeader(LogString& output, Pool& p)
+void HTMLLayout::appendHeader( LOG4CXX_APPEND_HEADER_FORMAL_PARAMETERS )
 {
 	output.append(LOG4CXX_STR("<!DOCTYPE HTML PUBLIC "));
 	output.append(LOG4CXX_STR("\"-//W3C//DTD HTML 4.01 Transitional//EN\" "));
@@ -238,7 +236,7 @@ void HTMLLayout::appendHeader(LogString& output, Pool& p)
 	output.append(LOG4CXX_EOL);
 }
 
-void HTMLLayout::appendFooter(LogString& output, Pool& /* pool */ )
+void HTMLLayout::appendFooter( LOG4CXX_APPEND_FOOTER_FORMAL_PARAMETERS  )
 {
 	output.append(LOG4CXX_STR("</table>"));
 	output.append(LOG4CXX_EOL);

--- a/src/main/cpp/jsonlayout.cpp
+++ b/src/main/cpp/jsonlayout.cpp
@@ -128,9 +128,7 @@ void JSONLayout::setOption(const LogString& option, const LogString& value)
 	}
 }
 
-void JSONLayout::format(LogString& output,
-	const spi::LoggingEventPtr& event,
-	Pool& p) const
+void JSONLayout::format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const
 {
 	auto& lsMsg = event->getRenderedMessage();
 	output.reserve(m_priv->expectedPatternLength + lsMsg.size());
@@ -197,7 +195,7 @@ void JSONLayout::format(LogString& output,
 	{
 		output.append(LOG4CXX_STR(","));
 		output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
-		appendSerializedLocationInfo(output, event, p);
+		appendSerializedLocationInfo(output, event);
 	}
 
 	output.append(m_priv->prettyPrint ? LOG4CXX_EOL : LOG4CXX_STR(" "));
@@ -392,8 +390,7 @@ void JSONLayout::appendSerializedNDC(LogString& buf,
 	buf.append(LOG4CXX_STR("]"));
 }
 
-void JSONLayout::appendSerializedLocationInfo(LogString& buf,
-	const LoggingEventPtr& event, Pool& p) const
+void JSONLayout::appendSerializedLocationInfo(LogString& buf, const LoggingEventPtr& event) const
 {
 	if (m_priv->prettyPrint)
 	{
@@ -461,3 +458,10 @@ void JSONLayout::appendSerializedLocationInfo(LogString& buf,
 	buf.append(LOG4CXX_STR("}"));
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
+void JSONLayout::appendSerializedLocationInfo(LogString& buf,
+	const LoggingEventPtr& event, Pool& p) const
+{
+	appendSerializedLocationInfo(buf, event);
+}
+#endif

--- a/src/main/cpp/layout.cpp
+++ b/src/main/cpp/layout.cpp
@@ -30,9 +30,50 @@ LogString Layout::getContentType() const
 	return LOG4CXX_STR("text/plain");
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
+void Layout::format(LogString& output, const spi::LoggingEventPtr& event) const
+{
+	Pool p;
+	format(output, event, p);
+}
+
 void Layout::appendHeader(LogString&, LOG4CXX_NS::helpers::Pool&) {}
 
+void Layout::appendHeader(LogString& output)
+{
+	Pool p;
+	appendHeader(output, p);
+}
+
 void Layout::appendFooter(LogString&, LOG4CXX_NS::helpers::Pool&) {}
+
+void Layout::appendFooter(LogString& output)
+{
+	Pool p;
+	appendFooter(output, p);
+}
+#else
+void Layout::format(LogString& output, const spi::LoggingEventPtr& event, helpers::Pool&) const
+{
+	format(output, event);
+}
+
+void Layout::appendHeader(LogString& output, helpers::Pool&)
+{
+	appendHeader(output);
+}
+void Layout::appendHeader(LogString& output)
+{
+}
+
+void Layout::appendFooter(LogString& output, helpers::Pool&)
+{
+	appendFooter(output);
+}
+void Layout::appendFooter(LogString& output)
+{
+}
+#endif
 
 /**
  * The expected length of a formatted event excluding the message text
@@ -46,8 +87,7 @@ size_t Layout::getFormattedEventCharacterCount() const
 		, LogString()
 		);
 	LogString text;
-	Pool pool;
-	format(text, exampleEvent, pool);
+	format(text, exampleEvent);
 	return text.size();
 }
 

--- a/src/main/cpp/patternlayout.cpp
+++ b/src/main/cpp/patternlayout.cpp
@@ -111,9 +111,7 @@ void PatternLayout::setConversionPattern(const LogString& pattern)
 	activateOptions();
 }
 
-void PatternLayout::format(LogString& output,
-	const spi::LoggingEventPtr& event,
-	Pool& pool) const
+void PatternLayout::format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const
 {
 	auto& lsMsg = event->getRenderedMessage();
 	output.reserve(m_priv->expectedPatternLength + lsMsg.size());

--- a/src/main/cpp/simplelayout.cpp
+++ b/src/main/cpp/simplelayout.cpp
@@ -26,9 +26,7 @@ IMPLEMENT_LOG4CXX_OBJECT(SimpleLayout)
 
 
 
-void SimpleLayout::format(LogString& output,
-	const spi::LoggingEventPtr& event,
-	LOG4CXX_NS::helpers::Pool&) const
+void SimpleLayout::format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const
 {
 	output.append(event->getLevel()->toString());
 	output.append(LOG4CXX_STR(" - "));

--- a/src/main/cpp/smtpappender.cpp
+++ b/src/main/cpp/smtpappender.cpp
@@ -732,17 +732,17 @@ void SMTPAppender::sendBuffer(Pool& p)
 	try
 	{
 		LogString sbuf;
-		_priv->layout->appendHeader(sbuf, p);
+		_priv->layout->appendHeader(sbuf);
 
 		int len = _priv->cb.length();
 
 		for (int i = 0; i < len; i++)
 		{
 			LoggingEventPtr event = _priv->cb.get();
-			_priv->layout->format(sbuf, event, p);
+			_priv->layout->format(sbuf, event);
 		}
 
-		_priv->layout->appendFooter(sbuf, p);
+		_priv->layout->appendFooter(sbuf);
 
 		SMTPSession session(_priv->smtpHost, _priv->smtpPort, _priv->smtpUsername, _priv->smtpPassword, p);
 

--- a/src/main/cpp/syslogappender.cpp
+++ b/src/main/cpp/syslogappender.cpp
@@ -277,10 +277,9 @@ void SyslogAppender::append( LOG4CXX_APPEND_FORMAL_PARAMETERS )
 		return;
 	}
 
-	helpers::Pool tempPool;
 	LogString msg;
 	std::string encoded;
-	_priv->layout->format(msg, event, tempPool);
+	_priv->layout->format(msg, event);
 
 	Transcoder::encode(msg, encoded);
 

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -278,7 +278,7 @@ void TelnetAppender::append( LOG4CXX_APPEND_FORMAL_PARAMETERS )
 		helpers::Pool tempPool;
 		LogString msg;
 		if (_priv->layout)
-			_priv->layout->format(msg, event, tempPool);
+			_priv->layout->format(msg, event);
 		else
 			msg = event->getRenderedMessage();
 		msg.append(LOG4CXX_STR("\r\n"));

--- a/src/main/cpp/writerappender.cpp
+++ b/src/main/cpp/writerappender.cpp
@@ -223,7 +223,7 @@ void WriterAppender::subAppend( LOG4CXX_APPEND_FORMAL_PARAMETERS )
 #endif
 	Pool tempPool;
 	LogString msg;
-	_priv->layout->format(msg, event, tempPool);
+	_priv->layout->format(msg, event);
 
 	if (_priv->writer != NULL)
 	{

--- a/src/main/cpp/writerappender.cpp
+++ b/src/main/cpp/writerappender.cpp
@@ -255,7 +255,7 @@ void WriterAppender::WriterAppenderPriv::writeFooter()
 	{
 		Pool p;
 		LogString foot;
-		this->layout->appendFooter(foot, p);
+		this->layout->appendFooter(foot);
 		this->writer->write(foot, p);
 	}
 }
@@ -266,7 +266,7 @@ void WriterAppender::WriterAppenderPriv::writeHeader()
 	{
 		Pool p;
 		LogString header;
-		this->layout->appendHeader(header, p);
+		this->layout->appendHeader(header);
 		this->writer->write(header, p);
 	}
 }

--- a/src/main/cpp/xmllayout.cpp
+++ b/src/main/cpp/xmllayout.cpp
@@ -74,9 +74,7 @@ void XMLLayout::setOption(const LogString& option,
 	}
 }
 
-void XMLLayout::format(LogString& output,
-	const spi::LoggingEventPtr& event,
-	Pool& p) const
+void XMLLayout::format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const
 {
 	auto& lsMsg = event->getRenderedMessage();
 	output.reserve(m_priv->expectedPatternLength + lsMsg.size());

--- a/src/main/cpp/xmlsocketappender.cpp
+++ b/src/main/cpp/xmlsocketappender.cpp
@@ -136,7 +136,7 @@ void XMLSocketAppender::append( LOG4CXX_APPEND_FORMAL_PARAMETERS )
 	{
 		Pool p;
 		LogString output;
-		_priv->layout->format(output, event, p);
+		_priv->layout->format(output, event);
 
 		try
 		{

--- a/src/main/include/log4cxx/fmtlayout.h
+++ b/src/main/include/log4cxx/fmtlayout.h
@@ -241,14 +241,9 @@ class LOG4CXX_EXPORT FMTLayout : public Layout
 		LogString getConversionPattern() const;
 
 		/**
-		Returns the log statement in a format consisting of the
-		<code>level</code>, followed by " - " and then the
-		<code>message</code>. For example, <pre> INFO - "A message"
-		</pre>
-		*/
-		void format(LogString& output,
-			const spi::LoggingEventPtr& event,
-			helpers::Pool& pool) const override;
+		 * Append the attributes of \c event onto \c output as specified by the conversion pattern.
+		 */
+		void format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const override;
 
 		bool ignoresThrowable() const override
 		{

--- a/src/main/include/log4cxx/fmtlayout.h
+++ b/src/main/include/log4cxx/fmtlayout.h
@@ -240,6 +240,7 @@ class LOG4CXX_EXPORT FMTLayout : public Layout
 		 */
 		LogString getConversionPattern() const;
 
+		using Layout::format;
 		/**
 		 * Append the attributes of \c event onto \c output as specified by the conversion pattern.
 		 */

--- a/src/main/include/log4cxx/htmllayout.h
+++ b/src/main/include/log4cxx/htmllayout.h
@@ -78,6 +78,7 @@ class LOG4CXX_EXPORT HTMLLayout : public Layout
 		*/
 		LogString getContentType() const override;
 
+		using Layout::activateOptions;
 #if LOG4CXX_ABI_VERSION <= 15
 		/**
 		\copybrief spi::OptionHandler::activateOptions()
@@ -96,18 +97,24 @@ class LOG4CXX_EXPORT HTMLLayout : public Layout
 		*/
 		void setOption(const LogString& option, const LogString& value) override;
 
-		void format(LogString& output,
-			const spi::LoggingEventPtr& event, helpers::Pool& pool) const override;
-
+		using Layout::format;
 		/**
-		Append appropriate HTML headers.
+		Append the attributes of \c event as a HTML table row onto \c output.
 		*/
-		void appendHeader(LogString& output, helpers::Pool& pool) override;
+		void format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const override;
 
+		using Layout::appendHeader;
 		/**
-		Append the appropriate HTML footers.
+		Append a HTML document header and start a HTML table with column headings
+		that align with the output produced by HTMLLayout::format.
 		*/
-		void appendFooter(LogString& output, helpers::Pool& pool) override;
+		void appendHeader( LOG4CXX_APPEND_HEADER_FORMAL_PARAMETERS ) override;
+
+		using Layout::appendFooter;
+		/**
+		Terminate the HTML table and the HTML document.
+		*/
+		void appendFooter( LOG4CXX_APPEND_FOOTER_FORMAL_PARAMETERS ) override;
 
 		/**
 		The HTML layout handles the throwable contained in logging

--- a/src/main/include/log4cxx/jsonlayout.h
+++ b/src/main/include/log4cxx/jsonlayout.h
@@ -39,9 +39,11 @@ class LOG4CXX_EXPORT JSONLayout : public Layout
 			const spi::LoggingEventPtr& event) const;
 		void appendSerializedNDC(LogString& buf,
 			const spi::LoggingEventPtr& event) const;
+		void appendSerializedLocationInfo(LogString& buf, const spi::LoggingEventPtr& event) const;
+#if LOG4CXX_ABI_VERSION <= 15
 		void appendSerializedLocationInfo(LogString& buf,
 			const spi::LoggingEventPtr& event, LOG4CXX_NS::helpers::Pool& p) const;
-
+#endif
 	public:
 		static void appendItem(const LogString& item, LogString& toAppendTo);
 		DECLARE_LOG4CXX_OBJECT(JSONLayout)
@@ -119,8 +121,11 @@ class LOG4CXX_EXPORT JSONLayout : public Layout
 		*/
 		void setOption(const LogString& option, const LogString& value) override;
 
-		void format(LogString& output,
-			const spi::LoggingEventPtr& event, helpers::Pool& pool) const override;
+		using Layout::format;
+		/**
+		Append the attributes of \c event as a JSON map onto \c output.
+		*/
+		void format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const override;
 
 		/**
 		The JSON layout handles the throwable contained in logging

--- a/src/main/include/log4cxx/layout.h
+++ b/src/main/include/log4cxx/layout.h
@@ -48,8 +48,24 @@ class LOG4CXX_EXPORT Layout
 		/**
 		Implement this method to create your own layout format.
 		*/
+#if LOG4CXX_ABI_VERSION <= 15
+		void format(LogString& output, const spi::LoggingEventPtr& event) const;
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to format() without a helpers::Pool parameter.
+		*/
 		virtual void format(LogString& output,
 			const spi::LoggingEventPtr& event, LOG4CXX_NS::helpers::Pool& pool) const = 0;
+#define LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS LogString& output, const spi::LoggingEventPtr& event, helpers::Pool& p
+#else
+		virtual void format(LogString& output, const spi::LoggingEventPtr& event) const = 0;
+#define LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS LogString& output, const spi::LoggingEventPtr& event
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use format() without a Pool parameter instead")]]
+		void format(LogString& output, const spi::LoggingEventPtr& event, helpers::Pool& p) const;
+#endif
 
 		/**
 		Returns the content type output by this layout. The base class
@@ -61,13 +77,45 @@ class LOG4CXX_EXPORT Layout
 		Append the header for the layout format. The base class does
 		nothing.
 		*/
+#if LOG4CXX_ABI_VERSION <= 15
+		void appendHeader(LogString& output);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to appendHeader() without a helpers::Pool parameter.
+		*/
 		virtual void appendHeader(LogString& output, LOG4CXX_NS::helpers::Pool& p);
+#define LOG4CXX_APPEND_HEADER_FORMAL_PARAMETERS LogString& output, LOG4CXX_NS::helpers::Pool& p
+#else
+		virtual void appendHeader(LogString& output);
+#define LOG4CXX_APPEND_HEADER_FORMAL_PARAMETERS LogString& output
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use appendHeader() without a Pool parameter instead")]]
+		void appendHeader(LogString& output, helpers::Pool& p);
+#endif
 
 		/**
 		Append the footer for the layout format. The base class does
 		nothing.
 		*/
+#if LOG4CXX_ABI_VERSION <= 15
+		void appendFooter(LogString& output);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to appendFooter() without a helpers::Pool parameter.
+		*/
 		virtual void appendFooter(LogString& output, LOG4CXX_NS::helpers::Pool& p);
+#define LOG4CXX_APPEND_FOOTER_FORMAL_PARAMETERS LogString& output, LOG4CXX_NS::helpers::Pool& p
+#else
+		virtual void appendFooter(LogString& output);
+#define LOG4CXX_APPEND_FOOTER_FORMAL_PARAMETERS LogString& output
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use appendFooter() without a Pool parameter instead")]]
+		void appendFooter(LogString& output, helpers::Pool& p);
+#endif
 
 		/**
 		If the layout handles the throwable object contained within

--- a/src/main/include/log4cxx/patternlayout.h
+++ b/src/main/include/log4cxx/patternlayout.h
@@ -523,12 +523,11 @@ class LOG4CXX_EXPORT PatternLayout : public Layout
 			return true;
 		}
 
+		using Layout::format;
 		/**
 		 * Produces a formatted string as specified by the conversion pattern.
 		 */
-		void format(    LogString& output,
-			const spi::LoggingEventPtr& event,
-			helpers::Pool& pool) const override;
+		void format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const override;
 
 	protected:
 		virtual LOG4CXX_NS::pattern::PatternMap getFormatSpecifiers();

--- a/src/main/include/log4cxx/simplelayout.h
+++ b/src/main/include/log4cxx/simplelayout.h
@@ -44,14 +44,13 @@ class LOG4CXX_EXPORT SimpleLayout : public Layout
 		END_LOG4CXX_CAST_MAP()
 
 		/**
-		Returns the log statement in a format consisting of the
-		<code>level</code>, followed by " - " and then the
-		<code>message</code>. For example, <pre> INFO - "A message"
+		Append the <code>level</code>, followed by " - "
+		and then the <code>message</code>.
+		For example,
+		<pre> INFO - "A message"
 		</pre>
 		*/
-		void format(LogString& output,
-			const spi::LoggingEventPtr& event,
-			helpers::Pool& pool) const override;
+		void format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const override;
 
 		/**
 		The SimpleLayout does not handle the throwable contained within

--- a/src/main/include/log4cxx/xml/xmllayout.h
+++ b/src/main/include/log4cxx/xml/xmllayout.h
@@ -117,13 +117,12 @@ class LOG4CXX_EXPORT XMLLayout : public Layout
 		void setOption(const LogString& option,
 			const LogString& value) override;
 
+		using Layout::format;
 		/**
 		* Formats a {@link spi::LoggingEvent LoggingEvent}
-		* in conformance with the log4cxx.dtd.
+		* in conformance with [this XML data definition file](https://logging.apache.org/log4j/1.x/apidocs/org/apache/log4j/xml/doc-files/log4j.dtd).
 		**/
-		void format(LogString& output,
-			const spi::LoggingEventPtr& event,
-			helpers::Pool& p) const override;
+		void format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const override;
 
 		/**
 		The XMLLayout prints and does not ignore exceptions. Hence the

--- a/src/site/doxy/Doxyfile.in
+++ b/src/site/doxy/Doxyfile.in
@@ -2359,6 +2359,9 @@ PREDEFINED             = LOG4CXX_NS=log4cxx \
                          LOG4CXX_FORMAT_NUMBER_FORMAL_PARAMETERS="LogString& toAppendTo, int n, helpers::Pool& p" \
                          LOG4CXX_FORMAT_EVENT_FORMAL_PARAMETERS="const spi::LoggingEventPtr& event, LogString& toAppendTo, helpers::Pool& p" \
                          LOG4CXX_FORMAT_EVENT_PARAMETERS="event, toAppendTo, p" \
+                         LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS="LogString& output, const spi::LoggingEventPtr& event, helpers::Pool& p" \
+                         LOG4CXX_APPEND_HEADER_FORMAL_PARAMETERS="LogString& output, LOG4CXX_NS::helpers::Pool& p" \
+                         LOG4CXX_APPEND_FOOTER_FORMAL_PARAMETERS="LogString& output, LOG4CXX_NS::helpers::Pool& p" \
                          LOG4CXX_HAS_DOMCONFIGURATOR=1 \
                          LOG4CXX_ASYNC_BUFFER_SUPPORTS_FMT=1 \
                          __LOG4CXX_FUNC__=compiler_dependent

--- a/src/test/cpp/fmttest.cpp
+++ b/src/test/cpp/fmttest.cpp
@@ -149,8 +149,7 @@ public:
 																							 log4cxx::spi::LocationInfo::getLocationUnavailable());
 		FMTLayout layout(LOG4CXX_STR("{d:%Y-%m-%d %H:%M:%S} {message}"));
 		LogString output;
-		log4cxx::helpers::Pool pool;
-		layout.format( output, logEvt, pool);
+		layout.format( output, logEvt);
 
 		log4cxx::helpers::Date::setGetCurrentTimeFunction(nullptr);
 

--- a/src/test/cpp/jsonlayouttest.cpp
+++ b/src/test/cpp/jsonlayouttest.cpp
@@ -300,8 +300,6 @@ public:
 	 */
 	void testAppendSerializedLocationInfo()
 	{
-		Pool p;
-
 		LoggingEventPtr event1 = LoggingEventPtr(new LoggingEvent(LOG4CXX_STR("Logger"),
 					Level::getInfo(),
 					LOG4CXX_STR("A message goes here."),
@@ -317,7 +315,7 @@ public:
 		.append(LOG4CXX_STR("\"class\": \"\", "))
 		.append(LOG4CXX_STR("\"method\": \"BarFunc\" }"));
 
-		appendSerializedLocationInfo(output1, event1, p);
+		appendSerializedLocationInfo(output1, event1);
 		LOGUNIT_ASSERT_EQUAL(expected1, output1);
 	}
 
@@ -326,8 +324,6 @@ public:
 	 */
 	void testAppendSerializedLocationInfoWithPrettyPrint()
 	{
-		Pool p;
-
 		LoggingEventPtr event1 = LoggingEventPtr(new LoggingEvent(LOG4CXX_STR("Logger"),
 					Level::getInfo(),
 					LOG4CXX_STR("A message goes here."),
@@ -356,7 +352,7 @@ public:
 		.append(LOG4CXX_STR("}"));
 
 		setPrettyPrint(true);
-		appendSerializedLocationInfo(output1, event1, p);
+		appendSerializedLocationInfo(output1, event1);
 
 		LOGUNIT_ASSERT_EQUAL(expected1, output1);
 	}
@@ -366,8 +362,6 @@ public:
 	 */
 	void testFormat()
 	{
-		Pool p;
-
 		LoggingEventPtr event1 = LoggingEventPtr(new LoggingEvent(LOG4CXX_STR("Logger"),
 					Level::getInfo(),
 					LOG4CXX_STR("A message goes here."),
@@ -400,11 +394,11 @@ public:
 		appendSerializedMDC(expected1, event1);
 		appendSerializedNDC(expected1, event1);
 		expected1.append(LOG4CXX_STR(", "));
-		appendSerializedLocationInfo(expected1, event1, p);
+		appendSerializedLocationInfo(expected1, event1);
 
 		expected1.append(LOG4CXX_STR(" }"));
 		expected1.append(LOG4CXX_EOL);
-		format(output1, event1, p);
+		format(output1, event1);
 
 		LOGUNIT_ASSERT_EQUAL(expected1, output1);
 	}
@@ -414,8 +408,6 @@ public:
 	 */
 	void testFormatWithPrettyPrint()
 	{
-		Pool p;
-
 		LoggingEventPtr event1 = LoggingEventPtr(new LoggingEvent(LOG4CXX_STR("Logger"),
 					Level::getInfo(),
 					LOG4CXX_STR("A message goes here."),
@@ -459,12 +451,12 @@ public:
 		appendSerializedNDC(expected1, event1);
 		expected1.append(LOG4CXX_STR(","));
 		expected1.append(LOG4CXX_EOL);
-		appendSerializedLocationInfo(expected1, event1, p);
+		appendSerializedLocationInfo(expected1, event1);
 
 		expected1.append(LOG4CXX_EOL);
 		expected1.append(LOG4CXX_STR("}"));
 		expected1.append(LOG4CXX_EOL);
-		format(output1, event1, p);
+		format(output1, event1);
 
 		LOGUNIT_ASSERT_EQUAL(expected1, output1);
 	}

--- a/src/test/cpp/mdctestcase.cpp
+++ b/src/test/cpp/mdctestcase.cpp
@@ -69,10 +69,9 @@ public:
 	{
 		MDC item1("key1", "value1");
 		MDC item2("key2", "value2");
-		helpers::Pool p;
 		LogString output;
 		PatternLayout l{ LOG4CXX_STR("%-5p %c - %.30J %m") };
-		l.format(output, std::make_shared<spi::LoggingEvent>(LOG4CXX_STR("MDC.LayoutTest"), Level::getInfo(), LOG4CXX_STR("Message"), spi::LocationInfo::getLocationUnavailable()), p);
+		l.format(output, std::make_shared<spi::LoggingEvent>(LOG4CXX_STR("MDC.LayoutTest"), Level::getInfo(), LOG4CXX_STR("Message"), spi::LocationInfo::getLocationUnavailable()));
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("INFO  MDC.LayoutTest - {\"key1\":\"value1\"} Message"), output);
 	}
 };

--- a/src/test/cpp/ndctestcase.cpp
+++ b/src/test/cpp/ndctestcase.cpp
@@ -121,10 +121,9 @@ public:
 		NDC item1("context1");
 		NDC item2("context2");
 		NDC item3("context3");
-		helpers::Pool p;
 		LogString output;
 		PatternLayout l{ LOG4CXX_STR("%-5p %c - %.20x %m") };
-		l.format(output, std::make_shared<spi::LoggingEvent>(LOG4CXX_STR("NDC.LayoutTest"), Level::getInfo(), LOG4CXX_STR("Message"), spi::LocationInfo::getLocationUnavailable()), p);
+		l.format(output, std::make_shared<spi::LoggingEvent>(LOG4CXX_STR("NDC.LayoutTest"), Level::getInfo(), LOG4CXX_STR("Message"), spi::LocationInfo::getLocationUnavailable()));
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("INFO  NDC.LayoutTest - t1 context2 context3 Message"), output);
 	}
 

--- a/src/test/cpp/patternlayouttest.cpp
+++ b/src/test/cpp/patternlayouttest.cpp
@@ -108,15 +108,14 @@ public:
 	{
 		LogString msg(size_t(INT_MAX) + 1000, 'E');
 		msg[msg.length() - 1] = 'X';
-		Pool p;
 		LogString output1;
 		PatternLayout l1{ LOG4CXX_STR("%-5p %c{2} - %.30m") };
-		l1.format(output1, std::make_shared<spi::LoggingEvent>(logger->getName(), Level::getInfo(), msg, spi::LocationInfo::getLocationUnavailable()), p);
+		l1.format(output1, std::make_shared<spi::LoggingEvent>(logger->getName(), Level::getInfo(), msg, spi::LocationInfo::getLocationUnavailable()));
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("INFO  log4j.PatternLayoutTest - EEEEEEEEEEEEEEEEEEEEEEEEEEEEEX"), output1);
 
 		PatternLayout l2{ LOG4CXX_STR("%p %.30m %p") };
 		LogString output2;
-		l2.format(output2, std::make_shared<spi::LoggingEvent>(logger->getName(), Level::getDebug(), msg, spi::LocationInfo::getLocationUnavailable()), p);
+		l2.format(output2, std::make_shared<spi::LoggingEvent>(logger->getName(), Level::getDebug(), msg, spi::LocationInfo::getLocationUnavailable()));
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("DEBUG EEEEEEEEEEEEEEEEEEEEEEEEEEEEEX DEBUG"), output2);
 	}
 

--- a/src/test/cpp/xml/xmllayouttest.cpp
+++ b/src/test/cpp/xml/xmllayouttest.cpp
@@ -115,9 +115,8 @@ public:
 	 */
 	void testGetHeader()
 	{
-		Pool p;
 		LogString header;
-		XMLLayout().appendHeader(header, p);
+		XMLLayout().appendHeader(header);
 		LOGUNIT_ASSERT_EQUAL((size_t) 0, header.size());
 	}
 
@@ -126,9 +125,8 @@ public:
 	 */
 	void testGetFooter()
 	{
-		Pool p;
 		LogString footer;
-		XMLLayout().appendFooter(footer, p);
+		XMLLayout().appendFooter(footer);
 		LOGUNIT_ASSERT_EQUAL((size_t) 0, footer.size());
 	}
 
@@ -282,7 +280,7 @@ public:
 		Pool p;
 		XMLLayout layout;
 		LogString result;
-		layout.format(result, event, p);
+		layout.format(result, event);
 		apr_xml_elem* parsedResult = parse(result, p);
 		checkEventElement(parsedResult, event);
 
@@ -316,7 +314,7 @@ public:
 		Pool p;
 		XMLLayout layout;
 		LogString result;
-		layout.format(result, event, p);
+		layout.format(result, event);
 		NDC::pop();
 
 		apr_xml_elem* parsedResult = parse(result, p);
@@ -398,7 +396,7 @@ public:
 		layout.setProperties(true);
 		Pool p;
 		LogString result;
-		layout.format(result, event, p);
+		layout.format(result, event);
 		MDC::clear();
 
 		apr_xml_elem* parsedResult = parse(result, p);
@@ -450,7 +448,7 @@ public:
 		XMLLayout layout;
 		Pool p;
 		LogString result;
-		layout.format(result, event, p);
+		layout.format(result, event);
 		NDC::clear();
 		apr_xml_elem* parsedResult = parse(result, p);
 		int ndcCount = 0;

--- a/src/test/cpp/xml/xmllayouttest.cpp
+++ b/src/test/cpp/xml/xmllayouttest.cpp
@@ -479,9 +479,8 @@ public:
 		auto event = std::make_shared<LoggingEvent>(problemName, level, problemName, LOG4CXX_LOCATION);
 
 		HTMLLayout layout;
-		Pool p;
 		LogString html(LOG4CXX_STR("<body>"));
-		layout.format(html, event, p);
+		layout.format(html, event);
 		html += LOG4CXX_STR("</body>");
 
 		LogLog::debug(html);
@@ -492,6 +491,7 @@ public:
 		encoder->encode(html, iter, buf);
 		LOGUNIT_ASSERT(iter == html.end());
 		buf.flip();
+		Pool p;
 		auto parser = apr_xml_parser_create(p.getAPRPool());
 		LOGUNIT_ASSERT(parser != 0);
 		auto stat = apr_xml_parser_feed(parser, buf.data(), buf.remaining());


### PR DESCRIPTION
This PR adds methods to the Layout interface that do not require a helpers::Pool parameter.

The objective is to avoid breaking client code that calls the methods with a helpers::Pool parameter.

Users who have extended Log4cxx with their own Layout subclass will need to modify code when using the new ABI.