### PR TITLE
Handle U+FFFF correctly in decodeUTF8 recovery path

### DIFF
--- a/src/main/cpp/transcoder.cpp
+++ b/src/main/cpp/transcoder.cpp
@@ -46,6 +46,7 @@ void Transcoder::decodeUTF8(const std::string& src, LogString& dst)
 
 	while (iter != src.end())
 	{
+		std::string::const_iterator start = iter;
 		unsigned int sv = decode(src, iter);
 
 		if (sv != 0xFFFF)
@@ -55,7 +56,16 @@ void Transcoder::decodeUTF8(const std::string& src, LogString& dst)
 		else
 		{
 			dst.append(1, LOSSCHAR);
-			iter++;
+
+			// decode() returns 0xFFFF both for a decode error (iter left at
+			// start) and for a successfully decoded U+FFFF (iter already
+			// advanced past EF BF BF).  Only advance here in the former case,
+			// otherwise the byte following U+FFFF is skipped and, at end of
+			// input, iter is pushed past src.end().
+			if (iter == start)
+			{
+				iter++;
+			}
 		}
 	}
 }

--- a/src/test/cpp/helpers/transcodertestcase.cpp
+++ b/src/test/cpp/helpers/transcodertestcase.cpp
@@ -70,6 +70,7 @@ LOGUNIT_CLASS(TranscoderTestCase)
 	LOGUNIT_TEST(testDecodeUTF8_RejectAboveMax);
 	LOGUNIT_TEST(testDecodeUTF8_MaxBoundary);
 	LOGUNIT_TEST(testDecodeUTF8_RejectInvalidLeadByte);
+	LOGUNIT_TEST(testDecodeUTF8_FFFF_KeepsFollowingByte);
 	LOGUNIT_TEST(testEncodeUTF16BE_BMP);
 	LOGUNIT_TEST(testEncodeUTF16BE_Supplementary);
 	LOGUNIT_TEST(testEncodeUTF16LE_Supplementary);
@@ -463,6 +464,22 @@ public:
 			bool hasLoss = out.find(Transcoder::LOSSCHAR) != LogString::npos;
 			LOGUNIT_ASSERT_EQUAL(c.reject, hasLoss);
 		}
+	}
+
+	/**
+	 * U+FFFF (EF BF BF) is a legal three-byte sequence whose scalar value
+	 * collides with the 0xFFFF error sentinel returned by Transcoder::decode.
+	 * decode() consumes all three bytes and returns 0xFFFF, but decodeUTF8
+	 * mistakes that for a decode failure (which leaves the iterator parked)
+	 * and advances the iterator a second time. The byte following U+FFFF is
+	 * therefore silently dropped. Here the trailing 'A' must survive.
+	 */
+	void testDecodeUTF8_FFFF_KeepsFollowingByte()
+	{
+		std::string src("\xEF\xBF\xBF\x41"); // U+FFFF then 'A'
+		LogString out;
+		Transcoder::decodeUTF8(src, out);
+		LOGUNIT_ASSERT(out.find(LOG4CXX_STR("A")) != LogString::npos);
 	}
 
 	void testEncodeUTF16BE_BMP()


### PR DESCRIPTION
### Summary

This change fixes an iterator advancement issue in `Transcoder::decodeUTF8()` when processing the UTF-8 sequence `EF BF BF` (U+FFFF).

### Root Cause

`Transcoder::decode()` uses `0xFFFF` as an internal error sentinel, but a successful decode of U+FFFF also returns `0xFFFF`.

`decodeUTF8()` treated both cases identically and always advanced the iterator, causing the byte immediately following U+FFFF to be skipped.

### Fix

Only advance the iterator when `decode()` did not consume any input.

This preserves the existing error-recovery behavior while avoiding the extra iterator advance after a successfully decoded U+FFFF sequence.