### PR TITLE
Avoid narrowing-sensitive arithmetic in FormattingInfo

### DIFF
--- a/src/main/cpp/formattinginfo.cpp
+++ b/src/main/cpp/formattinginfo.cpp
@@ -17,6 +17,7 @@
 
 #include <log4cxx/logstring.h>
 #include <log4cxx/pattern/formattinginfo.h>
+#include <algorithm>
 #include <limits.h>
 
 using namespace LOG4CXX_NS;
@@ -79,24 +80,34 @@ FormattingInfoPtr FormattingInfo::getDefault()
  */
 void FormattingInfo::format(const int fieldStart, LogString& buffer) const
 {
-	if (INT_MAX < buffer.length())
-		return;
-	int rawLength = static_cast<int>(buffer.length()) - fieldStart;
+	format(static_cast<LogString::size_type>(std::max(fieldStart, 0)), buffer);
+}
 
-	if (rawLength > m_priv->maxLength)
+void FormattingInfo::format(const LogString::size_type fieldStart, LogString& buffer) const
+{
+	if (fieldStart > buffer.length())
+	{
+		return;
+	}
+
+	const LogString::size_type rawLength = buffer.length() - fieldStart;
+	const LogString::size_type maxLength = static_cast<LogString::size_type>(m_priv->maxLength);
+	const LogString::size_type minLength = static_cast<LogString::size_type>(m_priv->minLength);
+
+	if (rawLength > maxLength)
 	{
 		buffer.erase(buffer.begin() + fieldStart,
-			buffer.begin() + fieldStart + (rawLength - m_priv->maxLength));
+			buffer.begin() + fieldStart + (rawLength - maxLength));
 	}
-	else if (rawLength < m_priv->minLength)
+	else if (rawLength < minLength)
 	{
 		if (m_priv->leftAlign)
 		{
-			buffer.append(m_priv->minLength - rawLength, (logchar) 0x20 /* ' ' */);
+			buffer.append(minLength - rawLength, (logchar) 0x20 /* ' ' */);
 		}
 		else
 		{
-			buffer.insert(fieldStart, m_priv->minLength - rawLength, 0x20 /* ' ' */);
+			buffer.insert(fieldStart, minLength - rawLength, 0x20 /* ' ' */);
 		}
 	}
 }

--- a/src/main/cpp/formattinginfo.cpp
+++ b/src/main/cpp/formattinginfo.cpp
@@ -78,12 +78,13 @@ FormattingInfoPtr FormattingInfo::getDefault()
  * @param fieldStart start of field in buffer.
  * @param buffer buffer to be modified.
  */
+#if LOG4CXX_ABI_VERSION <= 15
 void FormattingInfo::format(const int fieldStart, LogString& buffer) const
 {
-	format(static_cast<LogString::size_type>(std::max(fieldStart, 0)), buffer);
+	adjustField(static_cast<LogString::size_type>(std::max(fieldStart, 0)), buffer);
 }
-
-void FormattingInfo::format(const LogString::size_type fieldStart, LogString& buffer) const
+#endif
+void FormattingInfo::adjustField(const LogString::size_type fieldStart, LogString& buffer) const
 {
 	if (fieldStart > buffer.length())
 	{

--- a/src/main/cpp/patternlayout.cpp
+++ b/src/main/cpp/patternlayout.cpp
@@ -120,7 +120,7 @@ void PatternLayout::format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const
 	{
 		auto startField = output.length();
 		item->format(event, output);
-		item->getFormattingInfo().format(startField, output);
+		item->getFormattingInfo().adjustField(startField, output);
 	}
 
 }

--- a/src/main/cpp/patternlayout.cpp
+++ b/src/main/cpp/patternlayout.cpp
@@ -120,8 +120,7 @@ void PatternLayout::format( LOG4CXX_FORMAT_LAYOUT_FORMAL_PARAMETERS ) const
 	{
 		auto startField = output.length();
 		item->format(event, output);
-		if (startField < INT_MAX)
-			item->getFormattingInfo().format(static_cast<int>(startField), output);
+		item->getFormattingInfo().format(startField, output);
 	}
 
 }
