### PR TITLE
Normalize invalid Unicode scalar values in JSONLayout output

### DIFF
--- a/src/main/cpp/jsonlayout.cpp
+++ b/src/main/cpp/jsonlayout.cpp
@@ -228,6 +228,10 @@ void JSONLayout::appendItem(const LogString& input, LogString& buf)
 			nextCodePoint = input.end();
 			ch = 0xFFFD; // The Unicode replacement character
 		}
+		else if ((0xD800 <= ch && ch <= 0xDFFF) || 0x10FFFF < ch)
+		{
+			ch = 0xFFFD; // The Unicode replacement character
+		}
 		else if (0x22 == ch || 0x5c == ch) // double quote or backslash?
 			;
 		else if (0x20 <= ch) // not a control character?

--- a/src/test/cpp/jsonlayouttest.cpp
+++ b/src/test/cpp/jsonlayouttest.cpp
@@ -510,15 +510,11 @@ public:
 		LOGUNIT_ASSERT_EQUAL(expectedQuotedEscapedName, quotedEscapedName);
 
 		Transcoder::encode(0xD822, problemNameLS); // Add a character that cannot be converted to UTF16
-#if LOG4CXX_LOGCHAR_IS_WCHAR && defined(__STDC_ISO_10646__)
-		expectedQuotedEscapedName[expectedQuotedEscapedName.size() - 1] = 0xD822;
-		expectedQuotedEscapedName += 0x22; // Add a double quote at the end
-#elif LOG4CXX_LOGCHAR_IS_WCHAR
+#if LOG4CXX_LOGCHAR_IS_WCHAR && !defined(__STDC_ISO_10646__)
 		// encodeUTF16 adds 0xD822, but decodeUTF16 cannot convert 0xD822
 		expectedQuotedEscapedName.insert(expectedQuotedEscapedName.size() - 1, LOG4CXX_STR("\\ufffd")); // The Unicode replacement character
-#elif LOG4CXX_LOGCHAR_IS_UTF8
-		// 0xD822 is encoded in UTF-8 as 0xED 0xA0 0xA2
-		expectedQuotedEscapedName.insert(expectedQuotedEscapedName.size() - 1, "\xED\xA0\xA2");
+#else
+		expectedQuotedEscapedName.insert(expectedQuotedEscapedName.size() - 1, LOG4CXX_STR("\\ufffd")); // The Unicode replacement character
 #endif
 		LogString escapedQuoted0xD822Name;
 		appendQuotedEscapedString(escapedQuoted0xD822Name, problemNameLS);


### PR DESCRIPTION
## Summary

Normalize invalid Unicode scalar values before emitting JSON string content in `JSONLayout`.

This change ensures surrogate-range and out-of-range Unicode values are emitted as `\ufffd` instead of passing through as raw non-scalar content.

## What changed

- Added centralized normalization for invalid Unicode scalar values in `JSONLayout::appendItem`
- Replaced surrogate-range (`U+D800`–`U+DFFF`) and out-of-range code points with `U+FFFD`
- Updated `JSONLayoutTest::testAppendQuotedEscapedString` to verify normalized output behavior

## Why

`JSONLayout` already replaces malformed decode sequences with `U+FFFD`, but surrogate-range scalar values could still bypass escaping through the fast-path serialization logic.

This could produce non-interoperable JSON output containing invalid Unicode scalar values.

The fix keeps behavior unchanged for valid input while ensuring malformed scalar values are consistently normalized before JSON emission.