### PR TITLE
Add bounds checks to StringHelper::format placeholder handling

### DIFF
--- a/src/main/cpp/stringhelper.cpp
+++ b/src/main/cpp/stringhelper.cpp
@@ -174,22 +174,24 @@ LogString StringHelper::format(const LogString& pattern, const std::vector<LogSt
 {
 
 	LogString result;
-	int i = 0;
+	LogString::size_type i = 0;
 
-	while (pattern[i] != 0)
+	while (i < pattern.length())
 	{
-		if (pattern[i] == 0x7B /* '{' */ && pattern[i + 1] >= 0x30 /* '0' */ &&
+		if (i + 2 < pattern.length() &&
+			pattern[i] == 0x7B /* '{' */ && pattern[i + 1] >= 0x30 /* '0' */ &&
 			pattern[i + 1] <= 0x39 /* '9' */ && pattern[i + 2] == 0x7D /* '}' */)
 		{
-			int arg = pattern[i + 1] - 0x30 /* '0' */;
-			result = result + params[arg];
-			i += 3;
+			LogString::size_type arg = pattern[i + 1] - 0x30 /* '0' */;
+			if (arg < params.size())
+			{
+				result = result + params[arg];
+				i += 3;
+				continue;
+			}
 		}
-		else
-		{
-			result = result + pattern[i];
-			i++;
-		}
+		result = result + pattern[i];
+		i++;
 	}
 
 	return result;

--- a/src/test/cpp/helpers/stringhelpertestcase.cpp
+++ b/src/test/cpp/helpers/stringhelpertestcase.cpp
@@ -42,6 +42,8 @@ LOGUNIT_CLASS(StringHelperTestCase)
 	LOGUNIT_TEST( testEndsWith3 );
 	LOGUNIT_TEST( testEndsWith4 );
 	LOGUNIT_TEST( testEndsWith5 );
+	LOGUNIT_TEST( testFormatEmptyPattern );
+	LOGUNIT_TEST( testFormatMissingArgument );
 	LOGUNIT_TEST_SUITE_END();
 
 
@@ -127,6 +129,19 @@ public:
 	void testEndsWith5()
 	{
 		LOGUNIT_ASSERT_EQUAL(false, StringHelper::startsWith(LOG4CXX_STR("foobar"), LOG4CXX_STR("abc")));
+	}
+
+	void testFormatEmptyPattern()
+	{
+		std::vector<LogString> params;
+		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR(""), StringHelper::format(LOG4CXX_STR(""), params));
+	}
+
+	void testFormatMissingArgument()
+	{
+		std::vector<LogString> params(1);
+		params[0] = LOG4CXX_STR("first");
+		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("first {1}"), StringHelper::format(LOG4CXX_STR("{0} {1}"), params));
 	}
 
 


### PR DESCRIPTION
## Summary

Add bounds validation to `StringHelper::format` to safely handle malformed or under-supplied placeholders.

The previous implementation indexed `pattern[i + 1]`, `pattern[i + 2]`, and `params[arg]` without validating bounds, which could trigger invalid memory access and process failure for malformed format strings or missing arguments.

## Changes

- Replaced sentinel-style string iteration with length-checked iteration
- Added bounds checks before reading placeholder characters
- Added argument index validation before accessing `params[arg]`
- Preserved unresolved placeholders literally when arguments are missing

## Tests

Added regression coverage for:
- empty format patterns
- missing placeholder arguments