### PR TITLE
keep escaping input after an undecodable byte in XML/JSON layouts

### DIFF
--- a/src/main/cpp/jsonlayout.cpp
+++ b/src/main/cpp/jsonlayout.cpp
@@ -226,7 +226,15 @@ void JSONLayout::appendItem(const LogString& input, LogString& buf)
 		auto ch = Transcoder::decode(input, nextCodePoint);
 		if (nextCodePoint == lastCodePoint) // failed to decode input?
 		{
-			nextCodePoint = input.end();
+			// Skip the undecodable run and keep escaping the remaining input
+			// instead of discarding it; the run collapses to one replacement.
+			for (++nextCodePoint; nextCodePoint != input.end(); ++nextCodePoint)
+			{
+				auto probe = nextCodePoint;
+				Transcoder::decode(input, probe);
+				if (probe != nextCodePoint) // next unit starts a decodable sequence
+					break;
+			}
 			ch = 0xFFFD; // The Unicode replacement character
 		}
 		else if ((0xD800 <= ch && ch <= 0xDFFF) || 0x10FFFF < ch)

--- a/src/main/cpp/transform.cpp
+++ b/src/main/cpp/transform.cpp
@@ -45,7 +45,17 @@ void appendValidCharacters(LogString& buf, const LogString& input, CharProcessor
 		auto lastCodePoint = nextCodePoint;
 		auto ch = Transcoder::decode(input, nextCodePoint);
 		if (nextCodePoint == lastCodePoint) // failed to decode input?
-			nextCodePoint = input.end();
+		{
+			// Skip the undecodable run and keep escaping the remaining input
+			// instead of discarding it; the run collapses to one replacement.
+			for (++nextCodePoint; nextCodePoint != input.end(); ++nextCodePoint)
+			{
+				auto probe = nextCodePoint;
+				Transcoder::decode(input, probe);
+				if (probe != nextCodePoint) // next unit starts a decodable sequence
+					break;
+			}
+		}
 		else if (0xD800 <= ch && ch <= 0xDFFF)
 		{
 			// RFC 3629 §3 explicitly forbids surrogate-half values in UTF-8
@@ -140,7 +150,15 @@ void Transform::appendEscapingCDATA(
 		auto ch = Transcoder::decode(input, nextCodePoint);
 		if (nextCodePoint == lastCodePoint) // failed to decode input?
 		{
-			nextCodePoint = input.end();
+			// Skip the undecodable run and keep escaping the remaining input
+			// instead of discarding it; the run collapses to one replacement.
+			for (++nextCodePoint; nextCodePoint != input.end(); ++nextCodePoint)
+			{
+				auto probe = nextCodePoint;
+				Transcoder::decode(input, probe);
+				if (probe != nextCodePoint) // next unit starts a decodable sequence
+					break;
+			}
 			ch = 0xFFFD; // The Unicode replacement character
 		}
 		else if (CDATA_END[0] == ch && input.end() != nextCodePoint)

--- a/src/test/cpp/jsonlayouttest.cpp
+++ b/src/test/cpp/jsonlayouttest.cpp
@@ -53,6 +53,9 @@ LOGUNIT_CLASS(JSONLayoutTest), public JSONLayout
 	LOGUNIT_TEST(testIgnoresThrowable);
 	LOGUNIT_TEST(testAppendQuotedEscapedStringWithPrintableChars);
 	LOGUNIT_TEST(testAppendQuotedEscapedStringWithControlChars);
+#if LOG4CXX_LOGCHAR_IS_UTF8
+	LOGUNIT_TEST(testAppendQuotedEscapedStringWithInvalidByte);
+#endif
 	LOGUNIT_TEST(testAppendSerializedMDC);
 	LOGUNIT_TEST(testAppendSerializedMDCWithPrettyPrint);
 	LOGUNIT_TEST(testAppendSerializedNDC);
@@ -185,6 +188,22 @@ public:
 		appendQuotedEscapedString(esc_escaped, esc);
 		LOGUNIT_ASSERT_EQUAL(esc_expected, esc_escaped);
 	}
+
+#if LOG4CXX_LOGCHAR_IS_UTF8
+	/**
+	 * An undecodable byte must be replaced and the text following it kept,
+	 * not dropped along with the rest of the input.
+	 */
+	void testAppendQuotedEscapedStringWithInvalidByte()
+	{
+		logchar in[] = {'A', (logchar) 0xFF, 'B', 0};
+		LogString expected(LOG4CXX_STR("\"A\\ufffdB\""));
+		LogString actual;
+
+		appendQuotedEscapedString(actual, in);
+		LOGUNIT_ASSERT_EQUAL(expected, actual);
+	}
+#endif
 
 	/**
 	 * Tests appendSerializedMDC.


### PR DESCRIPTION
A byte that fails to decode makes the JSON and XML/HTML escapers move the cursor to input.end(), so anything after a malformed unit in a logged value is dropped from the output:

    "BEFORE_" + 0xFF + "_AFTER"  ->  BEFORE_&#xfffd;   (trailing text lost)

Skip just the undecodable run, emit one U+FFFD for it, and carry on escaping, the way Transcoder::decodeUTF8 already does. New jsonlayouttest case covers it.