### PR TITLE
#643 Log complete messages with embedded nul characters in console writers

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -105,6 +105,7 @@ target_sources(log4cxx
   colorendpatternconverter.cpp
   configurator.cpp
   consoleappender.cpp
+  consolewriter.cpp
   cyclicbuffer.cpp
   date.cpp
   dateformat.cpp

--- a/src/main/cpp/consolewriter.cpp
+++ b/src/main/cpp/consolewriter.cpp
@@ -15,51 +15,41 @@
  * limitations under the License.
  */
 
-#include <log4cxx/logstring.h>
-#include <log4cxx/helpers/systemerrwriter.h>
-#include <log4cxx/helpers/transcoder.h>
-#include <stdio.h>
-#if !defined(LOG4CXX)
-	#define LOG4CXX 1
-#endif
-#include <log4cxx/private/log4cxx_private.h>
 #include <log4cxx/private/consolewriter_priv.h>
+#include <log4cxx/helpers/transcoder.h>
+#include <log4cxx/private/log4cxx_private.h>
 
 using namespace LOG4CXX_NS;
-using namespace LOG4CXX_NS::helpers;
 
-IMPLEMENT_LOG4CXX_OBJECT(SystemErrWriter)
-
-SystemErrWriter::SystemErrWriter()
+static bool isConsoleWide(FILE *file)
 {
-}
-
-SystemErrWriter::~SystemErrWriter()
-{
-}
-
-void SystemErrWriter::close( LOG4CXX_CLOSE_WRITER_FORMAL_PARAMETERS )
-{
-}
-
-void SystemErrWriter::flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS )
-{
-	fflush(stderr);
-}
-
-void SystemErrWriter::write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS )
-{
-	helpers::writeToConsole(str, stderr);
-}
-
-#if LOG4CXX_ABI_VERSION <= 15
-void SystemErrWriter::write(const LogString& str)
-{
-	helpers::writeToConsole(str, stderr);
-}
-
-void SystemErrWriter::flush()
-{
-	fflush(stderr);
-}
+#if LOG4CXX_FORCE_WIDE_CONSOLE
+	return true;
+#elif LOG4CXX_FORCE_BYTE_CONSOLE || !LOG4CXX_HAS_FWIDE
+	return false;
+#else
+	return fwide(file, 0) > 0;
 #endif
+}
+
+size_t helpers::writeToConsole(const LogString& str, FILE *file)
+{
+#if LOG4CXX_WCHAR_T_API
+	if (isConsoleWide(file))
+	{
+		LOG4CXX_ENCODE_WCHAR(msg, str);
+		int status = fputws(msg.c_str(), file);
+		return status == EOF ? 0 : msg.size();
+	}
+#endif
+
+	LOG4CXX_ENCODE_CHAR(msg, str);
+
+	//
+	// We can't use fputs, fprintf, or even a `%.*s` specifier
+	// as the message may contain embedded null bytes, which would cause the
+	// message to be prematurely truncated.
+	//
+	msg.append("\n");
+	return fwrite(msg.data(), 1, msg.size(), file);
+}

--- a/src/main/cpp/consolewriter.cpp
+++ b/src/main/cpp/consolewriter.cpp
@@ -17,6 +17,9 @@
 
 #include <log4cxx/private/consolewriter_priv.h>
 #include <log4cxx/helpers/transcoder.h>
+#if !defined(LOG4CXX)
+	#define LOG4CXX 1
+#endif
 #include <log4cxx/private/log4cxx_private.h>
 
 using namespace LOG4CXX_NS;

--- a/src/main/cpp/systemerrwriter.cpp
+++ b/src/main/cpp/systemerrwriter.cpp
@@ -15,14 +15,8 @@
  * limitations under the License.
  */
 
-#include <log4cxx/logstring.h>
 #include <log4cxx/helpers/systemerrwriter.h>
-#include <log4cxx/helpers/transcoder.h>
 #include <stdio.h>
