### PR TITLE
Replace manual exception message buffers with std::string

### DIFF
--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -29,56 +29,29 @@ using namespace LOG4CXX_NS::helpers;
 Exception::Exception(const LogString& msg1)
 {
 	LOG4CXX_ENCODE_CHAR(m, msg1);
-	size_t len = m.size();
-
-	if (len > MSG_SIZE)
-	{
-		len = MSG_SIZE;
-	}
-
-#if defined(__STDC_LIB_EXT1__) || defined(__STDC_SECURE_LIB__)
-	memcpy_s(msg, sizeof msg, m.data(), len);
-#else
-	memcpy(msg, m.data(), len);
-#endif
-	msg[len] = 0;
+	msg = m;
 }
 
 Exception::Exception(const char* m)
 {
-#if defined(__STDC_LIB_EXT1__) || defined(__STDC_SECURE_LIB__)
-	strncpy_s(msg, sizeof msg, m, MSG_SIZE);
-#else
-	strncpy(msg, m, MSG_SIZE);
-#endif
-	msg[MSG_SIZE] = 0;
+	msg = (m ? std::string(m) : std::string());
 }
 
 
 Exception::Exception(const Exception& src) : std::exception()
 {
-#if defined(__STDC_LIB_EXT1__) || defined(__STDC_SECURE_LIB__)
-	strcpy_s(msg, sizeof msg, src.msg);
-#else
-	strncpy(msg, src.msg, MSG_SIZE);
-	msg[MSG_SIZE] = 0;
-#endif
+	msg = src.msg;
 }
 
 Exception& Exception::operator=(const Exception& src)
 {
-#if defined(__STDC_LIB_EXT1__) || defined(__STDC_SECURE_LIB__)
-	strcpy_s(msg, sizeof msg, src.msg);
-#else
-	strncpy(msg, src.msg, MSG_SIZE);
-	msg[MSG_SIZE] = 0;
-#endif
+	msg = src.msg;
 	return *this;
 }
 
 const char* Exception::what() const throw()
 {
-	return msg;
+	return msg.c_str();
 }
 
 RuntimeException::RuntimeException(log4cxx_status_t stat)

--- a/src/main/include/log4cxx/helpers/exception.h
+++ b/src/main/include/log4cxx/helpers/exception.h
@@ -21,6 +21,7 @@
 #include <exception>
 #include <log4cxx/log4cxx.h>
 #include <log4cxx/logstring.h>
+#include <string>
 
 #ifdef _MSC_VER
 	#pragma warning ( push )
@@ -47,8 +48,7 @@ class LOG4CXX_EXPORT Exception : public ::std::exception
 		static std::string makeMessage(const char* type, log4cxx_status_t stat);
 #endif
 	private:
-		enum { MSG_SIZE = 128 };
-		char msg[MSG_SIZE + 1];
+		std::string msg;
 }; // class Exception
 
 /** RuntimeException is the parent class of those exceptions that can be
@@ -97,14 +97,14 @@ class LOG4CXX_EXPORT IOException : public Exception
 		IOException(log4cxx_status_t stat);
 		IOException(const LogString& msg);
 		IOException(const char* msg);
-		IOException(const LogString& type, log4cxx_status_t stat);
+	IOException(const LogString& type, log4cxx_status_t stat);
 #if !LOG4CXX_LOGCHAR_IS_UTF8
-		IOException(const char* msg, log4cxx_status_t stat);
+	IOException(const char* msg, log4cxx_status_t stat);
 #endif
-		IOException(const IOException& src);
-		IOException& operator=(const IOException&);
-	private:
-		static LogString formatMessage(log4cxx_status_t stat);
+	IOException(const IOException& src);
+	IOException& operator=(const IOException&);
+    private:
+	static LogString formatMessage(log4cxx_status_t stat);
 };
 
 class LOG4CXX_EXPORT MissingResourceException : public Exception


### PR DESCRIPTION
This change replaces fixed-size exception message buffers with std::string-backed storage throughout the exception hierarchy.

The previous implementation relied on manual buffer management and multiple bounded string/memory copy routines, including memcpy, strncpy, and strcpy variants, along with explicit truncation and null-termination handling.

By migrating exception message storage to std::string, this patch:

- removes manual buffer lifetime management
- eliminates fixed-capacity truncation logic
- removes unsafe/error-prone string copy patterns
- improves memory-safety and code auditability
- aligns exception handling with modern RAII-based C++ practices
