### PR TITLE
Reject malformed MaxConnections values in TelnetAppender configuration

### DIFF
--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -278,7 +278,18 @@ int OptionConverter::toInt(const LogString& value, int dEfault)
 
 	LOG4CXX_ENCODE_CHAR(cvalue, trimmed);
 
-	return (int) atol(cvalue.c_str());
+	char* endptr = nullptr;
+	errno = 0;
+	long long parsed = strtoll(cvalue.c_str(), &endptr, 10);
+
+	if (endptr == cvalue.c_str() || *endptr != '\0' || errno == ERANGE ||
+		parsed < (std::numeric_limits<int>::min)() ||
+		parsed > (std::numeric_limits<int>::max)())
+	{
+		return dEfault;
+	}
+
+	return static_cast<int>(parsed);
 }
 
 long OptionConverter::toFileSize(const LogString& s, long dEfault)

--- a/src/main/cpp/telnetappender.cpp
+++ b/src/main/cpp/telnetappender.cpp
@@ -429,10 +429,17 @@ int TelnetAppender::getMaxConnections() const
 
 void TelnetAppender::setMaxConnections(int newValue)
 {
+	if (newValue < 0)
+	{
+		LogLog::warn(LOG4CXX_STR("TelnetAppender MaxConnections must be non-negative. Keeping the previous value."));
+		return;
+	}
+
 	std::lock_guard<std::recursive_mutex> lock(_priv->mutex);
-	if (_priv->connections.size() < newValue)
-		_priv->connections.resize(newValue);
-	else while (newValue < _priv->connections.size())
+	const size_t newSize = static_cast<size_t>(newValue);
+	if (_priv->connections.size() < newSize)
+		_priv->connections.resize(newSize);
+	else while (newSize < _priv->connections.size())
 	{
 		auto item = _priv->connections.back();
 		_priv->connections.pop_back();

--- a/src/test/cpp/helpers/optionconvertertestcase.cpp
+++ b/src/test/cpp/helpers/optionconvertertestcase.cpp
@@ -29,6 +29,7 @@
 #include <apr_file_io.h>
 #include <apr_user.h>
 #include <apr_env.h>
+#include <limits>
 
 
 using namespace log4cxx;
@@ -46,6 +47,8 @@ LOGUNIT_CLASS(OptionConverterTestCase)
 	LOGUNIT_TEST(varSubstTest4);
 	LOGUNIT_TEST(varSubstTest5);
 	LOGUNIT_TEST(varSubstRecursiveReferenceTest);
+	LOGUNIT_TEST(toIntReturnsDefaultOnOverflow);
+	LOGUNIT_TEST(toIntReturnsDefaultOnMalformedInput);
 	LOGUNIT_TEST(testTmpDir);
 #if APR_HAS_USER
 	LOGUNIT_TEST(testUserHome);
@@ -161,6 +164,24 @@ public:
 			LOG4CXX_DECODE_CHAR(lsMsg, ex.what());
 			LogLog::debug(lsMsg);
 		}
+	}
+
+	void toIntReturnsDefaultOnOverflow()
+	{
+		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR("9999999999999999999999"), 7));
+		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR("-9999999999999999999999"), 7));
+		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR("2147483648"), 7));
+		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR("-2147483649"), 7));
+	}
+
+	void toIntReturnsDefaultOnMalformedInput()
+	{
+		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR("not-a-number"), 7));
+		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR("123abc"), 7));
+		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR("42xyz"), 7));
+		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR(""), 7));
+		LOGUNIT_ASSERT_EQUAL((std::numeric_limits<int>::max)(), OptionConverter::toInt(LOG4CXX_STR("2147483647"), 7));
+		LOGUNIT_ASSERT_EQUAL((std::numeric_limits<int>::min)(), OptionConverter::toInt(LOG4CXX_STR("-2147483648"), 7));
 	}
 
 	void testTmpDir()

--- a/src/test/cpp/net/telnetappendertestcase.cpp
+++ b/src/test/cpp/net/telnetappendertestcase.cpp
@@ -24,6 +24,8 @@
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/loglog.h>
 #include <log4cxx/helpers/fileoutputstream.h>
+#include <log4cxx/helpers/pool.h>
+#include <log4cxx/config/propertysetter.h>
 #include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/helpers/socket.h>
 #include <log4cxx/spi/configurator.h>
@@ -50,6 +52,7 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 		LOGUNIT_TEST(testActivateWriteClose);
 		LOGUNIT_TEST(testConnectNoRead);
 		LOGUNIT_TEST(testActivateWriteNoClose);
+		LOGUNIT_TEST(testInvalidMaxConnectionsOptionFallsBack);
 
 		LOGUNIT_TEST_SUITE_END();
 
@@ -133,6 +136,21 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 #endif
 				LOG4CXX_INFO(root, "Hello, World " << i);
 			}
+		}
+
+		void testInvalidMaxConnectionsOptionFallsBack()
+		{
+			Pool p;
+			auto appender = std::make_shared<TelnetAppender>();
+			config::PropertySetter setter(appender);
+			setter.setProperty(LOG4CXX_STR("MaxConnections"), LOG4CXX_STR("9999999999999999999999"), p);
+			LOGUNIT_ASSERT_EQUAL(20, appender->getMaxConnections());
+
+			setter.setProperty(LOG4CXX_STR("MaxConnections"), LOG4CXX_STR("-2147483649"), p);
+			LOGUNIT_ASSERT_EQUAL(20, appender->getMaxConnections());
+
+			setter.setProperty(LOG4CXX_STR("MaxConnections"), LOG4CXX_STR("16"), p);
+			LOGUNIT_ASSERT_EQUAL(16, appender->getMaxConnections());
 		}
 
 		void testConnectNoRead()


### PR DESCRIPTION
## Summary

This patch hardens integer configuration parsing for `TelnetAppender` by rejecting malformed and out-of-range numeric values before they reach allocation-sensitive logic.

Previously, `OptionConverter::toInt()` relied on `atol()` narrowing behavior, which could silently accept overflowed, underflowed, or partially parsed values.

## Changes

* replace `atol()` narrowing in `OptionConverter::toInt()` with bounded `strtoll()` parsing
* reject:

  * overflow values
  * underflow values
  * empty input
  * partial numeric parses
* preserve valid integer parsing behavior
* reject negative `MaxConnections` values before resize logic
* remove signed/unsigned resize comparison hazards in `TelnetAppender`

## Tests

Added regression coverage for:

* malformed numeric input rejection
* overflow and underflow handling
* valid integer boundary parsing
* `TelnetAppender` configuration fallback behavior