-#if !defined(LOG4CXX)
-	#define LOG4CXX 1
-#endif
-#include <log4cxx/private/log4cxx_private.h>
 #include <log4cxx/private/consolewriter_priv.h>
 
 using namespace LOG4CXX_NS;

--- a/src/main/cpp/systemoutwriter.cpp
+++ b/src/main/cpp/systemoutwriter.cpp
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-#include <log4cxx/logstring.h>
 #include <log4cxx/helpers/systemoutwriter.h>
-#include <log4cxx/helpers/transcoder.h>
-#include <stdio.h>
-#if !defined(LOG4CXX)
-	#define LOG4CXX 1
-#endif
-#include <log4cxx/private/log4cxx_private.h>
 #include <log4cxx/private/consolewriter_priv.h>
 
 using namespace LOG4CXX_NS;

--- a/src/main/cpp/systemoutwriter.cpp
+++ b/src/main/cpp/systemoutwriter.cpp
@@ -23,6 +23,7 @@
 	#define LOG4CXX 1
 #endif
 #include <log4cxx/private/log4cxx_private.h>
+#include <log4cxx/private/consolewriter_priv.h>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
@@ -48,45 +49,13 @@ void SystemOutWriter::flush( LOG4CXX_FLUSH_WRITER_FORMAL_PARAMETERS )
 
 void SystemOutWriter::write( LOG4CXX_WRITE_WRITER_FORMAL_PARAMETERS )
 {
-#if LOG4CXX_WCHAR_T_API
-	if (isWide())
-	{
-		LOG4CXX_ENCODE_WCHAR(msg, str);
-		fputws(msg.c_str(), stdout);
-		return;
-	}
-
-#endif
-	LOG4CXX_ENCODE_CHAR(msg, str);
-	fputs(msg.c_str(), stdout);
-}
-
-bool SystemOutWriter::isWide()
-{
-#if LOG4CXX_FORCE_WIDE_CONSOLE
-	return true;
-#elif LOG4CXX_FORCE_BYTE_CONSOLE || !LOG4CXX_HAS_FWIDE
-	return false;
-#else
-	return fwide(stdout, 0) > 0;
-#endif
+	helpers::writeToConsole(str, stdout);
 }
 
 #if LOG4CXX_ABI_VERSION <= 15
 void SystemOutWriter::write(const LogString& str)
 {
-#if LOG4CXX_WCHAR_T_API
-
-	if (isWide())
-	{
-		LOG4CXX_ENCODE_WCHAR(msg, str);
-		fputws(msg.c_str(), stdout);
-		return;
-	}
-
-#endif
-	LOG4CXX_ENCODE_CHAR(msg, str);
-	fputs(msg.c_str(), stdout);
+	helpers::writeToConsole(str, stdout);
 }
 
 void SystemOutWriter::flush()

--- a/src/main/include/log4cxx/helpers/systemerrwriter.h
+++ b/src/main/include/log4cxx/helpers/systemerrwriter.h
@@ -54,7 +54,6 @@ class LOG4CXX_EXPORT SystemErrWriter : public Writer
 	private:
 		SystemErrWriter(const SystemErrWriter&);
 		SystemErrWriter& operator=(const SystemErrWriter&);
-		static bool isWide();
 };
 
 } // namespace helpers

--- a/src/main/include/log4cxx/helpers/systemoutwriter.h
+++ b/src/main/include/log4cxx/helpers/systemoutwriter.h
@@ -54,7 +54,6 @@ class LOG4CXX_EXPORT SystemOutWriter : public Writer
 	private:
 		SystemOutWriter(const SystemOutWriter&);
 		SystemOutWriter& operator=(const SystemOutWriter&);
-		static bool isWide();
 };
 
 } // namespace helpers

--- a/src/main/include/log4cxx/private/consolewriter_priv.h
+++ b/src/main/include/log4cxx/private/consolewriter_priv.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LOG4CXX_CONSOLEWRITER_PRIVATE_H
+#define LOG4CXX_CONSOLEWRITER_PRIVATE_H
+
+#include <log4cxx/rolling/action.h>
+
+namespace LOG4CXX_NS
+{
+namespace helpers
+{
+
+LOG4CXX_EXPORT size_t writeToConsole(const LogString& str, FILE *file);
+
+} // namespace helpers
+
+} // namespace log4cxx
+
+#endif /* LOG4CXX_CONSOLEWRITER_PRIVATE_H */

