### PR TITLE
CyclicBuffer validation ordering and resize wraparound handling

### DIFF
--- a/src/main/cpp/cyclicbuffer.cpp
+++ b/src/main/cpp/cyclicbuffer.cpp
@@ -25,6 +25,22 @@ using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
 using namespace LOG4CXX_NS::spi;
 
+namespace
+{
+int validateMaxSize(int maxSize)
+{
+	if (maxSize < 1)
+	{
+		LogString msg(LOG4CXX_STR("The maxSize argument ("));
+		StringHelper::toString(maxSize, msg);
+		msg.append(LOG4CXX_STR(") is not a positive integer."));
+		throw IllegalArgumentException(msg);
+	}
+
+	return maxSize;
+}
+}
+
 struct CyclicBuffer::CyclicBufferPriv
 {
 	CyclicBufferPriv(int maxSize1) :
@@ -43,15 +59,8 @@ The <code>maxSize</code> argument must a positive integer.
 @param maxSize The maximum number of elements in the buffer.
 */
 CyclicBuffer::CyclicBuffer(int maxSize1)
-	: m_priv(std::make_unique<CyclicBufferPriv>(maxSize1))
+	: m_priv(std::make_unique<CyclicBufferPriv>(validateMaxSize(maxSize1)))
 {
-	if (maxSize1 < 1)
-	{
-		LogString msg(LOG4CXX_STR("The maxSize argument ("));
-		StringHelper::toString(maxSize1, msg);
-		msg.append(LOG4CXX_STR(") is not a positive integer."));
-		throw IllegalArgumentException(msg);
-	}
 }
 
 CyclicBuffer::~CyclicBuffer()
@@ -153,7 +162,7 @@ void CyclicBuffer::resize(int newSize)
 		temp[i] = m_priv->ea[m_priv->first];
 		m_priv->ea[m_priv->first] = 0;
 
-		if (++m_priv->first == m_priv->numElems)
+		if (++m_priv->first == m_priv->maxSize)
 		{
 			m_priv->first = 0;
 		}

--- a/src/test/cpp/helpers/cyclicbuffertestcase.cpp
+++ b/src/test/cpp/helpers/cyclicbuffertestcase.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <log4cxx/helpers/cyclicbuffer.h>
+#include <log4cxx/helpers/exception.h>
 #include "../logunit.h"
 
 #include <log4cxx/logmanager.h>
@@ -36,6 +37,8 @@ LOGUNIT_CLASS(CyclicBufferTestCase)
 	LOGUNIT_TEST(test0);
 	LOGUNIT_TEST(test1);
 	LOGUNIT_TEST(testResize);
+	LOGUNIT_TEST_EXCEPTION(testNegativeSizeRejectedBeforeAllocation, IllegalArgumentException);
+	LOGUNIT_TEST(testResizeAfterReadPreservesOrder);
 	LOGUNIT_TEST_SUITE_END();
 
 	LoggerPtr logger;
@@ -166,6 +169,28 @@ public:
 		{
 			LOGUNIT_ASSERT_EQUAL(e[offset + j], cb.get(j));
 		}
+	}
+
+	void testNegativeSizeRejectedBeforeAllocation()
+	{
+		CyclicBuffer cb(-1);
+	}
+
+	void testResizeAfterReadPreservesOrder()
+	{
+		CyclicBuffer cb(5);
+		cb.add(e[0]);
+		cb.add(e[1]);
+		cb.add(e[2]); // first=0, numElems=3
+
+		LOGUNIT_ASSERT_EQUAL(e[0], cb.get()); // first=1, numElems=2
+
+		cb.resize(4);
+
+		LOGUNIT_ASSERT_EQUAL(2, cb.length());
+		LOGUNIT_ASSERT_EQUAL(e[1], cb.get());
+		LOGUNIT_ASSERT_EQUAL(e[2], cb.get());
+		LOGUNIT_ASSERT(cb.get() == 0);
 	}
 };
 


### PR DESCRIPTION
## Summary

This patch fixes two issues in `CyclicBuffer`:

* Validate `maxSize` before constructing the backing storage to prevent invalid negative sizes from reaching the internal allocation path.
* Fix wraparound handling in `CyclicBuffer::resize()` by wrapping `first` against `maxSize` instead of `numElems`.

## Tests

Added regression coverage for:

* negative size validation before allocation
* preserving event order when resizing a partially consumed buffer

Verified that the new resize test fails on unpatched behavior and passes with this change.
