### PR TITLE
Simplify the helpers::Writer interface in a future ABI version

### DIFF
--- a/src/main/cpp/bufferedwriter.cpp
+++ b/src/main/cpp/bufferedwriter.cpp
@@ -49,32 +49,32 @@ BufferedWriter::~BufferedWriter()
 {
 }
 
-void BufferedWriter::close(Pool& p)
+void BufferedWriter::close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS )
 {
-	flush(p);
-	m_priv->out->close(p);
+	flush();
+	m_priv->out->close();
 }
 
-void BufferedWriter::flush(Pool& p)
+void BufferedWriter::flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS )
 {
 	if (m_priv->buf.length() > 0)
 	{
-		m_priv->out->write(m_priv->buf, p);
+		m_priv->out->write(m_priv->buf);
 		m_priv->buf.erase(m_priv->buf.begin(), m_priv->buf.end());
 	}
 }
 
-void BufferedWriter::write(const LogString& str, Pool& p)
+void BufferedWriter::write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS )
 {
 	if (m_priv->buf.length() + str.length() > m_priv->sz)
 	{
-		m_priv->out->write(m_priv->buf, p);
+		m_priv->out->write(m_priv->buf);
 		m_priv->buf.erase(m_priv->buf.begin(), m_priv->buf.end());
 	}
 
 	if (str.length() > m_priv->sz)
 	{
-		m_priv->out->write(str, p);
+		m_priv->out->write(str);
 	}
 	else
 	{

--- a/src/main/cpp/bytearrayoutputstream.cpp
+++ b/src/main/cpp/bytearrayoutputstream.cpp
@@ -39,15 +39,15 @@ ByteArrayOutputStream::~ByteArrayOutputStream()
 {
 }
 
-void ByteArrayOutputStream::close(Pool& /* p */)
+void ByteArrayOutputStream::close( LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 }
 
-void ByteArrayOutputStream::flush(Pool& /* p */)
+void ByteArrayOutputStream::flush( LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 }
 
-void ByteArrayOutputStream::write(ByteBuffer& buf, Pool& /* p */ )
+void ByteArrayOutputStream::write( LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 	const size_t count = buf.remaining();
 	const size_t sz = m_priv->array.size();

--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -353,7 +353,7 @@ void FileAppender::setFileInternal(
 		Pool p;
 		char bom[] = { (char) 0xFE, (char) 0xFF };
 		ByteBuffer buf(bom, 2);
-		outStream->write(buf, p);
+		outStream->write(buf);
 	}
 
 	WriterPtr newWriter(createWriter(outStream));

--- a/src/main/cpp/fileoutputstream.cpp
+++ b/src/main/cpp/fileoutputstream.cpp
@@ -81,7 +81,7 @@ FileOutputStream::~FileOutputStream()
 	}
 }
 
-void FileOutputStream::close(Pool& /* p */)
+void FileOutputStream::close( LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 	if (m_priv->fileptr)
 	{
@@ -96,11 +96,11 @@ void FileOutputStream::close(Pool& /* p */)
 	}
 }
 
-void FileOutputStream::flush(Pool& /* p */)
+void FileOutputStream::flush( LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 }
 
-void FileOutputStream::write(ByteBuffer& buf, Pool& /* p */ )
+void FileOutputStream::write( LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 	if (m_priv->fileptr == NULL)
 	{

--- a/src/main/cpp/loglog.cpp
+++ b/src/main/cpp/loglog.cpp
@@ -206,7 +206,7 @@ void LogLog::emit_log(const LogString& prefix, const LogString& msg, const LogSt
 	out.append(suffix);
 	out.append(1, (logchar) 0x0A);
 
-	SystemErrWriter::write(out);
+	SystemErrWriter().write(out);
 }
 
 void LogLog::emit_log(const LogString& prefix, const std::exception& ex, const LogString& suffix)
@@ -227,5 +227,5 @@ void LogLog::emit_log(const LogString& prefix, const std::exception& ex, const L
 	out.append(suffix);
 	out.append(1, (logchar) 0x0A);
 
-	SystemErrWriter::write(out);
+	SystemErrWriter().write(out);
 }

--- a/src/main/cpp/outputstream.cpp
+++ b/src/main/cpp/outputstream.cpp
@@ -17,6 +17,7 @@
 
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/outputstream.h>
+#include <log4cxx/helpers/pool.h>
 #include <stdexcept>
 
 using namespace LOG4CXX_NS;
@@ -31,3 +32,25 @@ OutputStream::OutputStream()
 OutputStream::~OutputStream()
 {
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+void OutputStream::close()
+{
+	Pool p;
+	close(p);
+}
+void OutputStream::flush()
+{
+	Pool p;
+	flush(p);
+}
+void OutputStream::write(ByteBuffer& buf)
+{
+	Pool p;
+	write(buf, p);
+}
+#else
+void OutputStream::close(Pool&) { close(); }
+void OutputStream::flush(Pool&) { flush(); }
+void OutputStream::write(ByteBuffer& buf, Pool&) { write(buf); }
+#endif

--- a/src/main/cpp/outputstreamwriter.cpp
+++ b/src/main/cpp/outputstreamwriter.cpp
@@ -71,24 +71,24 @@ OutputStreamWriter::~OutputStreamWriter()
 {
 }
 
-void OutputStreamWriter::close(Pool& p)
+void OutputStreamWriter::close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS )
 {
-	m_priv->out->close(p);
+	m_priv->out->close();
 }
 
-void OutputStreamWriter::flush(Pool& p)
+void OutputStreamWriter::flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS )
 {
-	m_priv->out->flush(p);
+	m_priv->out->flush();
 }
 
-void OutputStreamWriter::write(const LogString& str, Pool& p)
+void OutputStreamWriter::write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS )
 {
 	if (str.empty())
 		return;
 	if (CharsetEncoder::isTriviallyCopyable(str, m_priv->enc))
 	{
 		ByteBuffer buf((char*)str.data(), str.size() * sizeof (logchar));
-		m_priv->out->write(buf, p);
+		m_priv->out->write(buf);
 	}
 	else
 	{
@@ -113,14 +113,14 @@ void OutputStreamWriter::write(const LogString& str, Pool& p)
 		{
 			CharsetEncoder::encode(m_priv->enc, str, iter, buf);
 			buf.flip();
-			m_priv->out->write(buf, p);
+			m_priv->out->write(buf);
 			buf.clear();
 		}
 
 		CharsetEncoder::encode(m_priv->enc, str, iter, buf);
 		m_priv->enc->flush(buf);
 		buf.flip();
-		m_priv->out->write(buf, p);
+		m_priv->out->write(buf);
 	}
 }
 

--- a/src/main/cpp/rollingfileappender.cpp
+++ b/src/main/cpp/rollingfileappender.cpp
@@ -554,26 +554,26 @@ class CountingOutputStream : public OutputStream
 		/**
 		 * {@inheritDoc}
 		 */
-		void close(Pool& p) override
+		void close( LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS ) override
 		{
-			os->close(p);
+			os->close();
 			rfa = 0;
 		}
 
 		/**
 		 * {@inheritDoc}
 		 */
-		void flush(Pool& p) override
+		void flush( LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS ) override
 		{
-			os->flush(p);
+			os->flush();
 		}
 
 		/**
 		 * {@inheritDoc}
 		 */
-		void write(ByteBuffer& buf, Pool& p) override
+		void write( LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS ) override
 		{
-			os->write(buf, p);
+			os->write(buf);
 
 			if (rfa != 0)
 			{

--- a/src/main/cpp/socketoutputstream.cpp
+++ b/src/main/cpp/socketoutputstream.cpp
@@ -45,13 +45,13 @@ SocketOutputStream::~SocketOutputStream()
 {
 }
 
-void SocketOutputStream::close(Pool& p)
+void SocketOutputStream::close( LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
-	flush(p);
+	flush();
 	m_priv->socket->close();
 }
 
-void SocketOutputStream::flush(Pool& /* p */)
+void SocketOutputStream::flush( LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 	if (m_priv->array.size() > 0)
 	{
@@ -61,7 +61,7 @@ void SocketOutputStream::flush(Pool& /* p */)
 	}
 }
 
-void SocketOutputStream::write(ByteBuffer& buf, Pool& /* p */ )
+void SocketOutputStream::write( LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 	if (buf.remaining() > 0)
 	{

--- a/src/main/cpp/systemerrwriter.cpp
+++ b/src/main/cpp/systemerrwriter.cpp
@@ -37,18 +37,28 @@ SystemErrWriter::~SystemErrWriter()
 {
 }
 
-void SystemErrWriter::close(Pool& /* p */)
+void SystemErrWriter::close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS )
 {
 }
 
-void SystemErrWriter::flush(Pool& /* p */)
+void SystemErrWriter::flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS )
 {
-	flush();
+	fflush(stderr);
 }
 
-void SystemErrWriter::write(const LogString& str, Pool& /* p */)
+void SystemErrWriter::write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS )
 {
-	write(str);
+#if LOG4CXX_WCHAR_T_API
+	if (isWide())
+	{
+		LOG4CXX_ENCODE_WCHAR(msg, str);
+		fputws(msg.c_str(), stderr);
+		return;
+	}
+
+#endif
+	LOG4CXX_ENCODE_CHAR(msg, str);
+	fputs(msg.c_str(), stderr);
 }
 
 bool SystemErrWriter::isWide()
@@ -62,6 +72,7 @@ bool SystemErrWriter::isWide()
 #endif
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
 void SystemErrWriter::write(const LogString& str)
 {
 #if LOG4CXX_WCHAR_T_API
@@ -82,3 +93,4 @@ void SystemErrWriter::flush()
 {
 	fflush(stderr);
 }
+#endif

--- a/src/main/cpp/systemoutwriter.cpp
+++ b/src/main/cpp/systemoutwriter.cpp
@@ -37,18 +37,28 @@ SystemOutWriter::~SystemOutWriter()
 {
 }
 
-void SystemOutWriter::close(Pool& /* p */ )
+void SystemOutWriter::close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS )
 {
 }
 
-void SystemOutWriter::flush(Pool& /* p */ )
+void SystemOutWriter::flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS )
 {
-	flush();
+	fflush(stdout);
 }
 
-void SystemOutWriter::write(const LogString& str, Pool& /* p */ )
+void SystemOutWriter::write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS )
 {
-	write(str);
+#if LOG4CXX_WCHAR_T_API
+	if (isWide())
+	{
+		LOG4CXX_ENCODE_WCHAR(msg, str);
+		fputws(msg.c_str(), stdout);
+		return;
+	}
+
+#endif
+	LOG4CXX_ENCODE_CHAR(msg, str);
+	fputs(msg.c_str(), stdout);
 }
 
 bool SystemOutWriter::isWide()
