### PR TITLE
Restore LoggingEvent throughput performance

### DIFF
--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -156,7 +156,7 @@ struct LoggingEvent::LoggingEventPrivate
 	 */
 	helpers::AsyncBuffer messageAppender;
 
-	/** Ensures the deferred message is RenderingCompleted exactly once.
+	/** Ensures an async message is rendered exactly once.
 	 *
 	 *  A LoggingEvent may be shared between threads, e.g. when it is
 	 *  queued to an AsyncAppender dispatcher while the logging thread
@@ -179,24 +179,23 @@ struct LoggingEvent::LoggingEventPrivate
 		uint8_t unrenderedState{ RenderingRequired };
 		if (renderState.compare_exchange_strong(unrenderedState, RenderingActive, std::memory_order_acquire))
 		{
-			if (!this->messageAppender.empty())
+			if (this->messageAppender.empty())
+				;
+			else try
 			{
-				try
-				{
-					helpers::LogCharMessageBuffer buf;
-					this->messageAppender.renderMessage(buf);
-					this->message = buf.extract_str(buf);
-					this->messageAppender.clear();
+				helpers::LogCharMessageBuffer buf;
+				this->messageAppender.renderMessage(buf);
+				this->message = buf.extract_str(buf);
+				this->messageAppender.clear();
 
-				}
-				catch (const std::exception& e)
-				{
-					helpers::Transcoder::decode(e.what(), this->message);
-				}
-				catch (...)
-				{
-					this->message = LOG4CXX_STR("mesage rendering failed");
-				}
+			}
+			catch (const std::exception& e)
+			{
+				helpers::Transcoder::decode(e.what(), this->message);
+			}
+			catch (...)
+			{
+				this->message = LOG4CXX_STR("mesage rendering failed");
 			}
 			renderState.store(RenderingCompleted, std::memory_order_release);
 		}

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -33,6 +33,9 @@
 #include <log4cxx/helpers/messagebuffer.h>
 #include <log4cxx/helpers/date.h>
 #include <log4cxx/helpers/optional.h>
+#include <atomic>
+#include <memory>
+#include <thread>
 
 using namespace LOG4CXX_NS;
 using namespace LOG4CXX_NS::spi;
@@ -158,11 +161,17 @@ struct LoggingEvent::LoggingEventPrivate
 	 *  move-assign \c message - a concurrent free/assign of the same
 	 *  heap buffer.
 	 */
-	std::once_flag renderOnce;
+	std::atomic<int> rendered{ 0 } ;
 
 	void renderMessage()
 	{
-		std::call_once(this->renderOnce, [this]()
+		int unrenderedValue{ 0 };
+		int isActiveValue{ 1 };
+		int renderedValue{ 2 };
+		if (rendered.compare_exchange_strong(unrenderedValue, isActiveValue
+				, std::memory_order_relaxed
+				, std::memory_order_relaxed
+				))
 		{
 			if (!this->messageAppender.empty())
 			{
@@ -171,7 +180,13 @@ struct LoggingEvent::LoggingEventPrivate
 				this->message = buf.extract_str(buf);
 				this->messageAppender.clear();
 			}
-		});
+			rendered.compare_exchange_strong(isActiveValue, renderedValue
+				, std::memory_order_relaxed
+				, std::memory_order_relaxed
+				);
+		}
+		else while (renderedValue != rendered.load(std::memory_order_relaxed))
+			std::this_thread::yield();
 	}
 };
 

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -161,17 +161,14 @@ struct LoggingEvent::LoggingEventPrivate
 	 *  move-assign \c message - a concurrent free/assign of the same
 	 *  heap buffer.
 	 */
