### PR TITLE
Handle zero-length writes in ByteArrayOutputStream

### DIFF
--- a/src/main/cpp/bytearrayoutputstream.cpp
+++ b/src/main/cpp/bytearrayoutputstream.cpp
@@ -19,7 +19,6 @@
 #include <log4cxx/helpers/bytearrayoutputstream.h>
 #include <log4cxx/helpers/exception.h>
 #include <log4cxx/helpers/bytebuffer.h>
-#include <string.h>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
@@ -51,15 +50,19 @@ void ByteArrayOutputStream::flush( LOG4CXX_FLUSH_OUTPUT_STREAM_FORMAL_PARAMETERS
 void ByteArrayOutputStream::write( LOG4CXX_WRITE_OUTPUT_STREAM_FORMAL_PARAMETERS )
 {
 	const size_t count = buf.remaining();
-	const size_t sz = m_priv->array.size();
 
-	if (count > m_priv->array.max_size() - sz)
+	if (count == 0)
+	{
+		return;
+	}
+
+	if (count > m_priv->array.max_size() - m_priv->array.size())
 	{
 		throw IllegalArgumentException(LOG4CXX_STR("ByteArrayOutputStream::write overflow"));
 	}
 
-	m_priv->array.resize(sz + count);
-	memcpy(&m_priv->array[sz], buf.current(), count);
+	const char* const current = buf.current();
+	m_priv->array.insert(m_priv->array.end(), current, current + count);
 	buf.increment_position(count);
 }
 
@@ -67,6 +70,5 @@ std::vector<unsigned char> ByteArrayOutputStream::toByteArray() const
 {
 	return m_priv->array;
 }
-
 
 

--- a/src/test/cpp/helpers/casttestcase.cpp
+++ b/src/test/cpp/helpers/casttestcase.cpp
@@ -38,6 +38,7 @@ LOGUNIT_CLASS(CastTestCase)
 	LOGUNIT_TEST(testNullParameter);
 	LOGUNIT_TEST(testRollingFileAppender);
 	LOGUNIT_TEST(testByteArrayOutputStreamWriteAfterDefaultConstruction);
+	LOGUNIT_TEST(testByteArrayOutputStreamIgnoresEmptyWrite);
 	LOGUNIT_TEST_SUITE_END();
 
 public:
@@ -103,6 +104,19 @@ public:
 		{
 			LOGUNIT_ASSERT_EQUAL(static_cast<unsigned char>(payload[i]), result[i]);
 		}
+	}
+
+	void testByteArrayOutputStreamIgnoresEmptyWrite()
+	{
+		ByteArrayOutputStreamPtr stream = std::make_shared<ByteArrayOutputStream>();
+
+		char payload[] = { 'x' };
+		ByteBuffer buf(payload, 0);
+
+		stream->write(buf);
+
+		LOGUNIT_ASSERT_EQUAL(size_t(0), stream->toByteArray().size());
+		LOGUNIT_ASSERT_EQUAL(size_t(0), buf.remaining());
 	}
 
 };


### PR DESCRIPTION
## Summary
- Handle zero-length writes in `ByteArrayOutputStream::write`
- Replace manual `resize + memcpy` append logic with `std::vector::insert`
- Add regression coverage for empty-write behavior

## Details
- Return early when `buf.remaining() == 0`
- Avoid indexed access on empty vectors during zero-length writes
- Keep existing overflow protection unchanged
- Preserve existing write semantics for non-empty buffers