### PR TITLE
Migrate hexdump() to Safe Buffers

### DIFF
--- a/src/cmake/compiler-features/check-compiler-support.cmake
+++ b/src/cmake/compiler-features/check-compiler-support.cmake
@@ -1,5 +1,12 @@
 # This module checks compiler and standard library support
 #
+include(CheckCXXCompilerFlag)
+
+# Does the compiler support the Safe Buffers diagnostic -Wunsafe-buffer-usage?
+# (Clang >= 16.)  Used to enforce, on a per-file basis, that translation units
+# migrated to the Safe Buffers Programming Model stay free of unchecked raw
+# pointer/array arithmetic.  See LOG4CXX_ENABLE_SAFE_BUFFERS.
+check_cxx_compiler_flag("-Wunsafe-buffer-usage" LOG4CXX_HAS_WUNSAFE_BUFFER_USAGE)
 
 # Does the compiler support thread_local?
 if(MINGW)

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -264,3 +264,34 @@ endif()
 if(${ENABLE_FMT_LAYOUT})
     target_link_libraries(log4cxx PUBLIC fmt::fmt)
 endif()
+
+# --- Safe Buffers Programming Model enforcement ------------------------------
+# Translation units below have been migrated to the Safe Buffers Programming
+# Model: raw C buffers and pointer arithmetic over untrusted input are replaced
+# by bounds-aware views/containers (e.g. std::span).  Compiling them with
+# Clang's -Wunsafe-buffer-usage prevents the unsafe patterns from being
+# reintroduced.  Append a file to this list once it has been migrated.
+set(LOG4CXX_SAFE_BUFFERS_SOURCES
+  hexdump.cpp
+)
+
+option(LOG4CXX_ENABLE_SAFE_BUFFERS
+  "Compile Safe-Buffers-migrated sources with -Wunsafe-buffer-usage (Clang)" OFF)
+option(LOG4CXX_SAFE_BUFFERS_AS_ERROR
+  "Treat -Wunsafe-buffer-usage as an error in Safe-Buffers-migrated sources" OFF)
+
+if(LOG4CXX_ENABLE_SAFE_BUFFERS)
+  if(LOG4CXX_HAS_WUNSAFE_BUFFER_USAGE)
+    set(_safe_buffers_flags -Wunsafe-buffer-usage)
+    if(LOG4CXX_SAFE_BUFFERS_AS_ERROR)
+      list(APPEND _safe_buffers_flags -Werror=unsafe-buffer-usage)
+    endif()
+    set_source_files_properties(${LOG4CXX_SAFE_BUFFERS_SOURCES}
+      PROPERTIES COMPILE_OPTIONS "${_safe_buffers_flags}")
+    message(STATUS "Safe Buffers enforcement enabled for: ${LOG4CXX_SAFE_BUFFERS_SOURCES}")
+  else()
+    message(WARNING
+      "LOG4CXX_ENABLE_SAFE_BUFFERS is ON but the compiler does not support "
+      "-Wunsafe-buffer-usage; Safe Buffers enforcement is disabled.")
+  endif()
+endif()

--- a/src/main/cpp/hexdump.cpp
+++ b/src/main/cpp/hexdump.cpp
@@ -26,14 +26,49 @@
 #include <ios>
 #include <iomanip>
 #include <cctype>
+#include <cstddef>
+#include <cstdint>
+#if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
+	#include <span>
+#endif
 
 using namespace LOG4CXX_NS;
 
 typedef std::basic_stringstream<logchar> LogStream;
 
