### PR TITLE
Normalize invalid FileAppender buffer sizes

### DIFF
--- a/src/main/cpp/fileappender.cpp
+++ b/src/main/cpp/fileappender.cpp
@@ -28,6 +28,7 @@
 #include "log4cxx/helpers/threadutility.h"
 #include <log4cxx/private/writerappender_priv.h>
 #include <log4cxx/private/fileappender_priv.h>
+#include <limits>
 #include <mutex>
 
 using namespace LOG4CXX_NS;
@@ -137,7 +138,13 @@ void FileAppender::setOption(const LogString& option,
 	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("BUFFERSIZE"), LOG4CXX_STR("buffersize")))
 	{
 		std::lock_guard<std::recursive_mutex> lock(_priv->mutex);
-		_priv->bufferSize = OptionConverter::toFileSize(value, 8 * 1024);
+		long parsed = OptionConverter::toFileSize(value, 8 * 1024);
+		if (parsed < 0 || parsed > static_cast<long>((std::numeric_limits<int>::max)()))
+		{
+			LogLog::warn(LOG4CXX_STR("FileAppender BufferSize is out of range. Using the default value."));
+			parsed = 8 * 1024;
+		}
+		_priv->bufferSize = static_cast<int>(parsed);
 	}
 	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("BUFFEREDSECONDS"), LOG4CXX_STR("bufferedseconds")))
 	{
@@ -368,7 +375,8 @@ void FileAppender::setFileInternal(
 	_priv->fileAppend = append1;
 	_priv->bufferedIO = bufferedIO1;
 	_priv->fileName = filename;
-	_priv->bufferSize = (int)bufferSize1;
+	const size_t intMax = static_cast<size_t>((std::numeric_limits<int>::max)());
+	_priv->bufferSize = static_cast<int>(bufferSize1 > intMax ? intMax : bufferSize1);
 	_priv->writeHeader();
 
 }
@@ -395,6 +403,11 @@ int FileAppender::getBufferedSeconds() const
 
 void FileAppender::setBufferSize(int newValue)
 {
+	if (newValue < 0)
+	{
+		LogLog::warn(LOG4CXX_STR("FileAppender BufferSize must be non-negative. Using zero."));
+		newValue = 0;
+	}
 	_priv->bufferSize = newValue;
 }
 

--- a/src/test/cpp/fileappendertestcase.cpp
+++ b/src/test/cpp/fileappendertestcase.cpp
@@ -43,6 +43,9 @@ class FileAppenderTestCase : public FileAppenderAbstractTestCase
 		//  tests defined here
 		LOGUNIT_TEST(testSetDoubleBackslashes);
 		LOGUNIT_TEST(testStripDuplicateBackslashes);
+		LOGUNIT_TEST(testNegativeBufferSizeOptionFallsBack);
+		LOGUNIT_TEST(testOversizedBufferSizeOptionFallsBack);
+		LOGUNIT_TEST(testSetBufferSizeNormalizesNegativeValue);
 
 		LOGUNIT_TEST_SUITE_END();
 
@@ -108,6 +111,27 @@ class FileAppenderTestCase : public FileAppenderAbstractTestCase
 			//      then it is a UNC
 			LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("\\\\foo.log"),
 				FileAppender::stripDuplicateBackslashes(LOG4CXX_STR("\\\\\\\\foo.log")));
+		}
+
+		void testNegativeBufferSizeOptionFallsBack()
+		{
+			FileAppender appender;
+			appender.setOption(LOG4CXX_STR("BUFFERSIZE"), LOG4CXX_STR("-1"));
+			LOGUNIT_ASSERT(appender.getBufferSize() >= 0);
+		}
+
+		void testOversizedBufferSizeOptionFallsBack()
+		{
+			FileAppender appender;
+			appender.setOption(LOG4CXX_STR("BUFFERSIZE"), LOG4CXX_STR("2G"));
+			LOGUNIT_ASSERT(appender.getBufferSize() >= 0);
+		}
+
+		void testSetBufferSizeNormalizesNegativeValue()
+		{
+			FileAppender appender;
+			appender.setBufferSize(-100);
+			LOGUNIT_ASSERT(appender.getBufferSize() >= 0);
 		}
 
 };


### PR DESCRIPTION
Normalize invalid `FileAppender` buffer size values before storing them in the internal `int` buffer size field.

`FileAppender::_priv->bufferSize` is stored as an `int`, but multiple code paths accepted larger or negative values without validation. On 64-bit systems, oversized values such as `2G` could overflow during narrowing conversion and later expand into extremely large `size_t` values during buffered writer initialization, preventing flush thresholds from triggering and causing unbounded memory growth.

## Changes Made

* Added validation for `BUFFERSIZE` values parsed via `OptionConverter::toFileSize()`.
* Invalid values (negative or greater than `INT_MAX`) now:

  * emit a `LogLog::warn`
  * fall back to the default `8 KiB` buffer size.
* Added bounds checking in `setFileInternal()` before narrowing `size_t` to `int`.
* Updated `setBufferSize(int)` to normalize negative inputs to `0` with a warning.
* Added `<limits>` for safe integer boundary checks.

## Tests Added

Added regression tests covering:

* Negative `BUFFERSIZE` option values.
* Oversized `BUFFERSIZE` option values (`2G` overflow path).
* Direct negative `setBufferSize(int)` calls.

Each test verifies that the resulting buffer size remains non-negative and does not pass through signed/unsigned reinterpretation paths.
