### PR TITLE
Normalize invalid SMTPAppender buffer sizes

### DIFF
--- a/src/main/cpp/smtpappender.cpp
+++ b/src/main/cpp/smtpappender.cpp
@@ -787,6 +787,11 @@ buffer. By default the size of the cyclic buffer is 512 events.
 */
 void SMTPAppender::setBufferSize(int sz)
 {
+	if (sz < 1)
+	{
+		sz = 1;
+	}
+
 	_priv->bufferSize = sz;
 	_priv->cb.resize(sz);
 }

--- a/src/test/cpp/net/smtpappendertestcase.cpp
+++ b/src/test/cpp/net/smtpappendertestcase.cpp
@@ -75,6 +75,7 @@ class SMTPAppenderTestCase : public AppenderSkeletonTestCase
 		LOGUNIT_TEST(testSetOptionThreshold);
 		LOGUNIT_TEST(testTrigger);
 		LOGUNIT_TEST(testInvalid);
+		LOGUNIT_TEST(testNegativeBufferSizeOption);
 //#define LOG4CXX_TEST_EMAIL_AND_SMTP_HOST_ARE_IN_ENVIRONMENT_VARIABLES
 #ifdef LOG4CXX_TEST_EMAIL_AND_SMTP_HOST_ARE_IN_ENVIRONMENT_VARIABLES
 		// This test requires the following environment variables:
@@ -133,6 +134,12 @@ class SMTPAppenderTestCase : public AppenderSkeletonTestCase
 			LOGUNIT_ASSERT(eh->errorReported());
 		}
 
+		void testNegativeBufferSizeOption()
+		{
+			SMTPAppender appender;
+			appender.setOption(LOG4CXX_STR("BUFFERSIZE"), LOG4CXX_STR("-10"));
+			LOGUNIT_ASSERT_EQUAL(1, appender.getBufferSize());
+		}
 
 		void testValid()
 		{


### PR DESCRIPTION
## Summary

Normalize invalid `SMTPAppender` buffer sizes to a minimum value of `1` in `setBufferSize()`.

This prevents invalid non-positive values from placing the internal cyclic buffer into an invalid state during configuration parsing.

## Tests

Added regression coverage for negative `BUFFERSIZE` configuration values.
