### PR TITLE
Reject trailing characters in StringHelper numeric parsing

### DIFF
--- a/src/main/cpp/stringhelper.cpp
+++ b/src/main/cpp/stringhelper.cpp
@@ -24,9 +24,26 @@
 #include <iterator>
 #include <algorithm>
 #include <cctype>
+#include <stdexcept>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
+
+namespace
+{
+void checkFullyParsed(const std::string& value, std::size_t pos)
+{
+	while (pos < value.size() && std::isspace(static_cast<unsigned char>(value[pos])))
+	{
+		++pos;
+	}
+
+	if (pos != value.size())
+	{
+		throw std::invalid_argument("unexpected trailing characters");
+	}
+}
+}
 
 bool StringHelper::equalsIgnoreCase(const LogString& s1, const logchar* upper, const logchar* lower)
 {
@@ -109,24 +126,20 @@ bool StringHelper::endsWith(const LogString& s, const LogString& suffix)
 
 int StringHelper::toInt(const LogString& s)
 {
-#if LOG4CXX_LOGCHAR_IS_UNICHAR
-	std::string as;
-	Transcoder::encode(s, as);
-	return std::stoi(as);
-#else
-	return std::stoi(s);
-#endif
+	LOG4CXX_ENCODE_CHAR(as, s);
+	std::size_t pos = 0;
+	int value = std::stoi(as, &pos);
+	checkFullyParsed(as, pos);
+	return value;
 }
 
 int64_t StringHelper::toInt64(const LogString& s)
 {
-#if LOG4CXX_LOGCHAR_IS_UNICHAR
-	std::string as;
-	Transcoder::encode(s, as);
-	return std::stoll(as);
-#else
-	return std::stoll(s);
-#endif
+	LOG4CXX_ENCODE_CHAR(as, s);
+	std::size_t pos = 0;
+	auto value = std::stoll(as, &pos);
+	checkFullyParsed(as, pos);
+	return value;
 }
 
 void StringHelper::toString(int n, LogString& dst)

--- a/src/test/cpp/helpers/stringhelpertestcase.cpp
+++ b/src/test/cpp/helpers/stringhelpertestcase.cpp
@@ -148,7 +148,7 @@ public:
 	void testToIntParsesWholeString()
 	{
 		LOGUNIT_ASSERT_EQUAL(42, StringHelper::toInt(LOG4CXX_STR(" 42 \t")));
-		LOGUNIT_ASSERT_EQUAL(1234567890123LL, StringHelper::toInt64(LOG4CXX_STR("1234567890123")));
+		LOGUNIT_ASSERT_EQUAL(int64_t(1234567890123LL), StringHelper::toInt64(LOG4CXX_STR("1234567890123")));
 	}
 
 	void testToIntRejectsEmptyString()

--- a/src/test/cpp/helpers/stringhelpertestcase.cpp
+++ b/src/test/cpp/helpers/stringhelpertestcase.cpp
@@ -19,6 +19,7 @@
 #include <log4cxx/helpers/stringhelper.h>
 #include "../insertwide.h"
 #include "../logunit.h"
+#include <stdexcept>
 
 
 using namespace log4cxx;
@@ -42,6 +43,13 @@ LOGUNIT_CLASS(StringHelperTestCase)
 	LOGUNIT_TEST( testEndsWith3 );
 	LOGUNIT_TEST( testEndsWith4 );
 	LOGUNIT_TEST( testEndsWith5 );
+	LOGUNIT_TEST( testToIntAcceptsSign );
+	LOGUNIT_TEST( testToIntParsesWholeString );
+	LOGUNIT_TEST_EXCEPTION( testToIntRejectsEmptyString, std::invalid_argument );
+	LOGUNIT_TEST_EXCEPTION( testToIntRejectsWhitespaceOnly, std::invalid_argument );
+	LOGUNIT_TEST_EXCEPTION( testToIntRejectsEmbeddedWhitespace, std::invalid_argument );
+	LOGUNIT_TEST_EXCEPTION( testToIntRejectsTrailingCharacters, std::invalid_argument );
+	LOGUNIT_TEST_EXCEPTION( testToInt64RejectsTrailingCharacters, std::invalid_argument );
 	LOGUNIT_TEST( testFormatEmptyPattern );
 	LOGUNIT_TEST( testFormatMissingArgument );
 	LOGUNIT_TEST_SUITE_END();
@@ -129,6 +137,43 @@ public:
 	void testEndsWith5()
 	{
 		LOGUNIT_ASSERT_EQUAL(false, StringHelper::startsWith(LOG4CXX_STR("foobar"), LOG4CXX_STR("abc")));
+	}
+
+	void testToIntAcceptsSign()
+	{
+		LOGUNIT_ASSERT_EQUAL(42, StringHelper::toInt(LOG4CXX_STR("+42")));
+		LOGUNIT_ASSERT_EQUAL(-42, StringHelper::toInt(LOG4CXX_STR("-42")));
+	}
+
+	void testToIntParsesWholeString()
+	{
+		LOGUNIT_ASSERT_EQUAL(42, StringHelper::toInt(LOG4CXX_STR(" 42 \t")));
+		LOGUNIT_ASSERT_EQUAL(1234567890123LL, StringHelper::toInt64(LOG4CXX_STR("1234567890123")));
+	}
+
+	void testToIntRejectsEmptyString()
+	{
+		StringHelper::toInt(LOG4CXX_STR(""));
+	}
+
+	void testToIntRejectsWhitespaceOnly()
+	{
+		StringHelper::toInt(LOG4CXX_STR("   "));
+	}
+
+	void testToIntRejectsEmbeddedWhitespace()
+	{
+		StringHelper::toInt(LOG4CXX_STR("12 34"));
+	}
+
+	void testToIntRejectsTrailingCharacters()
+	{
+		StringHelper::toInt(LOG4CXX_STR("123abc"));
+	}
+
+	void testToInt64RejectsTrailingCharacters()
+	{
+		StringHelper::toInt64(LOG4CXX_STR("123abc"));
 	}
 
 	void testFormatEmptyPattern()


### PR DESCRIPTION
## Summary

Improve `StringHelper::toInt` and `StringHelper::toInt64` to reject malformed numeric input with trailing non-whitespace characters instead of silently accepting partial parses.

Examples of previously accepted input:
- `"123abc"` → parsed as `123`
- `"514udp"` → parsed as `514`

This change now requires the full numeric string to be consumed (excluding trailing whitespace).

## Changes

- Added full-consumption validation after `std::stoi` / `std::stoll`
- Preserved support for surrounding whitespace and signed values
- Switched to `LOG4CXX_ENCODE_CHAR` for consistent cross-platform `LogString` handling
- Added regression tests covering:
  - trailing characters
  - empty input
  - whitespace-only input
  - embedded whitespace
  - signed numbers

## Rationale

`OptionConverter::toInt` already rejects trailing characters using full-string validation. This change aligns `StringHelper` numeric parsing behavior with the existing strict parsing semantics used elsewhere in the project and avoids silently accepting malformed numeric configuration values.