### PR TITLE
PropertyConfigurator reporting configured state for invalid appenders

### DIFF
--- a/src/main/cpp/propertyconfigurator.cpp
+++ b/src/main/cpp/propertyconfigurator.cpp
@@ -603,5 +603,6 @@ void PropertyConfigurator::registryPut(const AppenderPtr& appender)
 
 AppenderPtr PropertyConfigurator::registryGet(const LogString& name)
 {
-	return (*m_priv->registry)[name];
+	auto it = m_priv->registry->find(name);
+	return (it == m_priv->registry->end()) ? AppenderPtr() : it->second;
 }

--- a/src/test/cpp/propertyconfiguratortest.cpp
+++ b/src/test/cpp/propertyconfiguratortest.cpp
@@ -31,6 +31,7 @@ LOGUNIT_CLASS(PropertyConfiguratorTest)
 	LOGUNIT_TEST(testInherited);
 	LOGUNIT_TEST(testNull);
 	LOGUNIT_TEST(testAppenderThreshold);
+	LOGUNIT_TEST(testInvalidAppenderBehavesNotConfigured);
 	LOGUNIT_TEST_SUITE_END();
 
 public:
@@ -85,6 +86,27 @@ public:
 		LOG4CXX_WARN(root, "Warn message");
 		LOG4CXX_WARN(root, "Error message");
 		LOGUNIT_ASSERT_EQUAL((size_t) 2, appender->vector.size());
+		LogManager::resetConfiguration();
+	}
+
+	void testInvalidAppenderBehavesNotConfigured()
+	{
+		Properties props;
+		props.put(LOG4CXX_STR("log4j.rootLogger"), LOG4CXX_STR("DEBUG,BAD"));
+		props.put(LOG4CXX_STR("log4j.appender.BAD"), LOG4CXX_STR("does.not.Exist"));
+
+		auto status = PropertyConfigurator::configure(props);
+
+		// Expect: invalid appender config should result in NotConfigured
+		LOGUNIT_ASSERT_EQUAL(status, spi::ConfigurationStatus::NotConfigured);
+
+		// Repository should not be marked configured
+		LOGUNIT_ASSERT_EQUAL(false, LogManager::getLoggerRepository()->isConfigured());
+
+		// Root logger should have no appenders
+		LoggerPtr root(Logger::getRootLogger());
+		LOGUNIT_ASSERT_EQUAL((size_t)0, root->getAllAppenders().size());
+
 		LogManager::resetConfiguration();
 	}
 


### PR DESCRIPTION
## Summary
Fixes `PropertyConfigurator` incorrectly reporting a successful configuration when an appender fails to instantiate.

## Root Cause
`registryGet()` used `std::map::operator[]` during lookup, which inserted a null entry for missing appenders.

This caused the internal registry to become non-empty even when no appenders were successfully created, leading to:
- `ConfigurationStatus::Configured` being returned incorrectly
- repository marked as configured despite failed appender creation

## Fix
Replace the mutating lookup with a non-mutating `find()` lookup in `registryGet()`.

This preserves registry state during failed appender resolution and restores correct configured-state behavior.

## Tests
Added `testInvalidAppenderBehavesNotConfigured` covering:
- invalid appender class configuration
- `ConfigurationStatus::NotConfigured`
- repository remains unconfigured
- no appenders attached to the root logger

## Validation
- Reproduced issue before patch with invalid appender configuration
- Verified corrected behavior after patch
- Ran `propertyconfiguratortest`
- Ran relevant `ctest` validation
- `git diff --check` clean