### PR TITLE
Fix UTF-8 decoder rejecting valid U+0800 three-byte sequence

### DIFF
--- a/src/main/cpp/transcoder.cpp
+++ b/src/main/cpp/transcoder.cpp
@@ -265,7 +265,7 @@ unsigned int Transcoder::decode(const std::string& src,
 					+ ((ch2 & 0x3F) << 6)
 					+ (ch3 & 0x3F);
 
-				if (rv <= 0x800)
+				if (rv < 0x800)
 				{
 					iter = start;
 					return 0xFFFF;

--- a/src/test/cpp/helpers/transcodertestcase.cpp
+++ b/src/test/cpp/helpers/transcodertestcase.cpp
@@ -64,6 +64,7 @@ LOGUNIT_CLASS(TranscoderTestCase)
 	LOGUNIT_TEST(testDecodeUTF8_2);
 	LOGUNIT_TEST(testDecodeUTF8_3);
 	LOGUNIT_TEST(testDecodeUTF8_4);
+	LOGUNIT_TEST(testDecodeUTF8_U0800);
 	LOGUNIT_TEST(testEncodeUTF16BE_BMP);
 	LOGUNIT_TEST(testEncodeUTF16BE_Supplementary);
 	LOGUNIT_TEST(testEncodeUTF16LE_Supplementary);
@@ -314,6 +315,27 @@ public:
 		unsigned int sv = Transcoder::decode(out, iter);
 		LOGUNIT_ASSERT_EQUAL((unsigned int) 0xA9, sv);
 		LOGUNIT_ASSERT_EQUAL(true, iter == out.end());
+	}
+
+	/**
+	 * U+0800 (SAMARITAN LETTER ALAF) is the smallest code point that
+	 * legitimately requires a three-byte UTF-8 sequence (E0 A0 80).
+	 * The overlong check in the three-byte branch of Transcoder::decode
+	 * previously used `rv <= 0x800` instead of `rv < 0x800`, so this exact
+	 * code point was rejected as if it were an overlong encoding and the
+	 * caller substituted Transcoder::LOSSCHAR. Any UTF-8 input containing
+	 * the bytes E0 A0 80 was therefore silently corrupted on decode.
+	 */
+	void testDecodeUTF8_U0800()
+	{
+		std::string src("\xE0\xA0\x80");
+		LogString out;
+		Transcoder::decodeUTF8(src, out);
+
+		LogString expected;
+		Transcoder::encode(0x0800, expected);
+		LOGUNIT_ASSERT_EQUAL(expected, out);
+		LOGUNIT_ASSERT(out.find(Transcoder::LOSSCHAR) == LogString::npos);
 	}
 
 	void testEncodeUTF16BE_BMP()


### PR DESCRIPTION
This PR fixes an off-by-one error in the UTF-8 three-byte decoding validation logic.

## Problem

`Transcoder::decode` incorrectly rejected the canonical UTF-8 encoding of `U+0800`.

The three-byte overlong validation check used:

```cpp
if (rv <= 0x800)
```

which treated `0x0800` itself as invalid, even though it is the smallest valid code point that legitimately requires a three-byte UTF-8 sequence.

As a result, valid UTF-8 input containing the bytes:

```text
E0 A0 80
```

(the canonical encoding of `U+0800`) was decoded as `0xFFFF`, causing the caller to substitute `Transcoder::LOSSCHAR` and silently corrupt the decoded output.

## Fix

Change the validation condition to:

```cpp
if (rv < 0x800)
```

This preserves rejection of true overlong encodings while correctly accepting `U+0800`.

## Tests

Added `testDecodeUTF8_U0800` regression coverage which:

* decodes the literal UTF-8 byte sequence `E0 A0 80`
* verifies the decoded output matches `Transcoder::encode(0x0800, …)`
* asserts that no `LOSSCHAR` is introduced