### PR TITLE
Fix UTF-16 supplementary character encoding

### DIFF
--- a/src/main/cpp/transcoder.cpp
+++ b/src/main/cpp/transcoder.cpp
@@ -165,7 +165,7 @@ size_t Transcoder::encodeUTF16BE(unsigned int ch, char* dst)
 		unsigned char w = (unsigned char) ((ch >> 16) - 1);
 		dst[0] = (char) (0xD8 + (w >> 2));
 		dst[1] = (char) (((w & 0x03) << 6) + ((ch >> 10) & 0x3F));
-		dst[2] = (char) (0xDC + ((ch & 0x30) >> 4));
+		dst[2] = (char) (0xDC + ((ch >> 8) & 0x03));
 		dst[3] = (char) (ch & 0xFF);
 		return 4;
 	}
@@ -194,7 +194,7 @@ size_t Transcoder::encodeUTF16LE(unsigned int ch, char* dst)
 		unsigned char w = (unsigned char) ((ch >> 16) - 1);
 		dst[1] = (char) (0xD8 + (w >> 2));
 		dst[0] = (char) (((w & 0x03) << 6) + ((ch >> 10) & 0x3F));
-		dst[3] = (char) (0xDC + ((ch & 0x30) >> 4));
+		dst[3] = (char) (0xDC + ((ch >> 8) & 0x03));
 		dst[2] = (char) (ch & 0xFF);
 		return 4;
 	}

--- a/src/test/cpp/helpers/transcodertestcase.cpp
+++ b/src/test/cpp/helpers/transcodertestcase.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <log4cxx/helpers/transcoder.h>
+#include <log4cxx/helpers/bytebuffer.h>
 #include "../insertwide.h"
 #include "../logunit.h"
 
@@ -63,6 +64,9 @@ LOGUNIT_CLASS(TranscoderTestCase)
 	LOGUNIT_TEST(testDecodeUTF8_2);
 	LOGUNIT_TEST(testDecodeUTF8_3);
 	LOGUNIT_TEST(testDecodeUTF8_4);
+	LOGUNIT_TEST(testEncodeUTF16BE_BMP);
+	LOGUNIT_TEST(testEncodeUTF16BE_Supplementary);
+	LOGUNIT_TEST(testEncodeUTF16LE_Supplementary);
 #if LOG4CXX_UNICHAR_API
 	LOGUNIT_TEST(udecode2);
 	LOGUNIT_TEST(udecode4);
@@ -310,6 +314,44 @@ public:
 		unsigned int sv = Transcoder::decode(out, iter);
 		LOGUNIT_ASSERT_EQUAL((unsigned int) 0xA9, sv);
 		LOGUNIT_ASSERT_EQUAL(true, iter == out.end());
+	}
+
+	void testEncodeUTF16BE_BMP()
+	{
+		char raw[4] = { 0, 0, 0, 0 };
+		ByteBuffer buf(raw, sizeof(raw));
+		Transcoder::encodeUTF16BE(0x4E03, buf); // CJK 七
+		LOGUNIT_ASSERT_EQUAL((size_t) 2, buf.position());
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0x4E, (unsigned char) raw[0]);
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0x03, (unsigned char) raw[1]);
+	}
+
+	// U+1F600 (GRINNING FACE) encodes to UTF-16BE as D8 3D DE 00.
+	// Before the fix the low surrogate's high byte was derived from bits 4-5
+	// of the code point, yielding 0xDC here instead of 0xDE — corrupting the
+	// pair into two unpaired surrogates.
+	void testEncodeUTF16BE_Supplementary()
+	{
+		char raw[4] = { 0, 0, 0, 0 };
+		ByteBuffer buf(raw, sizeof(raw));
+		Transcoder::encodeUTF16BE(0x1F600, buf);
+		LOGUNIT_ASSERT_EQUAL((size_t) 4, buf.position());
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0xD8, (unsigned char) raw[0]);
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0x3D, (unsigned char) raw[1]);
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0xDE, (unsigned char) raw[2]);
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0x00, (unsigned char) raw[3]);
+	}
+
+	void testEncodeUTF16LE_Supplementary()
+	{
+		char raw[4] = { 0, 0, 0, 0 };
+		ByteBuffer buf(raw, sizeof(raw));
+		Transcoder::encodeUTF16LE(0x1F600, buf);
+		LOGUNIT_ASSERT_EQUAL((size_t) 4, buf.position());
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0x3D, (unsigned char) raw[0]);
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0xD8, (unsigned char) raw[1]);
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0x00, (unsigned char) raw[2]);
+		LOGUNIT_ASSERT_EQUAL((unsigned char) 0xDE, (unsigned char) raw[3]);
 	}
 
 


### PR DESCRIPTION
This fixes incorrect UTF-16 encoding for supplementary-plane Unicode characters in the UTF-16BE and UTF-16LE transcoder paths.

## Changes:

- Fixed low surrogate byte construction in transcoder.cpp
- Added regression tests for:
  - UTF-16BE BMP encoding
  - UTF-16BE supplementary-plane encoding
  - UTF-16LE supplementary-plane encoding

Testing

Added regression coverage in:

     src/test/cpp/helpers/transcodertestcase.cpp