### PR TITLE
data race on ThreadUtility termination flag

### DIFF
--- a/src/main/cpp/threadutility.cpp
+++ b/src/main/cpp/threadutility.cpp
@@ -23,6 +23,7 @@
 #include "log4cxx/helpers/loglog.h"
 #include "log4cxx/helpers/transcoder.h"
 
+#include <atomic>
 #include <signal.h>
 #include <mutex>
 #include <list>
@@ -79,7 +80,7 @@ struct ThreadUtility::priv_data
 	std::thread               thread;
 	std::condition_variable   interrupt;
 	std::mutex                interrupt_mutex;
-	bool                      terminated{ false };
+	std::atomic<bool>         terminated{ false };
 	int                       retryCount{ 2 };
 	Period                    maxDelay{ 0 };
 	bool                      threadIsActive{ false };
@@ -89,7 +90,7 @@ struct ThreadUtility::priv_data
 	void setTerminated()
 	{
 		std::lock_guard<std::mutex> lock(interrupt_mutex);
-		terminated = true;
+		terminated.store(true);
 	}
 
 	void stopThread()
@@ -278,7 +279,7 @@ void ThreadUtility::addPeriodicTask(const LogString& name, std::function<void()>
 
 	if (!m_priv->thread.joinable())
 	{
-		m_priv->terminated = false;
+		m_priv->terminated.store(false);
 		m_priv->threadIsActive = true;
 		m_priv->thread = createThread(LOG4CXX_STR("log4cxx"), std::bind(&priv_data::doPeriodicTasks, m_priv.get()));
 	}
@@ -351,7 +352,7 @@ void ThreadUtility::removePeriodicTasksMatching(const LogString& namePrefix)
 // Run ready tasks
 void ThreadUtility::priv_data::doPeriodicTasks()
 {
-	while (!this->terminated)
+	while (!this->terminated.load())
 	{
 		auto currentTime = std::chrono::system_clock::now();
 		TimePoint nextOperationTime = currentTime + this->maxDelay;
@@ -359,7 +360,7 @@ void ThreadUtility::priv_data::doPeriodicTasks()
 			std::lock_guard<std::recursive_mutex> lock(this->job_mutex);
 			for (auto& item : this->jobs)
 			{
-				if (this->terminated)
+				if (this->terminated.load())
 					return;
 				if (item.removed)
 					;


### PR DESCRIPTION
## Summary

Fix a data race on the `ThreadUtility` termination flag.

## Problem

ThreadSanitizer reports a race between:

* `ThreadUtility::priv_data::setTerminated()`
* `ThreadUtility::priv_data::doPeriodicTasks()`

The shutdown path writes `terminated` while the worker thread reads it concurrently.

## Solution

Store `terminated` as `std::atomic<bool>` and use atomic loads/stores for all accesses.

This preserves the existing worker lifecycle and shutdown behavior while removing the unsynchronized cross-thread access.