-	std::atomic<int> rendered{ 0 } ;
+	std::atomic<uint8_t> rendered{ 0 } ;
 
 	void renderMessage()
 	{
-		int unrenderedValue{ 0 };
-		int isActiveValue{ 1 };
-		int renderedValue{ 2 };
-		if (rendered.compare_exchange_strong(unrenderedValue, isActiveValue
-				, std::memory_order_relaxed
-				, std::memory_order_relaxed
-				))
+		uint8_t unrenderedValue{ 0 };
+		uint8_t isActiveValue{ 1 };
+		uint8_t renderedValue{ 2 };
+		if (rendered.compare_exchange_strong(unrenderedValue, isActiveValue, std::memory_order_acquire))
 		{
 			if (!this->messageAppender.empty())
 			{
@@ -180,12 +177,9 @@ struct LoggingEvent::LoggingEventPrivate
 				this->message = buf.extract_str(buf);
 				this->messageAppender.clear();
 			}
-			rendered.compare_exchange_strong(isActiveValue, renderedValue
-				, std::memory_order_relaxed
-				, std::memory_order_relaxed
-				);
+			rendered.store(renderedValue, std::memory_order_acquire);
 		}
-		else while (renderedValue != rendered.load(std::memory_order_relaxed))
+		else while (renderedValue != rendered.load(std::memory_order_acquire))
 			std::this_thread::yield();
 	}
 };

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -33,6 +33,7 @@
 #include <log4cxx/helpers/messagebuffer.h>
 #include <log4cxx/helpers/date.h>
 #include <log4cxx/helpers/optional.h>
+#include <log4cxx/helpers/transcoder.h>
 #include <atomic>
 #include <memory>
 #include <thread>
@@ -188,10 +189,9 @@ struct LoggingEvent::LoggingEventPrivate
 					this->messageAppender.clear();
 
 				}
-				catch (std::exception& e)
+				catch (const std::exception& e)
 				{
-					LOG4CXX_DECODE_CHAR(msg, e.what());
-					this->message = msg;
+					helpers::Transcoder::decode(e.what(), this->message);
 				}
 				catch (...)
 				{

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -180,7 +180,7 @@ struct LoggingEvent::LoggingEventPrivate
 			}
 			rendered.store(renderedValue, std::memory_order_release);
 		}
-		else while (renderedValue != rendered.load(std::memory_order_acquire))
+		else for (int i = 0; i < 10 && renderedValue != rendered.load(std::memory_order_relaxed); ++i)
 			std::this_thread::yield();
 	}
 };

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -46,6 +46,7 @@ struct LoggingEvent::LoggingEventPrivate
 	LoggingEventPrivate(const ThreadSpecificData::NamePairPtr p = ThreadSpecificData::getNames()) :
 		timeStamp(0),
 		pNames(p)
+		, renderState(RenderingRequired)
 	{
 	}
 
@@ -62,7 +63,8 @@ struct LoggingEvent::LoggingEventPrivate
 		timeStamp(Date::currentTime()),
 		locationInfo(locationInfo1),
 		chronoTimeStamp(std::chrono::microseconds(timeStamp)),
-		pNames(p)
+		pNames(p),
+		renderState(RenderingCompleted)
 	{
 	}
 
@@ -80,6 +82,7 @@ struct LoggingEvent::LoggingEventPrivate
 		, chronoTimeStamp(std::chrono::microseconds(timeStamp))
 		, pNames(p)
 		, messageAppender(std::move(messageAppenderArg))
+		, renderState(RenderingRequired)
 	{
 	}
 
@@ -94,7 +97,8 @@ struct LoggingEvent::LoggingEventPrivate
 		timeStamp(Date::currentTime()),
 		locationInfo(locationInfo1),
 		chronoTimeStamp(std::chrono::microseconds(timeStamp)),
-		pNames(p)
+		pNames(p),
+		renderState(RenderingCompleted)
 	{
 	}
 
@@ -151,7 +155,7 @@ struct LoggingEvent::LoggingEventPrivate
 	 */
 	helpers::AsyncBuffer messageAppender;
 
