### PR TITLE
Simplify the helpers::Reader interface in a future ABI version

### DIFF
--- a/src/main/cpp/inputstreamreader.cpp
+++ b/src/main/cpp/inputstreamreader.cpp
@@ -65,15 +65,16 @@ InputStreamReader::~InputStreamReader()
 {
 }
 
-void InputStreamReader::close(Pool& )
+void InputStreamReader::close( LOG4CXX_CLOSE_READER_FORMAL_PARAMETERS )
 {
 	m_priv->in->close();
 }
 
-LogString InputStreamReader::read(Pool& p)
+LogString InputStreamReader::read( LOG4CXX_READ_READER_FORMAL_PARAMETERS )
 {
 	const size_t BUFSIZE = 4096;
-	ByteBuffer buf(p.pstralloc(BUFSIZE), BUFSIZE);
+	char stackStorage[BUFSIZE];
+	ByteBuffer buf(stackStorage, BUFSIZE);
 	LogString output;
 	log4cxx_status_t stat{ 0 };
 

--- a/src/main/cpp/properties.cpp
+++ b/src/main/cpp/properties.cpp
@@ -441,8 +441,7 @@ LogString Properties::get(const LogString& key) const
 
 void Properties::load(InputStreamPtr inStream)
 {
-	Pool pool;
-	auto contents = InputStreamReader(inStream, CharsetDecoder::getISOLatinDecoder()).read(pool);
+	auto contents = InputStreamReader(inStream, CharsetDecoder::getISOLatinDecoder()).read();
 	PropertyParser().parse(contents, *this);
 }
 

--- a/src/main/cpp/reader.cpp
+++ b/src/main/cpp/reader.cpp
@@ -17,7 +17,9 @@
 
 #include <log4cxx/logstring.h>
 #include <log4cxx/helpers/reader.h>
+#include <log4cxx/helpers/pool.h>
 
+using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
 
 IMPLEMENT_LOG4CXX_OBJECT(Reader)
@@ -29,3 +31,19 @@ Reader::Reader()
 Reader::~Reader()
 {
 }
+
+#if LOG4CXX_ABI_VERSION <= 15
+void Reader::close()
+{
+	Pool p;
+	close(p);
+}
+LogString Reader::read()
+{
+	Pool p;
+	return read(p);
+}
+#else
+void Reader::close(Pool&) { close(); }
+LogString Reader::read(Pool&) { return read(); }
+#endif

--- a/src/main/include/log4cxx/helpers/cacheddateformat.h
+++ b/src/main/include/log4cxx/helpers/cacheddateformat.h
@@ -149,9 +149,8 @@ class LOG4CXX_EXPORT CachedDateFormat : public helpers::DateFormat
 
 		/**
 		* Format an integer consistent with the format method.
-		* @param s string to which the numeric string is appended.
+		* @param toAppendTo string to which the numeric string is appended.
 		* @param n integer value.
-		* @param p memory pool used during formatting.
 		*/
 		void numberFormat( LOG4CXX_FORMAT_NUMBER_FORMAL_PARAMETERS ) const override;
 

--- a/src/main/include/log4cxx/helpers/dateformat.h
+++ b/src/main/include/log4cxx/helpers/dateformat.h
@@ -47,7 +47,6 @@ class LOG4CXX_EXPORT DateFormat : public Object
 		* Formats an log4cxx_time_t into a date/time string.
 		* @param toAppendTo string to which the date/time string is appended.
 		* @param tm date to be formatted.
-		* @param p memory pool used during formatting.
 		*/
 #if LOG4CXX_ABI_VERSION <= 15
 #define LOG4CXX_FORMAT_TIME_FORMAL_PARAMETERS LogString& toAppendTo, log4cxx_time_t tm, helpers::Pool& p

--- a/src/main/include/log4cxx/helpers/inputstreamreader.h
+++ b/src/main/include/log4cxx/helpers/inputstreamreader.h
@@ -66,18 +66,17 @@ class LOG4CXX_EXPORT InputStreamReader : public Reader
 
 		~InputStreamReader();
 
+		using Reader::close;
 		/**
-		 * Closes the stream.
-		 *
-		 * @param p The memory pool associated with the reader.
+		 * Close the stream.
 		 */
-		void close(Pool& p) override;
+		void close( LOG4CXX_CLOSE_READER_FORMAL_PARAMETERS ) override;
 
+		using Reader::read;
 		/**
 		 * @return The complete stream contents as a LogString.
-		 * @param p The memory pool associated with the reader.
 		 */
-		LogString read(Pool& p) override;
+		LogString read( LOG4CXX_READ_READER_FORMAL_PARAMETERS ) override;
 
 		/**
 		 * @return The name of the character encoding being used by this stream.

--- a/src/main/include/log4cxx/helpers/reader.h
+++ b/src/main/include/log4cxx/helpers/reader.h
@@ -66,7 +66,7 @@ class LOG4CXX_EXPORT Reader : public Object
 #define LOG4CXX_CLOSE_READER_FORMAL_PARAMETERS helpers::Pool& p
 		/**
 		@deprecated The \c pool parameter is not used and will be removed in a future version.
-		Implement this method for now, but plan to migrate to close() without a helpers::Pool parameter.
+		Implement this method for now, but plan to migrate to read() without a helpers::Pool parameter.
 		*/
 		virtual LogString read(Pool& p) = 0;
 #define LOG4CXX_READ_READER_FORMAL_PARAMETERS helpers::Pool& p

--- a/src/main/include/log4cxx/helpers/reader.h
+++ b/src/main/include/log4cxx/helpers/reader.h
@@ -47,17 +47,52 @@ class LOG4CXX_EXPORT Reader : public Object
 		virtual ~Reader();
 
 	public:
+#if LOG4CXX_ABI_VERSION <= 15
 		/**
 		 * Closes the stream.
-		 * @param p The memory pool associated with the reader.
 		 */
-		virtual void close(Pool& p) = 0;
+		void close();
 
 		/**
 		 * @return The complete stream contents as a LogString.
-		 * @param p The memory pool associated with the reader.
 		 */
+		LogString read();
+
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to close() without a helpers::Pool parameter.
+		*/
+		virtual void close(Pool& p) = 0;
+#define LOG4CXX_CLOSE_READER_FORMAL_PARAMETERS helpers::Pool& p
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		Implement this method for now, but plan to migrate to close() without a helpers::Pool parameter.
+		*/
 		virtual LogString read(Pool& p) = 0;
+#define LOG4CXX_READ_READER_FORMAL_PARAMETERS helpers::Pool& p
+#else
+		/**
+		 * Closes the stream.
+		 */
+		virtual void close() = 0;
+#define LOG4CXX_CLOSE_READER_FORMAL_PARAMETERS
+
+		/**
+		 * @return The complete stream contents as a LogString.
+		 */
+		virtual LogString read() = 0;
+#define LOG4CXX_READ_READER_FORMAL_PARAMETERS
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use close() without a Pool parameter instead")]]
+		void close(Pool& p);
+		/**
+		@deprecated The \c pool parameter is not used and will be removed in a future version.
+		*/
+		[[deprecated("Use read() without a Pool parameter instead")]]
+		LogString read(Pool& p);
+#endif
 
 	private:
 		Reader(const Reader&);

--- a/src/site/doxy/Doxyfile.in
+++ b/src/site/doxy/Doxyfile.in
@@ -2362,6 +2362,14 @@ PREDEFINED             = LOG4CXX_NS=log4cxx \
                          LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS="LogString& output, const spi::LoggingEventPtr& event, helpers::Pool& p" \
                          LOG4CXX_APPEND_HEADER_FORMAL_PARAMETERS="LogString& output, LOG4CXX_NS::helpers::Pool& p" \
                          LOG4CXX_APPEND_FOOTER_FORMAL_PARAMETERS="LogString& output, LOG4CXX_NS::helpers::Pool& p" \
+                         LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS="helpers::Pool& p" \
+                         LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS="helpers::Pool& p" \
+                         LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS="const LogString& str, helpers::Pool& p" \
+                         LOG4CXX_CLOSE_OUTPUT_STREAM_FORMAL_PARAMETERS="helpers::Pool& p" \
+                         LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS="helpers::Pool& p" \
+                         LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS="ByteBuffer& buf, helpers::Pool& p" \
+                         LOG4CXX_CLOSE_READER_FORMAL_PARAMETERS="helpers::Pool& p" \
+                         LOG4CXX_READ_READER_FORMAL_PARAMETERS="helpers::Pool& p" \
                          LOG4CXX_HAS_DOMCONFIGURATOR=1 \
                          LOG4CXX_ASYNC_BUFFER_SUPPORTS_FMT=1 \
                          __LOG4CXX_FUNC__=compiler_dependent

--- a/src/test/cpp/decodingtest.cpp
+++ b/src/test/cpp/decodingtest.cpp
@@ -203,12 +203,11 @@ private:
 		LogString         lsContent;
 		std::wstring      wsContent;
 		LogString         path(LOG4CXX_STR("input/decoding/") + fileName);
-		Pool              pool;
 
 		FileInputStreamPtr   fis(     new FileInputStream(path));
 		InputStreamReaderPtr isReader(new InputStreamReader(fis, decoder));
 
-		lsContent.assign(isReader->read(pool));
+		lsContent.assign(isReader->read());
 		Transcoder::encode(lsContent, wsContent);
 
 		LOGUNIT_ASSERT_EQUAL((std::wstring) witness, wsContent);

--- a/src/test/cpp/filetestcase.cpp
+++ b/src/test/cpp/filetestcase.cpp
@@ -94,13 +94,12 @@ public:
 	void defaultRead()
 	{
 		File defFile;
-		Pool pool;
 
 		try
 		{
 			InputStreamPtr defInput = FileInputStreamPtr(new FileInputStream(defFile));
 			InputStreamReaderPtr inputReader = InputStreamReaderPtr(new InputStreamReader(defInput));
-			LogString contents(inputReader->read(pool));
+			LogString contents(inputReader->read());
 			LOGUNIT_ASSERT(false);
 		}
 		catch (IOException& ex)
@@ -128,8 +127,7 @@ public:
 				'p', 'r', 'o', 'p', 'e', 'r', 't', 'i', 'e', 's', 0
 			};
 		File propFile(filename);
-		Pool pool;
-		bool exists = propFile.exists(pool);
+		bool exists = propFile.exists();
 		LOGUNIT_ASSERT_EQUAL(true, exists);
 	}
 #endif
