### PR TITLE
Fix UB and locale-dependent behavior in StringHelper::toLowerCase

### DIFF
--- a/src/main/cpp/stringhelper.cpp
+++ b/src/main/cpp/stringhelper.cpp
@@ -67,9 +67,20 @@ bool StringHelper::equalsIgnoreCase(const LogString& s1, const LogString& upper,
 
 LogString StringHelper::toLowerCase(const LogString& s)
 {
+	// Fold ASCII A-Z only. Passing a value not representable as unsigned char
+	// (or EOF) to std::tolower(int) is undefined behaviour; with signed char,
+	// any byte > 0x7F sign-extends to a negative int. The previous implementation
+	// also produced locale-dependent output for the same input, which is wrong
+	// for the callers (class names, color names, column names — all ASCII).
 	LogString d;
-	std::transform(s.begin(), s.end(),
-		std::insert_iterator<LogString>(d, d.begin()), tolower);
+	d.reserve(s.size());
+	for (auto ch : s)
+	{
+		if (ch >= static_cast<logchar>('A') && ch <= static_cast<logchar>('Z'))
+			d.push_back(static_cast<logchar>(ch + ('a' - 'A')));
+		else
+			d.push_back(ch);
+	}
 	return d;
 }
 

--- a/src/test/cpp/helpers/stringhelpertestcase.cpp
+++ b/src/test/cpp/helpers/stringhelpertestcase.cpp
@@ -44,6 +44,8 @@ LOGUNIT_CLASS(StringHelperTestCase)
 	LOGUNIT_TEST( testEndsWith5 );
 	LOGUNIT_TEST( testFormatEmptyPattern );
 	LOGUNIT_TEST( testFormatMissingArgument );
+	LOGUNIT_TEST( testToLowerCaseAscii );
+	LOGUNIT_TEST( testToLowerCaseNonAsciiPassesThrough );
 	LOGUNIT_TEST_SUITE_END();
 
 
@@ -142,6 +144,32 @@ public:
 		std::vector<LogString> params(1);
 		params[0] = LOG4CXX_STR("first");
 		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("first {1}"), StringHelper::format(LOG4CXX_STR("{0} {1}"), params));
+	}
+
+	void testToLowerCaseAscii()
+	{
+		LOGUNIT_ASSERT_EQUAL((LogString) LOG4CXX_STR("hello world"),
+			StringHelper::toLowerCase(LOG4CXX_STR("Hello World")));
+	}
+
+	// Regression: passing a non-ASCII byte (negative when char is signed, or > 0xFF
+	// for wchar_t/UniChar) to ::tolower(int) is undefined behaviour. The prior
+	// implementation also varied with the active C locale, producing different
+	// output on different machines for the same configuration file. Verify the
+	// non-ASCII bytes pass through unchanged regardless of locale.
+	void testToLowerCaseNonAsciiPassesThrough()
+	{
+		LogString input;
+		input.push_back(static_cast<logchar>('A'));
+		input.push_back(static_cast<logchar>(0xC9));   // uppercase 'É' in Latin-1 / Windows-1252
+		input.push_back(static_cast<logchar>(0xE9));   // lowercase 'é' in Latin-1 / Windows-1252
+		input.push_back(static_cast<logchar>('Z'));
+		LogString expected;
+		expected.push_back(static_cast<logchar>('a'));
+		expected.push_back(static_cast<logchar>(0xC9));
+		expected.push_back(static_cast<logchar>(0xE9));
+		expected.push_back(static_cast<logchar>('z'));
+		LOGUNIT_ASSERT_EQUAL(expected, StringHelper::toLowerCase(input));
 	}
 
 


### PR DESCRIPTION
Fix undefined behavior and locale-dependent output in `StringHelper::toLowerCase`.

The previous implementation passed `LogString` characters directly to `::tolower(int)` via `std::transform`. This violates the C standard requirement that the argument must either be `EOF` or representable as `unsigned char`.

When `logchar = char` (commonly signed), any byte greater than `0x7F` sign-extends to a negative `int`, triggering undefined behavior. The behavior also depended on the active `LC_CTYPE` locale, causing the same configuration file to produce different lowercased values on different systems.

This patch replaces the locale-sensitive transformation with deterministic ASCII-only folding (`A-Z -> a-z`) while preserving all non-ASCII bytes unchanged.

## Changes

### `src/main/cpp/stringhelper.cpp`

* Replaced:

  * `std::transform(..., tolower)`
* With:

  * deterministic ASCII-only lowercase conversion
* Eliminates UB from invalid `tolower` inputs
* Removes locale-dependent behavior
* Preserves non-ASCII bytes unchanged

### `src/test/cpp/helpers/stringhelpertestcase.cpp`

Added regression coverage:

* `testToLowerCaseAscii`

  * verifies normal ASCII lowercase conversion
* `testToLowerCaseNonAsciiPassesThrough`

  * verifies non-ASCII bytes remain unchanged
  * validates locale-independent behavior

## Reproducer

With the original implementation:

* `testToLowerCaseNonAsciiPassesThrough` fails on systems using locales such as `English_India.1252`
* Example:

  * `0xC9` (`É`) may be transformed into `0xE9` (`é`) through locale-sensitive `tolower`

With this patch:

* all `stringhelpertestcase` tests pass
* `patternparsertestcase` also passes unchanged