-	/** Ensures the deferred message is rendered exactly once.
+	/** Ensures the deferred message is RenderingCompleted exactly once.
 	 *
 	 *  A LoggingEvent may be shared between threads, e.g. when it is
 	 *  queued to an AsyncAppender dispatcher while the logging thread
@@ -162,25 +166,41 @@ struct LoggingEvent::LoggingEventPrivate
 	 *  heap buffer.
 	 * Note: use of std::call_once was found to degrade throughput by up to 120%
 	 */
-	std::atomic<uint8_t> rendered{ 0 } ;
+	std::atomic<uint8_t> renderState;
+	static const uint8_t RenderingRequired = 0;
+	static const uint8_t RenderingActive = 1;
+	static const uint8_t RenderingCompleted = 2;
 
 	void renderMessage()
 	{
-		uint8_t unrenderedValue{ 0 };
-		uint8_t isActiveValue{ 1 };
-		uint8_t renderedValue{ 2 };
-		if (rendered.compare_exchange_strong(unrenderedValue, isActiveValue, std::memory_order_acquire))
+		if (renderState.load(std::memory_order_acquire) == RenderingCompleted)
+			return;
+		uint8_t unrenderedState{ RenderingRequired };
+		if (renderState.compare_exchange_strong(unrenderedState, RenderingActive, std::memory_order_acquire))
 		{
 			if (!this->messageAppender.empty())
 			{
-				helpers::LogCharMessageBuffer buf;
-				this->messageAppender.renderMessage(buf);
-				this->message = buf.extract_str(buf);
-				this->messageAppender.clear();
+				try
+				{
+					helpers::LogCharMessageBuffer buf;
+					this->messageAppender.renderMessage(buf);
+					this->message = buf.extract_str(buf);
+					this->messageAppender.clear();
+
+				}
+				catch (std::exception& e)
+				{
+					LOG4CXX_DECODE_CHAR(msg, e.what());
+					this->message = msg;
+				}
+				catch (...)
+				{
+					this->message = LOG4CXX_STR("mesage rendering failed");
+				}
 			}
-			rendered.store(renderedValue, std::memory_order_release);
+			renderState.store(RenderingCompleted, std::memory_order_release);
 		}
-		else for (int i = 0; i < 10 && renderedValue != rendered.load(std::memory_order_relaxed); ++i)
+		else while (renderState.load(std::memory_order_acquire) != RenderingCompleted)
 			std::this_thread::yield();
 	}
 };

--- a/src/main/cpp/loggingevent.cpp
+++ b/src/main/cpp/loggingevent.cpp
@@ -160,6 +160,7 @@ struct LoggingEvent::LoggingEventPrivate
 	 *  the closure vector while the other iterates it, and both
 	 *  move-assign \c message - a concurrent free/assign of the same
 	 *  heap buffer.
+	 * Note: use of std::call_once was found to degrade throughput by up to 120%
 	 */
 	std::atomic<uint8_t> rendered{ 0 } ;
 
@@ -177,7 +178,7 @@ struct LoggingEvent::LoggingEventPrivate
 				this->message = buf.extract_str(buf);
 				this->messageAppender.clear();
 			}
-			rendered.store(renderedValue, std::memory_order_acquire);
+			rendered.store(renderedValue, std::memory_order_release);
 		}
 		else while (renderedValue != rendered.load(std::memory_order_acquire))
 			std::this_thread::yield();

--- a/src/test/cpp/asyncappenderracestress.cpp
+++ b/src/test/cpp/asyncappenderracestress.cpp
@@ -127,7 +127,7 @@ public:
 	// Expected behavior:
 	// - Without single-shot rendering, ThreadSanitizer reports data races in
 	//   renderMessage (and the assertions below can observe torn messages).