+namespace {
+
+// Safe Buffers Programming Model: hexdump() receives a raw (pointer, length)
+// pair describing an untrusted byte buffer (typically bytes just read from a
+// socket or file).  Indexing that pointer directly with computed offsets is
+// exactly the unsafe pattern that Clang's -Wunsafe-buffer-usage flags, because
+// a single off-by-one in the bookkeeping below would read out of bounds.
+//
+// To remove that hazard the formatting code is written once against a
+// bounds-aware contiguous view.  When std::span is available (C++20) it is
+// used directly so -Wunsafe-buffer-usage accepts the body; on older toolchains
+// a minimal drop-in view provides the same subset of the API.
+#if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
+using ByteView = std::span<const uint8_t>;
+#else
+class ByteView
+{
+	public:
+		ByteView(const uint8_t* data, std::size_t size) noexcept
+			: m_data(data), m_size(size) {}
+		std::size_t size() const noexcept { return m_size; }
+		uint8_t operator[](std::size_t index) const noexcept { return m_data[index]; }
+	private:
+		const uint8_t* m_data;
+		std::size_t m_size;
+};
+#endif
+
+} // namespace
+
 LogString LOG4CXX_NS::hexdump(const void* bytes, uint32_t len, HexdumpFlags flags){
 	LogString ret;
-	const uint8_t* bytes_u8 = static_cast<const uint8_t*>(bytes);
+	const ByteView data{ static_cast<const uint8_t*>(bytes), len };
 	LogStream sstream;
 #if LOG4CXX_LOGCHAR_IS_WCHAR
 	const wchar_t fill_char = L'0';
@@ -47,7 +82,7 @@ LogString LOG4CXX_NS::hexdump(const void* bytes, uint32_t len, HexdumpFlags flag
 		sstream << LOG4CXX_EOL;
 	}
 
-	for(uint32_t offset = 0; offset < len; offset += 16){
+	for(uint32_t offset = 0; offset < data.size(); offset += 16){
 		if(offset != 0){
 			sstream << LOG4CXX_EOL;
 		}
@@ -59,7 +94,7 @@ LogString LOG4CXX_NS::hexdump(const void* bytes, uint32_t len, HexdumpFlags flag
 
 		// Print out the first 8 bytes
 		for(int byte = 0; byte < 8; byte++){
-			if(offset + byte >= len){
+			if(offset + byte >= data.size()){
 				sstream << LOG4CXX_STR("  ");
 				if(byte != 8){
 					sstream << LOG4CXX_STR(" ");
@@ -67,7 +102,7 @@ LogString LOG4CXX_NS::hexdump(const void* bytes, uint32_t len, HexdumpFlags flag
 				continue;
 			}
 
-			sstream << std::hex << std::setw(2) << std::setfill(fill_char) << static_cast<int>(bytes_u8[offset + byte]) << std::resetiosflags(std::ios_base::fmtflags(0));
+			sstream << std::hex << std::setw(2) << std::setfill(fill_char) << static_cast<int>(data[offset + byte]) << std::resetiosflags(std::ios_base::fmtflags(0));
 			sstream << std::setfill(space_fill_char);
 			if(byte != 8){
 				sstream << LOG4CXX_STR(" ");
@@ -78,7 +113,7 @@ LogString LOG4CXX_NS::hexdump(const void* bytes, uint32_t len, HexdumpFlags flag
 
 		// Print out the last 8 bytes
 		for(int byte = 8; byte < 16; byte++){
-			if(offset + byte >= len){
+			if(offset + byte >= data.size()){
 				sstream << LOG4CXX_STR("  ");
 				if(byte != 15){
 					sstream << LOG4CXX_STR(" ");
@@ -86,7 +121,7 @@ LogString LOG4CXX_NS::hexdump(const void* bytes, uint32_t len, HexdumpFlags flag
 				continue;
 			}
 
-			sstream << std::hex << std::setw(2) << std::setfill(fill_char) << static_cast<int>(bytes_u8[offset + byte]) << std::resetiosflags(std::ios_base::fmtflags(0));
+			sstream << std::hex << std::setw(2) << std::setfill(fill_char) << static_cast<int>(data[offset + byte]) << std::resetiosflags(std::ios_base::fmtflags(0));
 			if(byte != 15){
 				sstream << LOG4CXX_STR(" ");
 			}
@@ -95,11 +130,11 @@ LogString LOG4CXX_NS::hexdump(const void* bytes, uint32_t len, HexdumpFlags flag
 		// Print out the ASCII text
 		sstream << LOG4CXX_STR("  |");
 		for(int byte = 0; byte < 16; byte++){
-			if(offset + byte >= len){
+			if(offset + byte >= data.size()){
 				break;
 			}
-			if(std::isprint(bytes_u8[offset + byte])){
-				logchar to_append = bytes_u8[offset + byte];
+			if(std::isprint(static_cast<unsigned char>(data[offset + byte]))){
+				logchar to_append = data[offset + byte];
 				sstream << to_append;
 			}else{
 				sstream << LOG4CXX_STR(".");

--- a/src/test/cpp/hexdumptestcase.cpp
+++ b/src/test/cpp/hexdumptestcase.cpp
@@ -28,6 +28,7 @@ LOGUNIT_CLASS(HexdumpTestCase)
 	LOGUNIT_TEST(test2);
 	LOGUNIT_TEST(test_newline);
 	LOGUNIT_TEST(test_newline2);
+	LOGUNIT_TEST(test_empty);
 	LOGUNIT_TEST_SUITE_END();
 
 public:
@@ -97,6 +98,15 @@ public:
 				LOG4CXX_EOL;
 
 		LogString dumped = log4cxx::hexdump(test1_str, sizeof(test1_str), HexdumpFlags::AddStartingNewline | HexdumpFlags::AddEndingNewline);
+		LOGUNIT_ASSERT_EQUAL(expectedOutput, dumped);
+	}
+
+	// A zero-length buffer must not read any bytes and produces no rows.
+	// This exercises the lower bound of the Safe Buffers view used internally.
+	void test_empty()
+	{
+		LogString expectedOutput;
+		LogString dumped = log4cxx::hexdump(nullptr, 0);
 		LOGUNIT_ASSERT_EQUAL(expectedOutput, dumped);
 	}
 


### PR DESCRIPTION
This PR adopts the Safe Buffers Programming Model for the `hexdump()` implementation by replacing raw buffer access patterns with bounds-aware buffer views.

The change migrates `hexdump.cpp` from direct pointer arithmetic on untrusted input buffers to `std::span<const uint8_t>` when building with C++20, with a lightweight compatibility view for older supported standards. This reduces the risk of future out-of-bounds memory access bugs while preserving existing behavior and output formatting.

## Changes

### Safe buffer migration

* Replaced raw pointer indexing and arithmetic in `hexdump()` with bounds-aware buffer views.
* Added `std::span<const uint8_t>` support for C++20 builds.
* Added a minimal compatibility `ByteView` implementation for older supported language standards.
* Ensured all buffer access is performed through view-based indexing and size tracking.

### Character handling hardening

* Updated `isprint()` usage to operate on an unsigned character value, avoiding undefined behavior for negative signed character inputs.

### Regression-prevention infrastructure

* Added compiler detection for `-Wunsafe-buffer-usage`.
* Introduced `LOG4CXX_HAS_WUNSAFE_BUFFER_USAGE`.
* Added optional safe-buffer enforcement controls:

  * `LOG4CXX_ENABLE_SAFE_BUFFERS`
  * `LOG4CXX_SAFE_BUFFERS_AS_ERROR`
* Applied warning enforcement on a per-file basis for migrated sources.
* Preserved compatibility with compilers that do not support the warning.

### Tests

* Added a zero-length buffer test case covering an important boundary condition handled by the new buffer view abstraction.