@@ -62,6 +72,7 @@ bool SystemOutWriter::isWide()
 #endif
 }
 
+#if LOG4CXX_ABI_VERSION <= 15
 void SystemOutWriter::write(const LogString& str)
 {
 #if LOG4CXX_WCHAR_T_API
@@ -82,3 +93,4 @@ void SystemOutWriter::flush()
 {
 	fflush(stdout);
 }
+#endif

--- a/src/main/cpp/writer.cpp
+++ b/src/main/cpp/writer.cpp
@@ -18,6 +18,7 @@
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/writer.h>
 #include <log4cxx/helpers/loglog.h>
+#include <log4cxx/helpers/pool.h>
 #include <stdexcept>
 
 using namespace LOG4CXX_NS::helpers;
@@ -31,3 +32,25 @@ Writer::Writer()
 Writer::~Writer()
 {
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+void Writer::close()
+{
+	Pool p;
+	close(p);
+}
+void Writer::flush()
+{
+	Pool p;
+	flush(p);
+}
+void Writer::write(const LogString& str)
+{
+	Pool p;
+	write(str, p);
+}
+#else
+void Writer::close(Pool&) { close(); }
+void Writer::flush(Pool&) { flush(); }
+void Writer::write(const LogString& str, Pool&) { write(str); }
+#endif

--- a/src/main/cpp/writerappender.cpp
+++ b/src/main/cpp/writerappender.cpp
@@ -154,7 +154,7 @@ void WriterAppender::WriterAppenderPriv::close()
 			//    and pool is likely to be reclaimed soon when appender is destructed.
 			//
 			this->writeFooter();
-			this->writer->close(this->pool);
+			this->writer->close();
 			this->writer = 0;
 		}
 		catch (IOException& e)
@@ -221,17 +221,16 @@ void WriterAppender::subAppend( LOG4CXX_APPEND_FORMAL_PARAMETERS )
 	if (event->getRenderedMessage() == _priv->exceptionTriggeringMessage)
 		throw RuntimeException(LOG4CXX_STR("Simulated fault"));
 #endif
-	Pool tempPool;
 	LogString msg;
 	_priv->layout->format(msg, event);
 
 	if (_priv->writer != NULL)
 	{
-		_priv->writer->write(msg, tempPool);
+		_priv->writer->write(msg);
 
 		if (_priv->immediateFlush)
 		{
-			_priv->writer->flush(tempPool);
+			_priv->writer->flush();
 		}
 	}
 }
