### PR TITLE
Fix ignored gzip exit status in GZCompressAction

### DIFF
--- a/src/main/cpp/exception.cpp
+++ b/src/main/cpp/exception.cpp
@@ -22,6 +22,7 @@
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/transcoder.h>
 #include <apr_errno.h>
+#include <apr_thread_proc.h>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::helpers;
@@ -160,6 +161,43 @@ IOException& IOException::operator=(const IOException& src)
 LogString IOException::formatMessage(log4cxx_status_t stat)
 {
 	return makeMessage(LOG4CXX_STR("IO Exception"), stat);
+}
+
+SubProcessFailure::SubProcessFailure(const LogString& processName, int exitCode, int exitWhy)
+	: Exception(makeMessage(processName, exitCode, exitWhy))
+{
+}
+
+#if !LOG4CXX_LOGCHAR_IS_UTF8
+SubProcessFailure::SubProcessFailure(const char* processName, int exitCode, int exitWhy)
+	: Exception(makeMessage(Transcoder::decode(processName), exitCode, exitWhy))
+{
+}
+#endif
+
+SubProcessFailure::SubProcessFailure(const SubProcessFailure& src)
+	: Exception(src)
+{
+}
+
+SubProcessFailure& SubProcessFailure::operator=(const SubProcessFailure& src)
+{
+	Exception::operator=(src);
+	return *this;
+}
+
+LogString SubProcessFailure::makeMessage(const LogString& processName, int exitCode, int exitWhy)
+{
+	LogString msg = processName;
+	msg += LOG4CXX_STR(" exit code: ");
+	LogString codeStr;
+	StringHelper::toString(exitCode, codeStr);
+	msg += codeStr;
+	if (APR_PROC_SIGNAL == exitWhy || APR_PROC_SIGNAL_CORE == exitWhy)
+	{
+		msg += LOG4CXX_STR("; exited due to a signal");
+	}
+	return msg;
 }
 
 LogString Exception::makeMessage(const LogString& type, log4cxx_status_t stat)

--- a/src/main/cpp/gzcompressaction.cpp
+++ b/src/main/cpp/gzcompressaction.cpp
@@ -153,12 +153,18 @@ bool GZCompressAction::execute( LOG4CXX_EXECUTE_ACTION_FORMAL_PARAMETERS ) const
 			return true;
 		}
 
-		apr_proc_wait(&pid, NULL, NULL, APR_WAIT);
+		int exitCode = 0;
+		apr_proc_wait(&pid, &exitCode, NULL, APR_WAIT);
 		stat = apr_file_close(child_out);
 
 		if (stat != APR_SUCCESS)
 		{
 			throw IOException(stat);
+		}
+
+		if (exitCode != APR_SUCCESS)
+		{
+			throw IOException(exitCode);
 		}
 
 		priv->destination.setAutoDelete(false);

--- a/src/main/cpp/gzcompressaction.cpp
+++ b/src/main/cpp/gzcompressaction.cpp
@@ -154,7 +154,8 @@ bool GZCompressAction::execute( LOG4CXX_EXECUTE_ACTION_FORMAL_PARAMETERS ) const
 		}
 
 		int exitCode = 0;
-		apr_proc_wait(&pid, &exitCode, NULL, APR_WAIT);
+		apr_exit_why_e reason;
+		apr_proc_wait(&pid, &exitCode, &reason, APR_WAIT);
 		stat = apr_file_close(child_out);
 
 		if (stat != APR_SUCCESS)
@@ -162,9 +163,9 @@ bool GZCompressAction::execute( LOG4CXX_EXECUTE_ACTION_FORMAL_PARAMETERS ) const
 			throw IOException(stat);
 		}
 
-		if (exitCode != APR_SUCCESS)
+		if (exitCode != 0)
 		{
-			throw IOException(exitCode);
+			throw SubProcessFailure(LOG4CXX_STR("gzip"), exitCode, reason);
 		}
 
 		priv->destination.setAutoDelete(false);

--- a/src/main/cpp/zipcompressaction.cpp
+++ b/src/main/cpp/zipcompressaction.cpp
@@ -138,11 +138,12 @@ bool ZipCompressAction::execute( LOG4CXX_EXECUTE_ACTION_FORMAL_PARAMETERS ) cons
 	}
 
 	int exitCode;
-	apr_proc_wait(&pid, &exitCode, NULL, APR_WAIT);
+	apr_exit_why_e reason;
+	apr_proc_wait(&pid, &exitCode, &reason, APR_WAIT);
 
-	if (exitCode != APR_SUCCESS)
+	if (exitCode != 0)
 	{
-		throw IOException(exitCode);
+		throw SubProcessFailure(LOG4CXX_STR("zip"), exitCode, reason);
 	}
 
 	if (priv->deleteSource)

--- a/src/main/include/log4cxx/helpers/exception.h
+++ b/src/main/include/log4cxx/helpers/exception.h
@@ -108,6 +108,19 @@ class LOG4CXX_EXPORT IOException : public Exception
 		static LogString formatMessage(log4cxx_status_t stat);
 };
 
