### PR TITLE
Fix null deref in ByteArrayOutputStream default constructor

### DIFF
--- a/src/main/cpp/bytearrayoutputstream.cpp
+++ b/src/main/cpp/bytearrayoutputstream.cpp
@@ -32,6 +32,7 @@ struct ByteArrayOutputStream::ByteArrayOutputStreamPriv
 IMPLEMENT_LOG4CXX_OBJECT(ByteArrayOutputStream)
 
 ByteArrayOutputStream::ByteArrayOutputStream()
+	: m_priv(std::make_unique<ByteArrayOutputStreamPriv>())
 {
 }
 

--- a/src/test/cpp/helpers/casttestcase.cpp
+++ b/src/test/cpp/helpers/casttestcase.cpp
@@ -17,6 +17,7 @@
 
 #include "../logunit.h"
 #include <log4cxx/helpers/bytearrayoutputstream.h>
+#include <log4cxx/helpers/bytebuffer.h>
 #include <log4cxx/helpers/fileoutputstream.h>
 #include <log4cxx/rolling/rollingfileappender.h>
 #include <iostream>
@@ -36,6 +37,7 @@ LOGUNIT_CLASS(CastTestCase)
 	LOGUNIT_TEST(testBadCast);
 	LOGUNIT_TEST(testNullParameter);
 	LOGUNIT_TEST(testRollingFileAppender);
+	LOGUNIT_TEST(testByteArrayOutputStreamWriteAfterDefaultConstruction);
 	LOGUNIT_TEST_SUITE_END();
 
 public:
@@ -77,6 +79,30 @@ public:
 		AppenderPtr appender = log4cxx::cast<Appender>(rolling);
 
 		LOGUNIT_ASSERT(appender);
+	}
+
+	/**
+	 * The default constructor of ByteArrayOutputStream left its private
+	 * unique_ptr default-initialised (nullptr), so the first call into
+	 * write() / toByteArray() dereferenced a null pointer. Verify that
+	 * a freshly constructed instance can accept input and round-trip it
+	 * back through toByteArray() without crashing.
+	 */
+	void testByteArrayOutputStreamWriteAfterDefaultConstruction()
+	{
+		ByteArrayOutputStreamPtr stream = std::make_shared<ByteArrayOutputStream>();
+
+		char payload[] = { 'l', 'o', 'g', '4', 'c', 'x', 'x' };
+		ByteBuffer buf(payload, sizeof(payload));
+
+		stream->write(buf);
+
+		ByteList result = stream->toByteArray();
+		LOGUNIT_ASSERT_EQUAL(sizeof(payload), result.size());
+		for (size_t i = 0; i < sizeof(payload); ++i)
+		{
+			LOGUNIT_ASSERT_EQUAL(static_cast<unsigned char>(payload[i]), result[i]);
+		}
 	}
 
 };


### PR DESCRIPTION
Fixed a concrete library-side null-pointer dereference in ByteArrayOutputStream.

After storage was moved into ByteArrayOutputStreamPriv, the default constructor no longer initialized the private unique_ptr. As a result, every call into write() or toByteArray() dereferenced a null pointer through accesses such as:

- m_priv->array.size()
- m_priv->array.resize(...)
- &m_priv->array[sz]

This was a real crash in normal API usage (construct -> write -> read), not caller misuse.

Changes

- src/main/cpp/bytearrayoutputstream.cpp
  - Initialize m_priv in the default constructor using:
    std::make_unique<ByteArrayOutputStreamPriv>()

- src/test/cpp/helpers/casttestcase.cpp
  - Added testByteArrayOutputStreamWriteAfterDefaultConstruction
  - The test:
    - default-constructs ByteArrayOutputStream
    - writes 7 bytes through write()
    - validates the round-trip through toByteArray()
  - Without the fix, the test crashes on the first write() call.