### PR TITLE
Harden OptionConverter::toFileSize input validation

### DIFF
--- a/src/main/cpp/optionconverter.cpp
+++ b/src/main/cpp/optionconverter.cpp
@@ -21,6 +21,7 @@
 #include <log4cxx/appenderskeleton.h>
 #include <log4cxx/helpers/optionconverter.h>
 #include <algorithm>
+#include <cctype>
 #include <ctype.h>
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/exception.h>
@@ -49,6 +50,14 @@
 namespace
 {
 using namespace LOG4CXX_NS;
+
+void skipWhitespace(char*& p)
+{
+	while (std::isspace(static_cast<unsigned char>(*p)))
+	{
+		++p;
+	}
+}
 
 /// For recursion checking
 struct LogStringChain
@@ -300,30 +309,8 @@ long OptionConverter::toFileSize(const LogString& s, long dEfault)
 		return dEfault;
 	}
 
-	size_t index = trimmed.find_first_of(LOG4CXX_STR("bB"));
-
 	long long multiplier = 1;
-	LogString numericPart = trimmed;
-	if (index != LogString::npos && index > 0)
-	{
-		size_t suffixIndex = index - 1;
-		if (trimmed[suffixIndex] == 0x6B /* 'k' */ || trimmed[suffixIndex] == 0x4B /* 'K' */)
-		{
-			multiplier = 1024;
-		}
-		else if (trimmed[suffixIndex] == 0x6D /* 'm' */ || trimmed[suffixIndex] == 0x4D /* 'M' */)
-		{
-			multiplier = 1024 * 1024;
-		}
-		else if (trimmed[suffixIndex] == 0x67 /* 'g'*/ || trimmed[suffixIndex] == 0x47 /* 'G' */)
-		{
-			multiplier = 1024 * 1024 * 1024;
-		}
-
-		numericPart = trimmed.substr(0, suffixIndex);
-	}
-
-	LOG4CXX_ENCODE_CHAR(cvalue, numericPart);
+	LOG4CXX_ENCODE_CHAR(cvalue, trimmed);
 	char* endptr;
 	errno = 0;
 	long long parsed = strtoll(cvalue.c_str(), &endptr, 10);
@@ -331,6 +318,38 @@ long OptionConverter::toFileSize(const LogString& s, long dEfault)
 	if (endptr == cvalue.c_str() || errno == ERANGE || parsed < 0)
 	{
 		return dEfault;
+	}
+
+	skipWhitespace(endptr);
+	if (*endptr != '\0')
+	{
+		const char unit = static_cast<char>(std::toupper(static_cast<unsigned char>(*endptr)));
+		if (unit == 'K')
+		{
+			multiplier = 1024;
+			++endptr;
+		}
+		else if (unit == 'M')
+		{
+			multiplier = 1024 * 1024;
+			++endptr;
+		}
+		else if (unit == 'G')
+		{
+			multiplier = 1024 * 1024 * 1024;
+			++endptr;
+		}
+
+		if (static_cast<char>(std::toupper(static_cast<unsigned char>(*endptr))) != 'B')
+		{
+			return dEfault;
+		}
+		++endptr;
+		skipWhitespace(endptr);
+		if (*endptr != '\0')
+		{
+			return dEfault;
+		}
 	}
 
 	if (multiplier != 0 && parsed > std::numeric_limits<long long>::max() / multiplier)

--- a/src/test/cpp/helpers/optionconvertertestcase.cpp
+++ b/src/test/cpp/helpers/optionconvertertestcase.cpp
@@ -49,6 +49,12 @@ LOGUNIT_CLASS(OptionConverterTestCase)
 	LOGUNIT_TEST(varSubstRecursiveReferenceTest);
 	LOGUNIT_TEST(toIntReturnsDefaultOnOverflow);
 	LOGUNIT_TEST(toIntReturnsDefaultOnMalformedInput);
+	LOGUNIT_TEST(toFileSizeAcceptsValidValues);
+	LOGUNIT_TEST(toFileSizeAcceptsWhitespaceSeparatedValues);
+	LOGUNIT_TEST(toFileSizeAcceptsLowercaseSuffixes);
+	LOGUNIT_TEST(toFileSizeReturnsDefaultOnMalformedInput);
+	LOGUNIT_TEST(toFileSizeReturnsDefaultOnOverflow);
+	LOGUNIT_TEST(toFileSizeBoundaryValues);
 	LOGUNIT_TEST(testTmpDir);
 #if APR_HAS_USER
 	LOGUNIT_TEST(testUserHome);
@@ -182,6 +188,70 @@ public:
 		LOGUNIT_ASSERT_EQUAL(7, OptionConverter::toInt(LOG4CXX_STR(""), 7));
 		LOGUNIT_ASSERT_EQUAL((std::numeric_limits<int>::max)(), OptionConverter::toInt(LOG4CXX_STR("2147483647"), 7));
 		LOGUNIT_ASSERT_EQUAL((std::numeric_limits<int>::min)(), OptionConverter::toInt(LOG4CXX_STR("-2147483648"), 7));