+class LOG4CXX_EXPORT SubProcessFailure : public Exception
+{
+	public:
+		SubProcessFailure(const LogString& processName, int exitCode, int exitWhy);
+#if !LOG4CXX_LOGCHAR_IS_UTF8
+		SubProcessFailure(const char* processName, int exitCode, int exitWhy);
+#endif
+		SubProcessFailure(const SubProcessFailure& src);
+		SubProcessFailure& operator=(const SubProcessFailure&);
+
+		static LogString makeMessage(const LogString& processName, int exitCode, int exitWhy);
+};
+
 class LOG4CXX_EXPORT MissingResourceException : public Exception
 {
 	public:

--- a/src/test/cpp/fileappendertest.cpp
+++ b/src/test/cpp/fileappendertest.cpp
@@ -21,6 +21,7 @@
 #include <log4cxx/helpers/loglog.h>
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/transcoder.h>
+#include <log4cxx/helpers/exception.h>
 #include <log4cxx/helpers/fileoutputstream.h>
 #include <log4cxx/rolling/rollingfileappender.h>
 #include <log4cxx/rolling/timebasedrollingpolicy.h>
@@ -200,11 +201,7 @@ public:
 		apr_proc_wait(&pid, &exitCode, &reason, APR_WAIT);
 		if (exitCode != 0)
 		{
-			LogString msg = LOG4CXX_STR("child exit code: ");
-			helpers::StringHelper::toString(exitCode, msg);
-			msg += LOG4CXX_STR("; reason: ");
-			helpers::StringHelper::toString(reason, msg);
-			helpers::LogLog::warn(msg);
+			helpers::LogLog::warn(helpers::SubProcessFailure::makeMessage(LOG4CXX_STR("child"), exitCode, reason));
 		}
 		LOGUNIT_ASSERT_EQUAL(exitCode, 0);
 

--- a/src/test/cpp/net/telnetappendertestcase.cpp
+++ b/src/test/cpp/net/telnetappendertestcase.cpp
@@ -27,6 +27,7 @@
 #include <log4cxx/helpers/pool.h>
 #include <log4cxx/config/propertysetter.h>
 #include <log4cxx/helpers/transcoder.h>
+#include <log4cxx/helpers/exception.h>
 #include <log4cxx/helpers/socket.h>
 #include <log4cxx/spi/configurator.h>
 #include <apr_thread_proc.h>
@@ -172,11 +173,7 @@ class TelnetAppenderTestCase : public AppenderSkeletonTestCase
 			apr_proc_wait(&pid, &exitCode, &reason, APR_WAIT);
 			if (exitCode != 0 && helpers::LogLog::isDebugEnabled())
 			{
-				LogString msg = LOG4CXX_STR("child exit code: ");
-				helpers::StringHelper::toString(exitCode, msg);
-				msg += LOG4CXX_STR("; reason: ");
-				helpers::StringHelper::toString(reason, msg);
-				helpers::LogLog::debug(msg);
+				helpers::LogLog::debug(helpers::SubProcessFailure::makeMessage(LOG4CXX_STR("child"), exitCode, reason));
 			}
 			LOGUNIT_ASSERT_EQUAL(exitCode, 0);
 		}

--- a/src/test/cpp/rolling/multiprocessrollingtest.cpp
+++ b/src/test/cpp/rolling/multiprocessrollingtest.cpp
@@ -28,6 +28,7 @@
 #include <log4cxx/helpers/fileoutputstream.h>
 #include <log4cxx/helpers/loglog.h>
 #include <log4cxx/helpers/stringhelper.h>
+#include <log4cxx/helpers/exception.h>
 #include <filesystem>
 #include <fstream>
 #include <apr_thread_proc.h>
@@ -214,10 +215,7 @@ public:
 			{
 				LogString msg = LOG4CXX_STR("child: ");
 				helpers::StringHelper::toString(i, msg);
-				msg += LOG4CXX_STR("; exit code: ");
-				helpers::StringHelper::toString(exitCode, msg);
-				msg += LOG4CXX_STR("; reason: ");
-				helpers::StringHelper::toString(reason, msg);
+				msg += LOG4CXX_STR("; ") + helpers::SubProcessFailure::makeMessage(LOG4CXX_STR("child"), exitCode, reason);
 				helpers::LogLog::debug(msg);
 			}
 			LOGUNIT_ASSERT_EQUAL(exitCode, 0);


### PR DESCRIPTION
GZCompressAction::execute currently waits for the spawned gzip process using apr_proc_wait, but discards the child process exit status by passing NULL for the exit code parameter.

As a result, failures from the compression process are not explicitly detected before execution continues. This behavior differs from ZipCompressAction::execute, which retrieves and validates the child process exit status.

This patch updates GZCompressAction::execute to capture the exit status returned by apr_proc_wait and validate it before proceeding, aligning its behavior with the existing implementation in ZipCompressAction.

Impact
Improves error handling consistency for compression actions and ensures that gzip process failures are not silently ignored.
Proposed Changes
Retrieve the child process exit status in GZCompressAction::execute.
Validate the returned exit status before continuing.
Align gzip compression handling with the existing ZipCompressAction implementation.