@@ -138,8 +136,7 @@ public:
 	void cfstringConstructor()
 	{
 		File propFile(CFSTR("input/patternLayout1.properties"));
-		Pool pool;
-		bool exists = propFile.exists(pool);
+		bool exists = propFile.exists();
 		LOGUNIT_ASSERT_EQUAL(true, exists);
 	}
 #endif
@@ -163,10 +160,9 @@ public:
 	void propertyRead()
 	{
 		File propFile("input/patternLayout1.properties");
-		Pool pool;
 		InputStreamPtr propStream = FileInputStreamPtr(new FileInputStream(propFile));
 		InputStreamReaderPtr propReader = InputStreamReaderPtr(new InputStreamReader(propStream));
-		LogString props(propReader->read(pool));
+		LogString props(propReader->read());
 		LogString line1(LOG4CXX_STR("# Licensed to the Apache Software Foundation (ASF) under one or more"));
 		LOGUNIT_ASSERT_EQUAL(line1, props.substr(0, line1.length()));
 	}
@@ -184,7 +180,6 @@ public:
 				new FileOutputStream(LOG4CXX_STR("output/fileWrite1.txt")));
 		OutputStreamWriterPtr osw = OutputStreamWriterPtr(new OutputStreamWriter(fos));
 
-		Pool pool;
 		LogString greeting(LOG4CXX_STR("Hello, World"));
 		greeting.append(LOG4CXX_EOL);
 		osw->write(greeting);