@@ -253,10 +252,9 @@ void WriterAppender::WriterAppenderPriv::writeFooter()
 {
 	if (this->layout != NULL)
 	{
-		Pool p;
 		LogString foot;
 		this->layout->appendFooter(foot);
-		this->writer->write(foot, p);
+		this->writer->write(foot);
 	}
 }
 
@@ -264,10 +262,9 @@ void WriterAppender::WriterAppenderPriv::writeHeader()
 {
 	if (this->layout != NULL)
 	{
-		Pool p;
 		LogString header;
 		this->layout->appendHeader(header);
-		this->writer->write(header, p);
+		this->writer->write(header);
 	}
 }
 

--- a/src/main/cpp/xmlsocketappender.cpp
+++ b/src/main/cpp/xmlsocketappender.cpp
@@ -121,7 +121,7 @@ void XMLSocketAppender::XMLSocketAppenderPriv::close()
 	{
 		try
 		{
-			this->writer->close(this->pool);
+			this->writer->close();
 			this->writer = nullptr;
 		}
 		catch (std::exception&)
@@ -134,14 +134,13 @@ void XMLSocketAppender::append( LOG4CXX_APPEND_FORMAL_PARAMETERS )
 {
 	if (_priv->writer)
 	{
-		Pool p;
 		LogString output;
 		_priv->layout->format(output, event);
 
 		try
 		{
-			_priv->writer->write(output, p);
-			_priv->writer->flush(p);
+			_priv->writer->write(output);
+			_priv->writer->flush();
 		}
 		catch (std::exception& e)
 		{

--- a/src/main/include/log4cxx/helpers/bufferedwriter.h
+++ b/src/main/include/log4cxx/helpers/bufferedwriter.h
@@ -46,9 +46,12 @@ class LOG4CXX_EXPORT BufferedWriter : public Writer
 		BufferedWriter(WriterPtr& out, size_t sz);
 		virtual ~BufferedWriter();
 
-		void close(Pool& p) override;
-		void flush(Pool& p) override;
-		void write(const LogString& str, Pool& p) override;
+		using Writer::close;
+		void close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS ) override;
+		using Writer::flush;
+		void flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS ) override;
+		using Writer::write;
+		void write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS ) override;
 
 		WriterPtr getWriter() const;
 	private:

--- a/src/main/include/log4cxx/helpers/bytearrayoutputstream.h
+++ b/src/main/include/log4cxx/helpers/bytearrayoutputstream.h
@@ -48,9 +48,12 @@ class LOG4CXX_EXPORT ByteArrayOutputStream : public OutputStream
 		ByteArrayOutputStream();
 		virtual ~ByteArrayOutputStream();
 
-		void close(Pool& p) override;
-		void flush(Pool& p) override;
-		void write(ByteBuffer& buf, Pool& p) override;
+		using OutputStream::close;
+		void close( LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
+		using OutputStream::flush;
+		void flush( LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
+		using OutputStream::write;
+		void write( LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
 		ByteList toByteArray() const;
 
 	private:

--- a/src/main/include/log4cxx/helpers/fileoutputstream.h
+++ b/src/main/include/log4cxx/helpers/fileoutputstream.h
@@ -47,9 +47,12 @@ class LOG4CXX_EXPORT FileOutputStream : public OutputStream
 		FileOutputStream(const logchar* filename, bool append = false);
 		virtual ~FileOutputStream();
 
-		void close(Pool& p) override;
-		void flush(Pool& p) override;
-		void write(ByteBuffer& buf, Pool& p) override;
+		using OutputStream::close;
+		void close( LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
+		using OutputStream::flush;
+		void flush( LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
+		using OutputStream::write;
+		void write( LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
 
 		apr_file_t* getFilePtr() const;
 

--- a/src/main/include/log4cxx/helpers/outputstream.h
+++ b/src/main/include/log4cxx/helpers/outputstream.h
@@ -43,9 +43,48 @@ class LOG4CXX_EXPORT OutputStream : public Object
 		virtual ~OutputStream();
 
 	public:
+#if LOG4CXX_ABI_VERSION <= 15
+		void close();
+		void flush();
+		void write(ByteBuffer& buf);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to close() without a helpers::Pool parameter.
+		*/
 		virtual void close(Pool& p) = 0;
+#define LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS helpers::Pool& p
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to flush() without a helpers::Pool parameter.
+		*/
 		virtual void flush(Pool& p) = 0;
+#define LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS helpers::Pool& p
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to write() without a helpers::Pool parameter.
+		*/
 		virtual void write(ByteBuffer& buf, Pool& p) = 0;
+#define LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS ByteBuffer& buf, helpers::Pool& p
+#else
+		virtual void close() = 0;
+#define LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS
+		virtual void flush() = 0;
+#define LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS
+		virtual void write(ByteBuffer& buf) = 0;
+#define LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS ByteBuffer& buf
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		void close(Pool& p);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		void flush(Pool& p);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		void write(ByteBuffer& buf, Pool& p);
+#endif
 
 	private:
 		OutputStream(const OutputStream&);

--- a/src/main/include/log4cxx/helpers/outputstream.h
+++ b/src/main/include/log4cxx/helpers/outputstream.h
@@ -75,14 +75,17 @@ class LOG4CXX_EXPORT OutputStream : public Object
 		/**
 		@deprecated The \c pool parameter is not used and will be removed in a future version.
 		*/
+		[[deprecated("Use close() without a Pool parameter instead")]]
 		void close(Pool& p);
 		/**
 		@deprecated The \c pool parameter is not used and will be removed in a future version.
 		*/
+		[[deprecated("Use flush() without a Pool parameter instead")]]
 		void flush(Pool& p);
 		/**
 		@deprecated The \c pool parameter is not used and will be removed in a future version.
 		*/
+		[[deprecated("Use write() without a Pool parameter instead")]]
 		void write(ByteBuffer& buf, Pool& p);
 #endif
 

--- a/src/main/include/log4cxx/helpers/outputstreamwriter.h
+++ b/src/main/include/log4cxx/helpers/outputstreamwriter.h
@@ -53,9 +53,12 @@ class LOG4CXX_EXPORT OutputStreamWriter : public Writer
 		OutputStreamWriter(LOG4CXX_16_CONST OutputStreamPtr& out, LOG4CXX_16_CONST CharsetEncoderPtr& enc);
 		~OutputStreamWriter();
 
-		void close(Pool& p) override;
-		void flush(Pool& p) override;
-		void write(const LogString& str, Pool& p) override;
+		using Writer::close;
+		void close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS ) override;
+		using Writer::flush;
+		void flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS ) override;
+		using Writer::write;
+		void write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS ) override;
 		LogString getEncoding() const;
 
 		OutputStreamPtr getOutputStreamPtr() const;

--- a/src/main/include/log4cxx/helpers/socketoutputstream.h
+++ b/src/main/include/log4cxx/helpers/socketoutputstream.h
@@ -40,9 +40,12 @@ class LOG4CXX_EXPORT SocketOutputStream : public OutputStream
 		SocketOutputStream(const SocketPtr& socket);
 		~SocketOutputStream();
 
-		void close(Pool& p) override;
-		void flush(Pool& p) override;
-		void write(ByteBuffer& buf, Pool& p) override;
+		using OutputStream::close;
+		void close( LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
+		using OutputStream::flush;
+		void flush( LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
+		using OutputStream::write;
+		void write( LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS ) override;
 
 	private:
 		LOG4CXX_DECLARE_PRIVATE_MEMBER_PTR(SocketOutputStreamPrivate, m_priv)

--- a/src/main/include/log4cxx/helpers/systemerrwriter.h
+++ b/src/main/include/log4cxx/helpers/systemerrwriter.h
@@ -40,13 +40,17 @@ class LOG4CXX_EXPORT SystemErrWriter : public Writer
 		SystemErrWriter();
 		virtual ~SystemErrWriter();
 
-		void close(Pool& p) override;
-		void flush(Pool& p) override;
-		void write(const LogString& str, Pool& p) override;
+		using Writer::close;
+		void close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS ) override;
+		using Writer::flush;
+		void flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS ) override;
+		using Writer::write;
+		void write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS ) override;
 
+#if LOG4CXX_ABI_VERSION <= 15
 		static void write(const LogString& str);
 		static void flush();
-
+#endif
 	private:
 		SystemErrWriter(const SystemErrWriter&);
 		SystemErrWriter& operator=(const SystemErrWriter&);

--- a/src/main/include/log4cxx/helpers/systemoutwriter.h
+++ b/src/main/include/log4cxx/helpers/systemoutwriter.h
@@ -40,12 +40,17 @@ class LOG4CXX_EXPORT SystemOutWriter : public Writer
 		SystemOutWriter();
 		~SystemOutWriter();
 
-		void close(Pool& p) override;
-		void flush(Pool& p) override;
-		void write(const LogString& str, Pool& p) override;
+		using Writer::close;
+		void close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS ) override;
+		using Writer::flush;
+		void flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS ) override;
+		using Writer::write;
+		void write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS ) override;
 
