### PR TITLE
Prevent rollover failure with short file name patterns

### DIFF
--- a/src/main/cpp/fixedwindowrollingpolicy.cpp
+++ b/src/main/cpp/fixedwindowrollingpolicy.cpp
@@ -265,11 +265,11 @@ bool FixedWindowRollingPolicy::purge(int lowIndex, int highIndex, Pool& p) const
 
 	LogString lowFilename(buf);
 
-	if (lowFilename.compare(lowFilename.length() - 3, 3, LOG4CXX_STR(".gz")) == 0)
+	if (StringHelper::endsWith(lowFilename, LOG4CXX_STR(".gz")))
 	{
 		suffixLength = 3;
 	}
-	else if (lowFilename.compare(lowFilename.length() - 4, 4, LOG4CXX_STR(".zip")) == 0)
+	else if (StringHelper::endsWith(lowFilename, LOG4CXX_STR(".zip")))
 	{
 		suffixLength = 4;
 	}

--- a/src/test/cpp/rolling/manualrollingtest.cpp
+++ b/src/test/cpp/rolling/manualrollingtest.cpp
@@ -54,6 +54,7 @@ LOGUNIT_CLASS(ManualRollingTest)
 	//           LOGUNIT_TEST(test3);
 	LOGUNIT_TEST(test4);
 	LOGUNIT_TEST(test5);
+	LOGUNIT_TEST(testShortFileNamePattern);
 	LOGUNIT_TEST(create_directories);
 	LOGUNIT_TEST_SUITE_END();
 
@@ -165,6 +166,23 @@ public:
 				File("witness/rolling/sbr-test2.0")));
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/manual-test2.log.2"),
 				File("witness/rolling/sbr-test2.1")));
+	}
+
+	void testShortFileNamePattern()
+	{
+		FixedWindowRollingPolicyPtr policy = FixedWindowRollingPolicyPtr(new FixedWindowRollingPolicy());
+		policy->setMinIndex(0);
+		policy->setMaxIndex(1);
+		policy->setFileNamePattern(LOG4CXX_STR("%i"));
+		policy->activateOptions();
+
+		Pool pool;
+		RolloverDescriptionPtr desc = policy->rollover(
+				LOG4CXX_STR("output/manual-short-pattern-active.log"),
+				false,
+				pool);
+
+		LOGUNIT_ASSERT(desc != NULL);
 	}
 
 	/**

--- a/src/test/cpp/rolling/sizebasedrollingtest.cpp
+++ b/src/test/cpp/rolling/sizebasedrollingtest.cpp
@@ -56,6 +56,7 @@ LOGUNIT_CLASS(SizeBasedRollingTest)
 	LOGUNIT_TEST(test4);
 	LOGUNIT_TEST(test5);
 	LOGUNIT_TEST(test6);
+	LOGUNIT_TEST(testShortPatternRegression);
 	LOGUNIT_TEST_SUITE_END();
 
 	LoggerPtr root;
@@ -356,7 +357,51 @@ public:
 		LOGUNIT_ASSERT_EQUAL(true, Compare::compare(File("output/sbr-test6.log"),  File("witness/rolling/sbr-test3.log")));
 	}
 
-};
+	/**
+	 * Regression test for FixedWindowRollingPolicy::purge() underflow.
+	 * This test uses a very short fileNamePattern ("R%i" -> "R1") which would
+	 * trigger std::out_of_range in the original vulnerable code.
+	 */
+	void testShortPatternRegression()
+	{
+		LogString activeFile = LOG4CXX_STR("output/active.log");
+		LogString rolledFile = LOG4CXX_STR("R1");
+		File(activeFile).deleteFile();
+		File(rolledFile).deleteFile();
 
+		PatternLayoutPtr layout = PatternLayoutPtr(new PatternLayout(LOG4CXX_STR("%m\n")));
+		RollingFileAppenderPtr rfa = RollingFileAppenderPtr(new RollingFileAppender());
+		rfa->setAppend(false);
+		rfa->setLayout(layout);
+		rfa->setFile(activeFile);
+
+		FixedWindowRollingPolicyPtr swrp = FixedWindowRollingPolicyPtr(new FixedWindowRollingPolicy());
+		SizeBasedTriggeringPolicyPtr sbtp = SizeBasedTriggeringPolicyPtr(new SizeBasedTriggeringPolicy());
+
+		sbtp->setMaxFileSize(5); // Very small to trigger rollover
+		swrp->setMinIndex(1);
+		swrp->setFileNamePattern(LOG4CXX_STR("R%i"));
+		swrp->activateOptions();
+
+		rfa->setRollingPolicy(swrp);
+		rfa->setTriggeringPolicy(sbtp);
+		rfa->activateOptions();
+		root->addAppender(rfa);
+
+		// First log: goes to active.log, size becomes > 5
+		LOG4CXX_INFO(logger, LOG4CXX_STR("123456"));
+		// Second log: triggers rollover
+		LOG4CXX_INFO(logger, LOG4CXX_STR("next"));
+
+		// In the vulnerable code, rollover would fail due to std::out_of_range
+		// and the rolled file would not exist.
+		LOGUNIT_ASSERT(File(rolledFile).exists());
+
+		// Cleanup
+		File(activeFile).deleteFile();
+		File(rolledFile).deleteFile();
+	}
+
+};
 
 LOGUNIT_TEST_SUITE_REGISTRATION(SizeBasedRollingTest);


### PR DESCRIPTION
## Summary
Prevent rollover failures when using short file name patterns in `FixedWindowRollingPolicy`.

## What Changed
- Replaced manual suffix offset comparisons with `StringHelper::endsWith()`
- Removed unsafe `length() - N` arithmetic for `.gz` and `.zip` suffix checks
- Added a regression test covering short patterns such as `R%i`

## Problem
Short valid patterns like:

```text
R%i
```

can generate file names shorter than the suffix length being checked.

The previous implementation performed:

```cpp
lowFilename.compare(lowFilename.length() - 3, ...)
```

which could produce an invalid string position and cause rollover to fail with:

```text
log4cxx: invalid string position
```

## Regression Test
Added `testShortPatternRegression` to verify:
- rollover fails before the fix
- rollover succeeds after the fix
- the rolled file is created successfully

## Validation
- Verified failing behavior on the original implementation
- Verified passing behavior after the fix
- Re-ran the regression test multiple times to confirm deterministic behavior