### PR TITLE
Reject undersized SyslogAppender MaxMessageLength values

### DIFF
--- a/src/main/cpp/syslogappender.cpp
+++ b/src/main/cpp/syslogappender.cpp
@@ -477,6 +477,15 @@ bool SyslogAppender::getFacilityPrinting() const
 
 void SyslogAppender::setMaxMessageLength(int maxMessageLength1)
 {
+	// append() reserves 12 characters per chunk for an "(x/y)" sequence suffix.
+	// A value at or below the suffix size produces a zero-length chunk (causing
+	// an infinite split loop) or an iterator computed before msg.begin() (UB).
+	static const int MIN_MAX_MESSAGE_LENGTH = 13;
+	if (maxMessageLength1 < MIN_MAX_MESSAGE_LENGTH)
+	{
+		LogLog::warn(LOG4CXX_STR("SyslogAppender MaxMessageLength is too small. Using the default value."));
+		maxMessageLength1 = 1024;
+	}
 	_priv->maxMessageLength = maxMessageLength1;
 }
 

--- a/src/test/cpp/net/syslogappendertestcase.cpp
+++ b/src/test/cpp/net/syslogappendertestcase.cpp
@@ -33,6 +33,10 @@ class SyslogAppenderTestCase : public AppenderSkeletonTestCase
 		//
 		LOGUNIT_TEST(testDefaultThreshold);
 		LOGUNIT_TEST(testSetOptionThreshold);
+		LOGUNIT_TEST(testSetMaxMessageLengthBelowSuffixSizeFallsBack);
+		LOGUNIT_TEST(testSetMaxMessageLengthNegativeFallsBack);
+		LOGUNIT_TEST(testMaxMessageLengthOptionBelowSuffixSizeFallsBack);
+		LOGUNIT_TEST(testMaxMessageLengthOptionValid);
 
 		LOGUNIT_TEST_SUITE_END();
 
@@ -42,6 +46,34 @@ class SyslogAppenderTestCase : public AppenderSkeletonTestCase
 		AppenderSkeleton* createAppenderSkeleton() const
 		{
 			return new log4cxx::net::SyslogAppender();
+		}
+
+		void testSetMaxMessageLengthBelowSuffixSizeFallsBack()
+		{
+			log4cxx::net::SyslogAppender appender;
+			appender.setMaxMessageLength(12);
+			LOGUNIT_ASSERT(appender.getMaxMessageLength() >= 13);
+		}
+
+		void testSetMaxMessageLengthNegativeFallsBack()
+		{
+			log4cxx::net::SyslogAppender appender;
+			appender.setMaxMessageLength(-100);
+			LOGUNIT_ASSERT(appender.getMaxMessageLength() >= 13);
+		}
+
+		void testMaxMessageLengthOptionBelowSuffixSizeFallsBack()
+		{
+			log4cxx::net::SyslogAppender appender;
+			appender.setOption(LOG4CXX_STR("MAXMESSAGELENGTH"), LOG4CXX_STR("5"));
+			LOGUNIT_ASSERT(appender.getMaxMessageLength() >= 13);
+		}
+
+		void testMaxMessageLengthOptionValid()
+		{
+			log4cxx::net::SyslogAppender appender;
+			appender.setOption(LOG4CXX_STR("MAXMESSAGELENGTH"), LOG4CXX_STR("2048"));
+			LOGUNIT_ASSERT_EQUAL(2048, appender.getMaxMessageLength());
 		}
 };
 


### PR DESCRIPTION
The append() splitting loop computes chunk-end iterators as start + maxMessageLength - 12 to reserve space for an "(x/y)" sequence suffix. With maxMessageLength == 12 the chunk size is zero and the loop never advances, growing the packets vector indefinitely. Smaller positive values walk the iterator before msg.begin() before constructing LogString(start, end) with start > end (undefined behaviour).

Validate the value in setMaxMessageLength so the public setter and the setOption("MaxMessageLength", ...) configuration path both fall back to the documented default when the configured value cannot satisfy the suffix-reservation arithmetic.

## Changes
- Added validation in SyslogAppender::setMaxMessageLength()
- Values < 13 now fall back to the documented default value (1024)
- Added a warning when invalid values are supplied
- Both the public setter and the setOption("MAXMESSAGELENGTH", ...) configuration path now share the same validation logic
Tests Added

## Added tests covering:

- boundary value 12
- negative values
- setOption("MAXMESSAGELENGTH", "5")
- regression test ensuring valid values (2048) remain unchanged