@@ -269,6 +268,5 @@ pattern::PatternConverterPtr PatternLayout::createColorStartPatternConverter(con
 
 	return colorPatternConverter;
 }
-
 
 

--- a/src/main/cpp/rollingpolicybase.cpp
+++ b/src/main/cpp/rollingpolicybase.cpp
@@ -122,7 +122,7 @@ void RollingPolicyBase::formatFileName(
 	{
 		auto startField = toAppendTo.length();
 		item->format(obj, toAppendTo);
-		item->getFormattingInfo().format(startField, toAppendTo);
+		item->getFormattingInfo().adjustField(startField, toAppendTo);
 	}
 }
 #if LOG4CXX_ABI_VERSION <= 15

--- a/src/main/cpp/rollingpolicybase.cpp
+++ b/src/main/cpp/rollingpolicybase.cpp
@@ -122,7 +122,7 @@ void RollingPolicyBase::formatFileName(
 	{
 		auto startField = toAppendTo.length();
 		item->format(obj, toAppendTo);
-		item->getFormattingInfo().format((int)startField, toAppendTo);
+		item->getFormattingInfo().format(startField, toAppendTo);
 	}
 }
 #if LOG4CXX_ABI_VERSION <= 15

--- a/src/main/include/log4cxx/pattern/formattinginfo.h
+++ b/src/main/include/log4cxx/pattern/formattinginfo.h
@@ -85,21 +85,24 @@ class LOG4CXX_EXPORT FormattingInfo : public virtual LOG4CXX_NS::helpers::Object
 		 */
 		int getMaxLength() const;
 
+#if LOG4CXX_ABI_VERSION <= 15
 		/**
 		 * Adjust the content of the buffer based on the specified lengths and alignment.
+		 * @deprecated This function is deprecated and will be removed in a future version.
 		 *
 		 * @param fieldStart start of field in buffer.
 		 * @param buffer buffer to be modified.
 		 */
+		[[ deprecated( "Use adjustField() instead" ) ]]
 		void format(const int fieldStart, LogString& buffer) const;
-
+#endif
 		/**
 		 * Adjust the content of the buffer based on the specified lengths and alignment.
 		 *
 		 * @param fieldStart start of field in buffer.
 		 * @param buffer buffer to be modified.
 		 */
-		void format(const LogString::size_type fieldStart, LogString& buffer) const;
+		void adjustField(const LogString::size_type fieldStart, LogString& buffer) const;
 };
 LOG4CXX_PTR_DEF(FormattingInfo);
 }

--- a/src/main/include/log4cxx/pattern/formattinginfo.h
+++ b/src/main/include/log4cxx/pattern/formattinginfo.h
@@ -92,6 +92,14 @@ class LOG4CXX_EXPORT FormattingInfo : public virtual LOG4CXX_NS::helpers::Object
 		 * @param buffer buffer to be modified.
 		 */
 		void format(const int fieldStart, LogString& buffer) const;
+
+		/**
+		 * Adjust the content of the buffer based on the specified lengths and alignment.
+		 *
+		 * @param fieldStart start of field in buffer.
+		 * @param buffer buffer to be modified.
+		 */
+		void format(const LogString::size_type fieldStart, LogString& buffer) const;
 };
 LOG4CXX_PTR_DEF(FormattingInfo);
 }

--- a/src/test/cpp/pattern/patternparsertestcase.cpp
+++ b/src/test/cpp/pattern/patternparsertestcase.cpp
@@ -179,7 +179,7 @@ public:
 		{
 			auto fieldStart = actual.length();
 			item->format(event, actual);
-			item->getFormattingInfo().format(fieldStart, actual);
+			item->getFormattingInfo().adjustField(fieldStart, actual);
 		}
 
 		LOGUNIT_ASSERT_EQUAL(expected, actual);
