### PR TITLE
Fix runner being used

### DIFF
--- a/.github/workflows/log4cxx-ubuntu.yml
+++ b/.github/workflows/log4cxx-ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
         name: [ubuntu24-gcc, ubuntu24-clang, ubuntu26-gcc, ubuntu26-clang]
         include:
           - name: ubuntu24-gcc
-            os: ubuntu24.04
+            os: ubuntu-24.04
             cxx: g++
             fmt: OFF
             qt: ON
@@ -39,7 +39,7 @@ jobs:
             logchar: utf-8
             next_abi: OFF
           - name: ubuntu24-clang
-            os: ubuntu24.04
+            os: ubuntu-24.04
             cxx: clang++
             fmt: OFF
             qt: OFF


### PR DESCRIPTION
It seems the label for the runner changed at some point, so the ubuntu 24 builds were waiting indefinitely for the runner to come up