+#if LOG4CXX_ABI_VERSION <= 15
 		static void write(const LogString& str);
 		static void flush();
+#endif
 	private:
 		SystemOutWriter(const SystemOutWriter&);
 		SystemOutWriter& operator=(const SystemOutWriter&);

--- a/src/main/include/log4cxx/helpers/writer.h
+++ b/src/main/include/log4cxx/helpers/writer.h
@@ -75,14 +75,17 @@ class LOG4CXX_EXPORT Writer : public Object
 		/**
 		@deprecated The \c pool parameter is not used and will be removed in a future version.
 		*/
+		[[deprecated("Use close() without a Pool parameter instead")]]
 		void close(Pool& p);
 		/**
 		@deprecated The \c pool parameter is not used and will be removed in a future version.
 		*/
+		[[deprecated("Use flush() without a Pool parameter instead")]]
 		void flush(Pool& p);
 		/**
 		@deprecated The \c pool parameter is not used and will be removed in a future version.
 		*/
+		[[deprecated("Use write() without a Pool parameter instead")]]
 		void write(const LogString& str, Pool& p);
 #endif
 	private:

--- a/src/main/include/log4cxx/helpers/writer.h
+++ b/src/main/include/log4cxx/helpers/writer.h
@@ -43,10 +43,48 @@ class LOG4CXX_EXPORT Writer : public Object
 		virtual ~Writer();
 
 	public:
