### PR TITLE
Bound multiprocess map-file filename reads

### DIFF
--- a/src/main/cpp/timebasedrollingpolicy.cpp
+++ b/src/main/cpp/timebasedrollingpolicy.cpp
@@ -29,6 +29,7 @@
 #include <log4cxx/helpers/optionconverter.h>
 #include <log4cxx/helpers/transcoder.h>
 #include <log4cxx/fileappender.h>
+#include <algorithm>
 #include <iostream>
 #include <apr_mmap.h>
 
@@ -121,6 +122,29 @@ struct TimeBasedRollingPolicy::TimeBasedRollingPolicyPrivate{
 #define MAX_FILE_LEN 2048
 
 #if LOG4CXX_HAS_MULTIPROCESS_ROLLING_FILE_APPENDER
+namespace
+{
+LogString readMappedFileName(apr_mmap_t* mmap)
+{
+	if (!mmap || !mmap->mm)
+	{
+		return LogString();
+	}
+
+	const auto* first = static_cast<const logchar*>(mmap->mm);
+	const auto* last = first + (MAX_FILE_LEN / sizeof(logchar));
+	const auto* terminator = std::find(first, last, logchar(0));
+
+	if (terminator == last)
+	{
+		LogLog::warn(LOG4CXX_STR("Ignoring invalid multiprocess rolling map file: missing string terminator"));
+		return LogString();
+	}
+
+	return LogString(first, terminator);
+}
+}
+
 bool TimeBasedRollingPolicy::isMapFileEmpty(LOG4CXX_NS::helpers::Pool& pool)
 {
 	apr_finfo_t finfo;
@@ -406,9 +430,10 @@ RolloverDescriptionPtr TimeBasedRollingPolicy::rollover(
 		if (m_priv->_mmap && !isMapFileEmpty(m_priv->_mmapPool))
 		{
 			lockMMapFile(APR_FLOCK_SHARED);
-			LogString mapLastFile(static_cast<logchar*>(m_priv->_mmap->mm));
-			m_priv->lastFileName = mapLastFile;
+			LogString mapLastFile(readMappedFileName(m_priv->_mmap));
 			unLockMMapFile();
+			if (!mapLastFile.empty())
+				m_priv->lastFileName = mapLastFile;
 		}
 		else
 		{
@@ -508,14 +533,18 @@ bool TimeBasedRollingPolicy::isTriggeringEvent(
 		if (m_priv->bRefreshCurFile && m_priv->_mmap && !isMapFileEmpty(m_priv->_mmapPool))
 		{
 			lockMMapFile(APR_FLOCK_SHARED);
-			LogString mapCurrent(static_cast<logchar*>(m_priv->_mmap->mm));
+			LogString mapCurrent(readMappedFileName(m_priv->_mmap));
 			unLockMMapFile();
-			LogString mapCurrentBase(mapCurrent.substr(0, mapCurrent.length() - m_priv->suffixLength));
 
-			if (!mapCurrentBase.empty() && mapCurrentBase != filename)
+			if (!mapCurrent.empty() && static_cast<size_t>(m_priv->suffixLength) <= mapCurrent.length())
 			{
-				if (auto fappend = dynamic_cast<FileAppender*>(appender))
-					fappend->setFile(mapCurrentBase);
+				LogString mapCurrentBase(mapCurrent.substr(0, mapCurrent.length() - m_priv->suffixLength));
+
+				if (!mapCurrentBase.empty() && mapCurrentBase != filename)
+				{
+					if (auto fappend = dynamic_cast<FileAppender*>(appender))
+						fappend->setFile(mapCurrentBase);
+				}
 			}
 		}
 
@@ -559,7 +588,7 @@ bool TimeBasedRollingPolicy::isLastFileNameUnchanged()
 		if (m_priv->_mmap)
 		{
 			lockMMapFile(APR_FLOCK_SHARED);
-			LogString mapCurrent(static_cast<logchar*>(m_priv->_mmap->mm));
+			LogString mapCurrent(readMappedFileName(m_priv->_mmap));
 			unLockMMapFile();
 			result = (mapCurrent == m_priv->lastFileName);
 		}
@@ -578,7 +607,7 @@ void TimeBasedRollingPolicy::loadLastFileName()
 		if (m_priv->_mmap)
 		{
 			lockMMapFile(APR_FLOCK_SHARED);
-			LogString mapLastFile(static_cast<logchar*>(m_priv->_mmap->mm));
+			LogString mapLastFile(readMappedFileName(m_priv->_mmap));
 			unLockMMapFile();
 			if (!mapLastFile.empty())
 				m_priv->lastFileName = mapLastFile;

--- a/src/test/cpp/rolling/timebasedrollingtest.cpp
+++ b/src/test/cpp/rolling/timebasedrollingtest.cpp
@@ -31,8 +31,12 @@
 #include "../util/compare.h"
 #include "../logunit.h"
 
+#include <fstream>
 #include <apr_strings.h>
 #include <apr_time.h>
+#if LOG4CXX_HAS_MULTIPROCESS_ROLLING_FILE_APPENDER
+#include <apr_user.h>
+#endif
 #include <random>
 #ifndef INT64_C
 	#define INT64_C(x) x ## LL
@@ -83,6 +87,9 @@ LOGUNIT_CLASS(TimeBasedRollingTest)
 	LOGUNIT_TEST(test6);
 	LOGUNIT_TEST(test7);
 	LOGUNIT_TEST(rollIntoDir);
+#if LOG4CXX_HAS_MULTIPROCESS_ROLLING_FILE_APPENDER
+	LOGUNIT_TEST(unterminatedMultiprocessMapFile);
+#endif
 	LOGUNIT_TEST_SUITE_END();
 
 private:
@@ -683,6 +690,59 @@ public:
 		this->logMsgAndSleep(	pool, nrOfLogMsgs, __LOG4CXX_FUNC__, __LINE__);
 		this->checkFilesExist(	pool, LOG4CXX_STR("test6."), fnames, 0, __LINE__);
 	}
+
+#if LOG4CXX_HAS_MULTIPROCESS_ROLLING_FILE_APPENDER
+	void unterminatedMultiprocessMapFile()
+	{
+		Pool pool;
+		char uidBuffer[64] = "0000";
+#ifndef _WIN32
+		apr_uid_t uid;
+		apr_gid_t groupid;
+		if (APR_SUCCESS == apr_uid_current(&uid, &groupid, pool.getAPRPool()))
+			apr_snprintf(uidBuffer, sizeof(uidBuffer), "%u", uid);
+#endif
+		std::string mapFile("output/rolling/tbr-map-corrupt-");
+		mapFile += uidBuffer;
+		mapFile += ".map";
+		std::string lockFile("output/rolling/tbr-map-corrupt-");
+		lockFile += uidBuffer;
+		lockFile += ".maplck";
+
+		File("output/rolling").mkdirs();
+		File(mapFile).deleteFile();
+		File(lockFile).deleteFile();
+
+		std::ofstream corruptMap(mapFile, std::ios::binary | std::ios::trunc);
+		LOGUNIT_ASSERT(corruptMap.is_open());
+		std::string unterminatedMap(4096, 'x');
+		corruptMap.write(unterminatedMap.data(), unterminatedMap.size());
+		corruptMap.close();
+
+		PatternLayoutPtr layout(new PatternLayout(PATTERN_LAYOUT));
+		RollingFileAppenderPtr rfa(new RollingFileAppender());
+		rfa->setAppend(false);
+		rfa->setLayout(layout);
+		rfa->setFile(LOG4CXX_STR("output/rolling/tbr-map-corrupt.log"));
+
+		TimeBasedRollingPolicyPtr tbrp(new TimeBasedRollingPolicy());
+		tbrp->setMultiprocess(true);
+		tbrp->setFileNamePattern(LOG4CXX_STR("output/rolling/tbr-map-corrupt-%d{" DATE_PATTERN "}"));
+		tbrp->activateOptions();
+		rfa->setRollingPolicy(tbrp);
+		rfa->activateOptions();
+		logger->addAppender(rfa);
+
+		this->delayUntilNextSecond();
+		LOG4CXX_DEBUG(logger, "roll despite corrupt map");
+		LOGUNIT_ASSERT(File("output/rolling/tbr-map-corrupt.log").exists());
+
+		logger->removeAppender(rfa);
+		rfa->close();
+		File(mapFile).deleteFile();
+		File(lockFile).deleteFile();
+	}
+#endif
 
 };
 


### PR DESCRIPTION
## Summary
Bound multiprocess map-file filename reads to avoid constructing `LogString` from unterminated mmap-backed data.

## What changed
- Added a bounded helper for reading mmap-backed filenames.
- Replaced direct `LogString(const logchar*)` construction from raw mapped memory.
- Reject invalid map contents that do not contain a string terminator within the mapped region.
- Added validation before subtracting `suffixLength` from mapped filename length.
- Added a regression test covering corrupt non-NUL-terminated `.map` contents.

## Why
The previous code assumed mmap-backed shared-state strings were always NUL-terminated and constructed `LogString` directly from raw mapped memory. Corrupt or malformed `.map` contents could cause unbounded string scanning past the mapped payload.

The new logic bounds the scan to the mapped filename region and safely ignores invalid shared-state contents.