### PR TITLE
Ignore character case in loaded option names in the next ABI version

### DIFF
--- a/src/main/cpp/properties.cpp
+++ b/src/main/cpp/properties.cpp
@@ -36,7 +36,7 @@ struct Properties::Less
 			, str2.begin(), str2.end()
 			, [](Char c1, Char c2)
 				{
-					return std::tolower(c1) < std::tolower(c2);
+					return std::tolower(static_cast<unsigned char>(c1)) < std::tolower(static_cast<unsigned char>(c2));
 				}
 			);
 	}

--- a/src/main/cpp/properties.cpp
+++ b/src/main/cpp/properties.cpp
@@ -20,9 +20,27 @@
 #include <log4cxx/helpers/inputstreamreader.h>
 #include <log4cxx/helpers/exception.h>
 #include <log4cxx/helpers/pool.h>
+#include <cctype>
+#include <algorithm>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
+
+template <typename Char>
+struct Properties::Less
+{
+	bool operator()(const std::basic_string<Char>& str1, const std::basic_string<Char>& str2) const
+	{
+		return std::lexicographical_compare
+			( str1.begin(), str1.end()
+			, str2.begin(), str2.end()
+			, [](Char c1, Char c2)
+				{
+					return std::tolower(c1) < std::tolower(c2);
+				}
+			);
+	}
+};
 
 class PropertyParser
 {

--- a/src/main/include/log4cxx/helpers/properties.h
+++ b/src/main/include/log4cxx/helpers/properties.h
@@ -32,7 +32,12 @@ namespace helpers
 class LOG4CXX_EXPORT Properties
 {
 	private:
-		typedef std::map<LogString, LogString> PropertyMap;
+		template <typename Char> struct Less;
+#if LOG4CXX_ABI_VERSION < 15
+		using PropertyMap = std::map<LogString, LogString>;
+#else
+		using PropertyMap = std::map<LogString, LogString, Less<logchar> >;
+#endif
 		PropertyMap* properties;
 
 	public: // ...structors

--- a/src/test/cpp/helpers/propertiestestcase.cpp
+++ b/src/test/cpp/helpers/propertiestestcase.cpp
@@ -306,7 +306,7 @@ public:
 		LOGUNIT_ASSERT_EQUAL(keyCount, 2);
 #else
 		LOGUNIT_ASSERT_EQUAL(keyCount, 1);
-		LOGUNIT_ASSERT_EQUAL(properties.get(keys.front()), LOG4CXX_STR("value2"));
+		LOGUNIT_ASSERT_EQUAL(properties.get(LOG4CXX_STR("key")), LOG4CXX_STR("value2"));
 #endif
 	}
 

--- a/src/test/cpp/helpers/propertiestestcase.cpp
+++ b/src/test/cpp/helpers/propertiestestcase.cpp
@@ -44,6 +44,7 @@ LOGUNIT_CLASS(PropertiesTestCase)
 	LOGUNIT_TEST(testCRLF);
 	LOGUNIT_TEST(testLF);
 	LOGUNIT_TEST(testMixedLineEndings);
+	LOGUNIT_TEST(testCaseSensitivity);
 	LOGUNIT_TEST_SUITE_END();
 
 public:
@@ -293,6 +294,20 @@ public:
 		LOGUNIT_ASSERT_EQUAL(LogString(LOG4CXX_STR("hi this is a test")), value1);
 		LOGUNIT_ASSERT_EQUAL(LogString(LOG4CXX_STR("something")), value2);
 		LOGUNIT_ASSERT_EQUAL(LogString(LOG4CXX_STR("some_value")), value3);
+	}
+
+	void testCaseSensitivity(){
+		Properties properties;
+		properties.setProperty(LOG4CXX_STR("key"), LOG4CXX_STR("value1"));
+		properties.setProperty(LOG4CXX_STR("Key"), LOG4CXX_STR("value2"));
+		auto keys = properties.propertyNames();
+		auto keyCount = static_cast<int>(keys.size());
+#if LOG4CXX_ABI_VERSION < 15
+		LOGUNIT_ASSERT_EQUAL(keyCount, 2);
+#else
+		LOGUNIT_ASSERT_EQUAL(keyCount, 1);
+		LOGUNIT_ASSERT_EQUAL(properties.get(keys.front()), LOG4CXX_STR("value2"));
+#endif
 	}
 
 };

--- a/src/test/cpp/helpers/threadutilitytestcase.cpp
+++ b/src/test/cpp/helpers/threadutilitytestcase.cpp
@@ -163,6 +163,8 @@ public:
 		auto logger = LogManager::getRootLogger();
 		logger->addAppender(appender);
 		std::thread t = ThreadUtility::instance()->createThread( LOG4CXX_STR("FooName"), [logger]() {
+			// wait 30 ms for thread name change to be effected
+			std::this_thread::sleep_for(std::chrono::milliseconds(30));
 			LOG4CXX_DEBUG(logger, "Test message");
 		});
 		t.join();


### PR DESCRIPTION
This PR changes Log4cxx behaviour (when the next ABI version is released) by equating option names that differ only in character case.