--- a/src/main/include/log4cxx/private/consolewriter_priv.h
+++ b/src/main/include/log4cxx/private/consolewriter_priv.h
@@ -17,7 +17,8 @@
 #ifndef LOG4CXX_CONSOLEWRITER_PRIVATE_H
 #define LOG4CXX_CONSOLEWRITER_PRIVATE_H
 
-#include <log4cxx/rolling/action.h>
+#include <log4cxx/logstring.h>
+#include <stdio.h>
 
 namespace LOG4CXX_NS
 {

--- a/src/test/cpp/helpers/CMakeLists.txt
+++ b/src/test/cpp/helpers/CMakeLists.txt
@@ -15,12 +15,13 @@
 # limitations under the License.
 #
 
-set(HELPER_TESTS 
+set(HELPER_TESTS
     absolutetimedateformattestcase
     cacheddateformattestcase
     casttestcase
     charsetdecodertestcase
     charsetencodertestcase
+    consolewritertestcase
     cyclicbuffertestcase
     datetimedateformattestcase
     filewatchdogtest

--- a/src/test/cpp/helpers/consolewritertestcase.cpp
+++ b/src/test/cpp/helpers/consolewritertestcase.cpp
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../logunit.h"
+
+#include <log4cxx/private/consolewriter_priv.h>
+#include <log4cxx/helpers/pool.h>
+#include <apr_file_io.h>
+
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+
+LOGUNIT_CLASS(ConsoleWriterTest)
+{
+	LOGUNIT_TEST_SUITE(ConsoleWriterTest);
+	LOGUNIT_TEST(testWriteEmbeddedNullCharacters);
+	LOGUNIT_TEST_SUITE_END();
+
+public:
+	/**
+	 * Tests writing to an unknown host.
+	 */
+	void testWriteEmbeddedNullCharacters()
+	{
+		Pool p;
+		const char* tmpdir = NULL;
+		apr_status_t stat = apr_temp_dir_get(&tmpdir, p.getAPRPool());
+		LOGUNIT_ASSERT_EQUAL(APR_SUCCESS, stat);
+
+		std::string path = tmpdir;
+		path += "/log4cxx.test.log";
+
+		remove(path.c_str());
+
+		std::string message{"Hello\0World!", 12};
+
+		{
+			FILE *fp = fopen(path.c_str(), "wb");
+			LOG4CXX_DECODE_CHAR(lsMessage, message);
+			size_t written = helpers::writeToConsole(lsMessage, fp);
+			LOGUNIT_ASSERT_EQUAL(message.size() + 1, written);
+			fclose(fp);
+		}
+
+		std::string content;
+
+		{
+			FILE *fp = fopen(path.c_str(), "rb");
+			content.resize(1024);
+			size_t count = fread((void*)content.data(), 1, content.size(), fp);
+			content.resize(count);
+			fclose(fp);
+		}
+
+		LOGUNIT_ASSERT_EQUAL(content, message + "\n");
+	}
+
+};
+
+
+LOGUNIT_TEST_SUITE_REGISTRATION(ConsoleWriterTest);

--- a/src/test/cpp/helpers/consolewritertestcase.cpp
+++ b/src/test/cpp/helpers/consolewritertestcase.cpp
@@ -19,6 +19,7 @@
 
 #include <log4cxx/private/consolewriter_priv.h>
 #include <log4cxx/helpers/pool.h>
+#include <log4cxx/helpers/transcoder.h>
 #include <apr_file_io.h>
 
 using namespace log4cxx;


### PR DESCRIPTION
Resolves #643 
Writes to stdout and stderr now go through fwrite rather than fputs. This stops embedded nul characters in log messages from truncating the rest of the message. Added a regression test `testWriteEmbeddedNullCharacters` to go along with the changes.