+	}
+
+	void toFileSizeAcceptsValidValues()
+	{
+		LOGUNIT_ASSERT_EQUAL(10L, OptionConverter::toFileSize(LOG4CXX_STR("10"), 7));
+		LOGUNIT_ASSERT_EQUAL(10L, OptionConverter::toFileSize(LOG4CXX_STR("10B"), 7));
+		LOGUNIT_ASSERT_EQUAL(10L * 1024L, OptionConverter::toFileSize(LOG4CXX_STR("10 KB"), 7));
+		LOGUNIT_ASSERT_EQUAL(10L * 1024L * 1024L, OptionConverter::toFileSize(LOG4CXX_STR("10MB"), 7));
+	}
+
+	void toFileSizeAcceptsWhitespaceSeparatedValues()
+	{
+		LOGUNIT_ASSERT_EQUAL(10L, OptionConverter::toFileSize(LOG4CXX_STR("10 B"), 7));
+		LOGUNIT_ASSERT_EQUAL(10L * 1024L, OptionConverter::toFileSize(LOG4CXX_STR("10 KB"), 7));
+		LOGUNIT_ASSERT_EQUAL(10L * 1024L * 1024L, OptionConverter::toFileSize(LOG4CXX_STR("10   MB"), 7));
+		const long tenGBExpected = ((std::numeric_limits<long>::max)() >= (10LL * 1024LL * 1024LL * 1024LL))
+			? static_cast<long>(10LL * 1024LL * 1024LL * 1024LL)
+			: 7L;
+		LOGUNIT_ASSERT_EQUAL(tenGBExpected, OptionConverter::toFileSize(LOG4CXX_STR("10GB   "), 7));
+	}
+
+	void toFileSizeAcceptsLowercaseSuffixes()
+	{
+		LOGUNIT_ASSERT_EQUAL(10L * 1024L, OptionConverter::toFileSize(LOG4CXX_STR("10kb"), 7));
+		LOGUNIT_ASSERT_EQUAL(10L * 1024L * 1024L, OptionConverter::toFileSize(LOG4CXX_STR("10mb"), 7));
+		const long tenGbLowerExpected = ((std::numeric_limits<long>::max)() >= (10LL * 1024LL * 1024LL * 1024LL))
+			? static_cast<long>(10LL * 1024LL * 1024LL * 1024LL)
+			: 7L;
+		LOGUNIT_ASSERT_EQUAL(tenGbLowerExpected, OptionConverter::toFileSize(LOG4CXX_STR("10gb"), 7));
+	}
+
+	void toFileSizeReturnsDefaultOnMalformedInput()
+	{
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("not-a-size"), 7));
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("123abc"), 7));
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("10XB"), 7));
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("10QB"), 7));
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("10K"), 7));
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("10MBjunk"), 7));
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("10 B junk"), 7));
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("-1MB"), 7));
+	}
+
+	void toFileSizeReturnsDefaultOnOverflow()
+	{
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("9999999999999999999999"), 7));
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(LOG4CXX_STR("9999999999999999999999GB"), 7));
+	}
+
+	void toFileSizeBoundaryValues()
+	{
+		auto maxLongString = std::to_string((std::numeric_limits<long>::max)());
+		LOG4CXX_DECODE_CHAR(lsMaxLong, maxLongString);
+		LOGUNIT_ASSERT_EQUAL((std::numeric_limits<long>::max)(), OptionConverter::toFileSize(lsMaxLong, 7));
+
+		const unsigned long long onePastMaxLong = static_cast<unsigned long long>((std::numeric_limits<long>::max)()) + 1ULL;
+		auto onePastMaxLongString = std::to_string(onePastMaxLong);
+		LOG4CXX_DECODE_CHAR(lsOnePastMaxLong, onePastMaxLongString);
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(lsOnePastMaxLong, 7));
+
+		const unsigned long long overflowBase = static_cast<unsigned long long>((std::numeric_limits<long>::max)() / (1024LL * 1024LL * 1024LL)) + 1ULL;
+		auto overflowSizeString = std::to_string(overflowBase) + "GB";
+		LOG4CXX_DECODE_CHAR(lsOverflowAfterMultiply, overflowSizeString);
+		LOGUNIT_ASSERT_EQUAL(7L, OptionConverter::toFileSize(lsOverflowAfterMultiply, 7));
 	}
 
 	void testTmpDir()


### PR DESCRIPTION
## Description

* Harden `OptionConverter::toFileSize` to require full validation of size strings instead of accepting partially parsed values.
* Reject malformed, negative, trailing-junk, and overflowed inputs such as:

  * `123abc`
  * `10XB`
  * `10MBjunk`
  * `-1MB`
* Preserve documented valid formats including:

  * `10`
  * `10B`
  * `10 KB`
  * `10MB`
  * lowercase suffixes (`10kb`, `10mb`, `10gb`)
* Add regression coverage for:

  * valid inputs
  * whitespace-separated suffixes
  * lowercase suffix handling
  * malformed input rejection
  * overflow and boundary handling