### PR TITLE
Fix ISO Latin-1 decoder sign extension

### DIFF
--- a/src/main/cpp/charsetdecoder.cpp
+++ b/src/main/cpp/charsetdecoder.cpp
@@ -355,7 +355,7 @@ class ISOLatinCharsetDecoder : public CharsetDecoder
 
 			while (src < srcEnd)
 			{
-				auto sv = static_cast<unsigned int>(*src++);
+				auto sv = static_cast<unsigned int>(static_cast<unsigned char>(*src++));
 				Transcoder::encode(sv, out);
 			}
 			in.increment_position(availableByteCount);

--- a/src/test/cpp/helpers/charsetdecodertestcase.cpp
+++ b/src/test/cpp/helpers/charsetdecodertestcase.cpp
@@ -166,19 +166,21 @@ public:
 	 */
 	void testISOLatinHighBytes()
 	{
-		char buf[2];
+		char buf[1];
 		auto dec = CharsetDecoder::getISOLatinDecoder();
 		for (unsigned int b = 0x80; b <= 0xFF; ++b)
 		{
 			buf[0] = static_cast<char>(b);
-			buf[1] = 0;
 			ByteBuffer in(buf, 1);
 			LogString out;
 			log4cxx_status_t stat = dec->decode(in, out);
 			LOGUNIT_ASSERT_EQUAL(APR_SUCCESS, stat);
-			LOGUNIT_ASSERT_EQUAL((size_t) 1, out.size());
-			LOGUNIT_ASSERT_EQUAL(static_cast<unsigned int>(b),
-				static_cast<unsigned int>(out[0]));
+
+			// Build the expected LogString by encoding code point b
+			// through the same Transcoder path the decoder uses.
+			LogString expected;
+			Transcoder::encode(b, expected);
+			LOGUNIT_ASSERT_EQUAL(expected, out);
 		}
 	}
 

--- a/src/test/cpp/helpers/charsetdecodertestcase.cpp
+++ b/src/test/cpp/helpers/charsetdecodertestcase.cpp
@@ -40,6 +40,7 @@ LOGUNIT_CLASS(CharsetDecoderTestCase)
 	LOGUNIT_TEST(decode2);
 	LOGUNIT_TEST(decode3);
 	LOGUNIT_TEST(decode4);
+	LOGUNIT_TEST(testISOLatinHighBytes);
 #if LOG4CXX_LOGCHAR_IS_WCHAR && LOG4CXX_HAS_MBSRTOWCS
     LOGUNIT_TEST(testMbstowcsInfiniteLoop);
 #endif
@@ -149,6 +150,35 @@ public:
 			msg.append(LOG4CXX_STR(": "));
 			msg.append(LOG4CXX_STR("en_US.UTF-8"));
 			LogLog::warn(msg);
+		}
+	}
+
+	/**
+	 * Decoding ISO-8859-1 must map every byte 0x80..0xFF to the
+	 * code point of the same numeric value. On platforms where plain
+	 * char is signed (default on MSVC/GCC/Clang for x86/x64), a
+	 * static_cast<unsigned int>(*src) sign-extends bytes >= 0x80 into
+	 * 0xFFFFFFxx, which Transcoder::encode then treats as out-of-range
+	 * Unicode and replaces with U+FFFD (or appends garbage on wchar_t
+	 * builds). The .properties configuration loader uses this decoder
+	 * per the Java spec, so the bug silently corrupts any non-ASCII
+	 * Latin-1 byte that appears in a log4cxx configuration file.
+	 */
+	void testISOLatinHighBytes()
+	{
+		char buf[2];
+		auto dec = CharsetDecoder::getISOLatinDecoder();
+		for (unsigned int b = 0x80; b <= 0xFF; ++b)
+		{
+			buf[0] = static_cast<char>(b);
+			buf[1] = 0;
+			ByteBuffer in(buf, 1);
+			LogString out;
+			log4cxx_status_t stat = dec->decode(in, out);
+			LOGUNIT_ASSERT_EQUAL(APR_SUCCESS, stat);
+			LOGUNIT_ASSERT_EQUAL((size_t) 1, out.size());
+			LOGUNIT_ASSERT_EQUAL(static_cast<unsigned int>(b),
+				static_cast<unsigned int>(out[0]));
 		}
 	}
 


### PR DESCRIPTION
Fix sign-extension corruption in `ISOLatinCharsetDecoder::decode` when decoding bytes >= `0x80`.

`charsetdecoder.cpp` previously converted input bytes using:

```cpp
static_cast<unsigned int>(*src)
```

Because `char` is signed by default on common MSVC/GCC/Clang x86/x64 builds, bytes in the range `0x80..0xFF` were sign-extended to `0xFFFFFFxx`. This caused `Transcoder::encode` to treat them as invalid Unicode values, producing `U+FFFD` on UTF-8 builds (or invalid `wchar_t` values on WCHAR builds).

The fix casts through `unsigned char` first, matching the existing unsigned-byte handling patterns already used elsewhere in the codebase.

## Impact

`properties.cpp` selects this decoder for Java `.properties` parsing, so any Latin-1 characters above ASCII in log4cxx configuration files could be silently corrupted. This affects cases such as:

* accented file paths
* logger names
* layout patterns
* localized configuration text

## Changes

* Fix signed-char sign extension in `ISOLatinCharsetDecoder::decode`
* Add `testISOLatinHighBytes`
* Verify round-trip behavior for all bytes `0x80..0xFF`