-	// - With renderMessage guarded by std::call_once, ThreadSanitizer is clean
+	// - With renderMessage guarded by std::atomic, ThreadSanitizer is clean
 	//   and both threads observe identical messages.
 	void raceDeferredMessageRendering()
 	{


### PR DESCRIPTION
This PR fixes the following catastrophic performance degradation caused by the use of std::call_once in commit 2dc44dc.

Comparing commit_acaf388_benchmark.json to commit_2dc44dc_benchmark.json
| Benchmark | Time | CPU | Time  Old | Time New | 
| ------------ | ------ | ---- | ----------- | ----------- |
| Testing disabled logging request | -0.0052 | -0.0052 | 0 | 0|
| Testing disabled logging request/threads:6 | +0.0211 | +0.0211 | 0 | 0|
| Appending 5 char string using MessageBuffer, pattern: %m%n | +1.3364 | +1.3364 | 360 | 840|
| Appending 5 char string using MessageBuffer, pattern: %m%n/threads:6 | +1.8875 | +0.8603 | 573 | 1656|
| Appending 49 char string using MessageBuffer, pattern: %m%n | +1.2600 | +1.2601 | 390 | 882|
| Appending 49 char string using MessageBuffer, pattern: %m%n/threads:6 | +1.5799 | +0.5670 | 653 | 1686|
| Appending int value using MessageBuffer, pattern: %m%n | +0.8815 | +0.8815 | 542 | 1019|
| Appending int value using MessageBuffer, pattern: %m%n/threads:6 | +1.5328 | +0.4836 | 695 | 1760|
| Appending int+float using MessageBuffer, pattern: %m%n | +0.5231 | +0.5232 | 973 | 1483|
| Appending int+float using MessageBuffer, pattern: %m%n/threads:6 | +1.4483 | +0.5422 | 968 | 2370|
| Appending int+10float using MessageBuffer, pattern: %m%n | +0.0165 | +0.0165 | 4787 | 4866|
| Appending int+10float using MessageBuffer, pattern: %m%n/threads:6 | +0.0010 | +0.0017 | 2036 | 2038|
| Appending int value using MessageBuffer, pattern: [%d] %m%n | +0.8675 | +0.8676 | 637 | 1190|
| Appending int value using MessageBuffer, pattern: [%d] [%c] [%p] %m%n | +0.7394 | +0.7394 | 770 | 1340|
| Appending 49 char string using FMT, pattern: %m%n | +1.3553 | +1.3554 | 373 | 879|
| Appending 49 char string using FMT, pattern: %m%n/threads:6 | +1.4849 | +0.5792 | 696 | 1729|
| Appending int value using FMT, pattern: %m%n | +1.1461 | +1.1461 | 421 | 903|
| Appending int value using FMT, pattern: %m%n/threads:6 | +1.5843 | +0.6148 | 678 | 1753|
| Appending int+float using FMT, pattern: %m%n | +0.9075 | +0.9076 | 548 | 1046|
| Appending int+float using FMT, pattern: %m%n/threads:6 | +1.2775 | +0.3857 | 785 | 1789|
| Appending int+10float using FMT, pattern: %m%n | +0.2787 | +0.2787 | 1779 | 2275|
| Appending int+10float using FMT, pattern: %m%n/threads:6 | +0.6015 | +0.2497 | 1270 | 2034|
| Async, Sending int+10float using FMT and AsyncBuffer | +0.0093 | +0.0093 | 768 | 775|
| Async, Sending int+10float using FMT and AsyncBuffer/threads:6 | +0.0115 | +0.0092 | 1601 | 1620|
| Async, Sending int+10float using operator<< and AsyncBuffer | +0.0048 | +0.0048 | 1344 | 1351|
| Async, Sending int+10float using operator<< and AsyncBuffer/threads:6 | -0.0257 | -0.0283 | 1657 | 1615|
| Logging int+float using MessageBuffer, pattern: %d %m%n | +0.4026 | +0.4042 | 1216 | 1706|
| Logging int+float using MessageBuffer, pattern: %d %m%n/threads:6 | +0.6030 | +0.1085 | 1835 | 2942|
| Logging int+float using MessageBuffer, JSON | +0.0740 | +0.0739 | 5505 | 5912|
| Logging int+float using MessageBuffer, JSON/threads:6 | -0.3340 | -0.2294 | 8276 | 5512|