@@ -192,7 +187,7 @@ public:
 		InputStreamPtr is = FileInputStreamPtr(
 				new FileInputStream(LOG4CXX_STR("output/fileWrite1.txt")));
 		InputStreamReaderPtr isr = InputStreamReaderPtr(new InputStreamReader(is));
-		LogString reply = isr->read(pool);
+		LogString reply = isr->read();
 
 		LOGUNIT_ASSERT_EQUAL(greeting, reply);
 	}
@@ -235,13 +230,12 @@ public:
 	 */
 	void testSplitMultibyteUtf8()
 	{
-		Pool p;
 		// InputStreamReader uses a buffer of size 4096
 		std::string input( 4094, 'A' );
 		// räksmörgås.josefsson.org
 		input.append("\162\303\244\153\163\155\303\266\162\147\303\245\163\056\152\157\163\145\146\163\163\157\156\056\157\162\147");
 		InputStreamReader reader(std::make_shared<MockInputStream>(input.c_str(), input.size()), CharsetDecoder::getUTF8Decoder());
-		auto contentLS = reader.read(p);
+		auto contentLS = reader.read();
 		LOG4CXX_ENCODE_CHAR(content, contentLS);
 		LOGUNIT_ASSERT_EQUAL(input, content);
 	}
@@ -251,13 +245,12 @@ public:
 	 */
 	void testInvalidUtf8()
 	{
-		Pool p;
 		// 0xC2 is a generic start byte for a 2-byte sequence in UTF-8.
 		char input[] = { 'A', (char)0xC2, 'B', 'C', 0 };
 		InputStreamReader reader(std::make_shared<MockInputStream>(input, 4), CharsetDecoder::getUTF8Decoder());
 		try
 		{
-			reader.read(p);
+			reader.read();
 			LOGUNIT_ASSERT(false);
 		}
 		catch (const Exception& ex)

--- a/src/test/cpp/util/compare.cpp
+++ b/src/test/cpp/util/compare.cpp
@@ -28,15 +28,13 @@ using namespace log4cxx::helpers;
 
 bool Compare::compare(const File& file1, const File& file2)
 {
-	Pool pool;
 	InputStreamPtr fileIn1 = InputStreamPtr( new FileInputStream(file1) );
 	InputStreamReaderPtr reader1 = InputStreamReaderPtr( new InputStreamReader(fileIn1) );
-	LogString in1(reader1->read(pool));
+	LogString in1(reader1->read());
 
-	Pool pool2;
 	InputStreamPtr fileIn2 = InputStreamPtr( new FileInputStream(file2) );
 	InputStreamReaderPtr reader2 = InputStreamReaderPtr( new InputStreamReader(fileIn2) );
-	LogString in2(reader2->read(pool2));
+	LogString in2(reader2->read());
 
 	LogString back1(in1);
 	LogString back2(in2);
@@ -73,8 +71,8 @@ bool Compare::compare(const File& file1, const File& file2)
 			msg += LOG4CXX_EOL;
 			emit(msg);
 
-			outputFile(file1, back1, pool);
-			outputFile(file2, back2, pool);
+			outputFile(file1, back1);
+			outputFile(file2, back2	);
 
 			return false;
 		}
@@ -90,8 +88,8 @@ bool Compare::compare(const File& file1, const File& file2)
 		msg += LOG4CXX_STR("].");
 		msg += LOG4CXX_EOL;
 		emit(msg);
-		outputFile(file1, back1, pool);
-		outputFile(file2, back2, pool);
+		outputFile(file1, back1);
+		outputFile(file2, back2);
 
 		return false;
 	}
@@ -100,8 +98,7 @@ bool Compare::compare(const File& file1, const File& file2)
 }
 
 void Compare::outputFile(const File& file,
-	const LogString& contents,
-	log4cxx::helpers::Pool& pool)
+	const LogString& contents)
 {
 	int lineCounter = 0;
 	emit(LOG4CXX_STR("--------------------------------"));

--- a/src/test/cpp/util/compare.h
+++ b/src/test/cpp/util/compare.h
@@ -34,8 +34,7 @@ class Compare
 	private:
 		/// Prints file on the console.
 		static void outputFile(const File& file,
-			const LogString& contents,
-			log4cxx::helpers::Pool& pool);
+			const LogString& contents);
 
 		static void emit(const LogString& line);
 		static bool getline(LogString& buf, LogString& line);


### PR DESCRIPTION
This PR adds methods to the helpers::Reader interface that do not require a helpers::Pool parameter.

The objective is to avoid breaking client code that calls the methods with a helpers::Pool parameter.