@@ -302,10 +302,10 @@ public:
 	void testFormattingInfoUsesSizeTypeFieldStart()
 	{
 		LogString actual(LOG4CXX_STR("prefix"));
-		const LogString::size_type fieldStart = actual.length();
+		auto fieldStart = actual.length();
 		actual.append(LOG4CXX_STR("abcdef"));
 
-		FormattingInfo(false, 0, 3).format(fieldStart, actual);
+		FormattingInfo(false, 0, 3).adjustField(fieldStart, actual);
 
 		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("prefixdef"), actual);
 	}

--- a/src/test/cpp/pattern/patternparsertestcase.cpp
+++ b/src/test/cpp/pattern/patternparsertestcase.cpp
@@ -27,6 +27,7 @@
 #include <log4cxx/spi/loggerrepository.h>
 #include <log4cxx/pattern/patternparser.h>
 #include <log4cxx/pattern/patternconverter.h>
+#include <log4cxx/pattern/formattinginfo.h>
 #include <log4cxx/helpers/relativetimedateformat.h>
 #include <log4cxx/helpers/simpledateformat.h>
 #include <log4cxx/helpers/transcoder.h>
@@ -81,6 +82,7 @@ LOGUNIT_CLASS(PatternParserTestCase)
 	LOGUNIT_TEST(testMultiOption);
 	LOGUNIT_TEST(testThreadUsername);
 	LOGUNIT_TEST(testInvalidPatterns);
+	LOGUNIT_TEST(testFormattingInfoUsesSizeTypeFieldStart);
 	LOGUNIT_TEST_SUITE_END();
 
 	LoggingEventPtr event;
@@ -175,7 +177,7 @@ public:
 
 		for (auto item : converters)
 		{
-			auto fieldStart = static_cast<int>(actual.length());
+			auto fieldStart = actual.length();
 			item->format(event, actual);
 			item->getFormattingInfo().format(fieldStart, actual);
 		}
@@ -295,6 +297,17 @@ public:
 		assertFormattedEquals(LOG4CXX_STR("%6.6666c"),
 			getFormatSpecifiers(),
 			LOG4CXX_STR("%6.6666c"));
+	}
+
+	void testFormattingInfoUsesSizeTypeFieldStart()
+	{
+		LogString actual(LOG4CXX_STR("prefix"));
+		const LogString::size_type fieldStart = actual.length();
+		actual.append(LOG4CXX_STR("abcdef"));
+
+		FormattingInfo(false, 0, 3).format(fieldStart, actual);
+
+		LOGUNIT_ASSERT_EQUAL(LOG4CXX_STR("prefixdef"), actual);
 	}
 
 };

--- a/src/test/cpp/rolling/filenamepatterntestcase.cpp
+++ b/src/test/cpp/rolling/filenamepatterntestcase.cpp
@@ -74,9 +74,9 @@ public:
 
 		for (auto item :  converters)
 		{
-			LogString::size_type i = result.length();
+			auto fieldStart = result.length();
 			item->format(obj, result);
-			item->getFormattingInfo().format((int)i, result);
+			item->getFormattingInfo().adjustField(fieldStart, result);
 		}
 
 		return result;


### PR DESCRIPTION
## Summary

Use `LogString::size_type` for `FormattingInfo` width arithmetic to avoid narrowing-sensitive offset calculations.

## Changes

- Added a `LogString::size_type` overload for `FormattingInfo::format`
- Kept the existing `int` overload as a compatibility wrapper
- Replaced narrowing-sensitive `int` arithmetic with `size_type` arithmetic
- Updated internal formatting call sites to pass native offset types directly
- Added bounds handling for invalid `fieldStart` values
- Added regression coverage for size-type formatting offsets

## Notes

This keeps formatting calculations in the native size domain while preserving existing formatting behavior for normal inputs.