+#if LOG4CXX_ABI_VERSION <= 15
+		void close();
+		void flush();
+		void write(const LogString& str);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to close() without a helpers::Pool parameter.
+		*/
 		virtual void close(Pool& p) = 0;
+#define LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS helpers::Pool& p
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to flush() without a helpers::Pool parameter.
+		*/
 		virtual void flush(Pool& p) = 0;
+#define LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS helpers::Pool& p
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to write() without a helpers::Pool parameter.
+		*/
 		virtual void write(const LogString& str, Pool& p) = 0;
-
+#define LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS const LogString& str, helpers::Pool& p
+#else
+		virtual void close() = 0;
+#define LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS
+		virtual void flush() = 0;
+#define LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS
+		virtual void write(const LogString& str) = 0;
+#define LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS const LogString& str
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		void close(Pool& p);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		void flush(Pool& p);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		void write(const LogString& str, Pool& p);
+#endif
 	private:
 		Writer(const Writer&);
 		Writer& operator=(const Writer&);

--- a/src/main/include/log4cxx/private/writerappender_priv.h
+++ b/src/main/include/log4cxx/private/writerappender_priv.h
@@ -53,7 +53,7 @@ struct WriterAppender::WriterAppenderPriv : public AppenderSkeleton::AppenderSke
 	{
 		std::lock_guard<std::recursive_mutex> lock(mutex);
 		if (writer)
-			writer->flush(pool);
+			writer->flush();
 	}
 
 	/**

--- a/src/test/cpp/autoconfiguretestcase.cpp
+++ b/src/test/cpp/autoconfiguretestcase.cpp
@@ -158,9 +158,9 @@ public:
 		}
 		bbuf.flip();
 		helpers::FileOutputStream of(m_configFile, true);
-		of.write(bbuf, m_pool);
-		of.flush(m_pool);
-		of.close(m_pool);
+		of.write(bbuf);
+		of.flush();
+		of.close();
 
 		// wait 1.5 sec for the change to be noticed
 		apr_sleep(1500000);

--- a/src/test/cpp/filetestcase.cpp
+++ b/src/test/cpp/filetestcase.cpp
@@ -187,7 +187,7 @@ public:
 		Pool pool;
 		LogString greeting(LOG4CXX_STR("Hello, World"));
 		greeting.append(LOG4CXX_EOL);
-		osw->write(greeting, pool);
+		osw->write(greeting);
 
 		InputStreamPtr is = FileInputStreamPtr(
 				new FileInputStream(LOG4CXX_STR("output/fileWrite1.txt")));

--- a/src/test/cpp/qtconfigurationtest.cpp
+++ b/src/test/cpp/qtconfigurationtest.cpp
@@ -113,9 +113,9 @@ public:
 		bbuf.flip();
 		LOG4CXX_DECODE_QSTRING(lsConfigFile, m_configFile);
 		helpers::FileOutputStream of(lsConfigFile, true);
-		of.write(bbuf, m_pool);
-		of.flush(m_pool);
-		of.close(m_pool);
+		of.write(bbuf);
+		of.flush();
+		of.close();
 		helpers::LogLog::debug(LOG4CXX_STR("Updated ") + lsConfigFile);
 
 		// wait 0.1 sec for the change to be noticed

--- a/src/test/cpp/rolling/manualrollingtest.cpp
+++ b/src/test/cpp/rolling/manualrollingtest.cpp
@@ -73,7 +73,6 @@ public:
 	}
 
 	void common(RollingFileAppenderPtr & rfa,
-		Pool & pool,
 		LoggerPtr & logger1)
 	{
 		char msg[] = { 'H', 'e', 'l', 'l', 'o', '-', '-', '-', 'N', 0 };
@@ -126,8 +125,7 @@ public:
 		rfa->activateOptions();
 		root->addAppender(rfa);
 
-		Pool p;
-		common(rfa, p, logger);
+		common(rfa, logger);
 
 		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test1.0").exists());
 		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test1.1").exists());
@@ -155,8 +153,7 @@ public:
 		rfa->activateOptions();
 		root->addAppender(rfa);
 
-		Pool p;
-		common(rfa, p, logger);
+		common(rfa, logger);
 
 		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test2.log").exists());
 		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test2.log.1").exists());
@@ -185,13 +182,12 @@ public:
 		fwrp->setMinIndex(0);
 		rfa->setFile(LOG4CXX_STR("output/manual-test3.log"));
 		fwrp->setFileNamePattern(LOG4CXX_STR("output/sbr-test3.%i.gz"));
-		Pool p;
 		fwrp->activateOptions();
 		rfa->setRollingPolicy(fwrp);
 		rfa->activateOptions();
 		root->addAppender(rfa);
 
-		common(rfa, p, logger);
+		common(rfa, logger);
 
 		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test3.log").exists());
 		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test3.0.gz").exists());
@@ -222,14 +218,13 @@ public:
 		//   test4 directory should not exists.  Should cause all rollover attempts to fail.
 		//
 		swrp->setFileNamePattern(LOG4CXX_STR("output/test4/manual-test4.%i"));
-		Pool p;
 		swrp->activateOptions();
 
 		rfa->setRollingPolicy(swrp);
 		rfa->activateOptions();
 		root->addAppender(rfa);
 
-		common(rfa, p, logger);
+		common(rfa, logger);
 
 		LOGUNIT_ASSERT_EQUAL(true, File("output/manual-test4.log").exists());
 
@@ -263,16 +258,15 @@ public:
 
 		//
 		//   put stray file about locked file
-		Pool p;
 		FileOutputStream os1(LOG4CXX_STR("output/manual-test5.1"), false);
-		os1.close(p);
+		os1.close();
 
 
 		FileOutputStream os0(LOG4CXX_STR("output/manual-test5.0"), false);
 
-		common(rfa, p, logger);
+		common(rfa, logger);
 
-		os0.close(p);
+		os0.close();
 
 		if (File("output/manual-test5.3").exists())
 		{
@@ -339,9 +333,7 @@ public:
 		rfa->activateOptions();
 		root->addAppender(rfa);
 
-
-		Pool p;
-		common(rfa, p, logger);
+		common(rfa, logger);
 
 		LOGUNIT_ASSERT_EQUAL(true, File(filenamePatternPrefix + LOG4CXX_STR("/file-0.gz")).exists());
 		LOGUNIT_ASSERT_EQUAL(true, File(filenamePatternPrefix + LOG4CXX_STR("/file-1.gz")).exists());

--- a/src/test/cpp/rolling/sizebasedrollingtest.cpp
+++ b/src/test/cpp/rolling/sizebasedrollingtest.cpp
@@ -279,16 +279,15 @@ public:
 
 		//
 		//   put stray file about locked file
-		Pool p;
 		FileOutputStream os1(LOG4CXX_STR("output/sizeBased-test5.1"), false);
-		os1.close(p);
+		os1.close();
 
 
 		FileOutputStream os0(LOG4CXX_STR("output/sizeBased-test5.0"), false);
 
 		common(logger, 0);
 
-		os0.close(p);
+		os0.close();
 
 		if (File("output/sizeBased-test5.3").exists())
 		{

--- a/src/test/cpp/util/compare.cpp
+++ b/src/test/cpp/util/compare.cpp
@@ -145,7 +145,7 @@ void Compare::outputFile(const File& file,
 
 void Compare::emit(const LogString& s1)
 {
-	SystemOutWriter::write(s1);
+	SystemOutWriter().write(s1);
 }
 
 


### PR DESCRIPTION
This PR adds methods to the helpers::Writer and helpers::OutputStream interfaces that do not require a helpers::Pool parameter.

The objective is to avoid breaking client code that calls the methods with a helpers::Pool parameter.
