### PR TITLE
Use reasonable fuzzing input data sizes

### DIFF
--- a/src/fuzzers/cpp/HTMLLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/HTMLLayoutFuzzer.cpp
@@ -71,7 +71,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	std::string val4 = fdp.ConsumeRandomLengthString(MaxValueLength);
 	std::string ndcMessage = fdp.ConsumeRandomLengthString(MaxKeyLength);
 	std::string loggerStr = fdp.ConsumeRandomLengthString(MaxKeyLength);
-	std::string contentStr = fdp.ConsumeRemainingBytesAsString(MaxMessageLength);
+	std::string contentStr = fdp.ConsumeRemainingBytesAsString();
 
 	LogString key1, key2, val1, val2, logger, content;
 

--- a/src/fuzzers/cpp/HTMLLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/HTMLLayoutFuzzer.cpp
@@ -28,6 +28,13 @@ using namespace log4cxx;
 using namespace log4cxx::helpers;
 using namespace log4cxx::spi;
 
+namespace
+{
+	const int MaxKeyLength = 50;
+	const int MaxValueLength = 500;
+	const int MaxMessageLength = 2000;
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	// Setup HTMLLayout
 	HTMLLayout layout;
@@ -41,30 +48,30 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	}
 	// Optional threadinfo
 	if (fdp.ConsumeBool()) {
-		LOG4CXX_DECODE_CHAR(title, fdp.ConsumeRandomLengthString());
+		LOG4CXX_DECODE_CHAR(title, fdp.ConsumeRandomLengthString(MaxValueLength));
 		layout.setOption(LOG4CXX_STR("TITLE"), title);
 	}
 
 	// Header
 	if (fdp.ConsumeBool()) {
-		std::string headerStr = fdp.ConsumeRandomLengthString();
+		std::string headerStr = fdp.ConsumeRandomLengthString(MaxValueLength);
 		LogString header;
 		Transcoder::decode(headerStr, header);
 		layout.appendHeader(header, p);
 	}
 
 	// Create random strings we need later
-	std::string key1Str = fdp.ConsumeRandomLengthString();
-	std::string val1Str = fdp.ConsumeRandomLengthString();
-	std::string key2Str = fdp.ConsumeRandomLengthString();
-	std::string val2Str = fdp.ConsumeRandomLengthString();
-	std::string key3 = fdp.ConsumeRandomLengthString();
-	std::string val3 = fdp.ConsumeRandomLengthString();
-	std::string key4 = fdp.ConsumeRandomLengthString();
-	std::string val4 = fdp.ConsumeRandomLengthString();
-	std::string ndcMessage = fdp.ConsumeRandomLengthString();
-	std::string loggerStr = fdp.ConsumeRandomLengthString();
-	std::string contentStr = fdp.ConsumeRemainingBytesAsString();
+	std::string key1Str = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string val1Str = fdp.ConsumeRandomLengthString(MaxValueLength);
+	std::string key2Str = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string val2Str = fdp.ConsumeRandomLengthString(MaxValueLength);
+	std::string key3 = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string val3 = fdp.ConsumeRandomLengthString(MaxValueLength);
+	std::string key4 = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string val4 = fdp.ConsumeRandomLengthString(MaxValueLength);
+	std::string ndcMessage = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string loggerStr = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string contentStr = fdp.ConsumeRemainingBytesAsString(MaxMessageLength);
 
 	LogString key1, key2, val1, val2, logger, content;
 

--- a/src/fuzzers/cpp/PatternConverterFuzzer.cpp
+++ b/src/fuzzers/cpp/PatternConverterFuzzer.cpp
@@ -81,8 +81,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	// create strings from "data".
 	FuzzedDataProvider fdp(data, size);
 
-	auto loggerStr = fdp.ConsumeRandomLengthString();
-	auto contentStr = fdp.ConsumeRandomLengthString();
+	auto loggerStr = fdp.ConsumeRandomLengthString(MaximumNameByteCount);
+	auto contentStr = fdp.ConsumeRandomLengthString(MaximumOptionByteCount);
 
 	LogString logger, content;
 	Transcoder::decode(loggerStr, logger);

--- a/src/fuzzers/cpp/TimeBasedRollingPolicyFuzzer.cpp
+++ b/src/fuzzers/cpp/TimeBasedRollingPolicyFuzzer.cpp
@@ -28,6 +28,10 @@
 using namespace log4cxx;
 using namespace log4cxx::helpers;
 using namespace log4cxx::rolling;
+namespace
+{
+	const int MaxMessageLength = 2000;
+}
 
 // A fuzzer for TimeBasedRollingPolicy
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
@@ -65,7 +69,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 rfa->rollover(pool);
             }
 
-            LOG4CXX_DEBUG(logger, fdp.ConsumeRandomLengthString());
+            LOG4CXX_DEBUG(logger, fdp.ConsumeRandomLengthString(MaxMessageLength));
     }
 
     // Cleanup

--- a/src/fuzzers/cpp/XMLLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/XMLLayoutFuzzer.cpp
@@ -30,6 +30,12 @@
 using namespace log4cxx;
 using namespace log4cxx::helpers;
 using namespace log4cxx::spi;
+namespace
+{
+	const int MaxKeyLength = 50;
+	const int MaxValueLength = 500;
+	const int MaxMessageLength = 2000;
+}
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	// Setup XMLLayout
@@ -38,15 +44,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
 	// Create random strings
 	FuzzedDataProvider fdp(data, size);
-	std::string key1 = fdp.ConsumeRandomLengthString();
-	std::string val1 = fdp.ConsumeRandomLengthString();
-	std::string key2 = fdp.ConsumeRandomLengthString();
-	std::string val2 = fdp.ConsumeRandomLengthString();
-	std::string ndcMessage = fdp.ConsumeRandomLengthString();
-	std::string loggerString = fdp.ConsumeRandomLengthString();
-	std::string propkey = fdp.ConsumeRandomLengthString();
-	std::string propval = fdp.ConsumeRandomLengthString();
-	std::string content = fdp.ConsumeRemainingBytesAsString();
+	std::string key1 = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string val1 = fdp.ConsumeRandomLengthString(MaxValueLength);
+	std::string key2 = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string val2 = fdp.ConsumeRandomLengthString(MaxValueLength);
+	std::string ndcMessage = fdp.ConsumeRandomLengthString(MaxMessageLength);
+	std::string loggerString = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string propkey = fdp.ConsumeRandomLengthString(MaxKeyLength);
+	std::string propval = fdp.ConsumeRandomLengthString(MaxValueLength);
+	std::string content = fdp.ConsumeRemainingBytesAsString(MaxMessageLength);
 
 	log4cxx::LevelPtr level = log4cxx::Level::getInfo();
 	log4cxx::NDC::push(ndcMessage);

--- a/src/fuzzers/cpp/XMLLayoutFuzzer.cpp
+++ b/src/fuzzers/cpp/XMLLayoutFuzzer.cpp
@@ -52,7 +52,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	std::string loggerString = fdp.ConsumeRandomLengthString(MaxKeyLength);
 	std::string propkey = fdp.ConsumeRandomLengthString(MaxKeyLength);
 	std::string propval = fdp.ConsumeRandomLengthString(MaxValueLength);
-	std::string content = fdp.ConsumeRemainingBytesAsString(MaxMessageLength);
+	std::string content = fdp.ConsumeRemainingBytesAsString();
 
 	log4cxx::LevelPtr level = log4cxx::Level::getInfo();
 	log4cxx::NDC::push(ndcMessage);

--- a/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
+++ b/src/main/include/log4cxx/rolling/multiprocessrollingfileappender.h
@@ -51,6 +51,7 @@ class LOG4CXX_EXPORT MultiprocessRollingFileAppender : public RollingFileAppende
 	public:
 		MultiprocessRollingFileAppender();
 
+		using RollingFileAppender::activateOptions;
 		/**
 		\copybrief FileAppender::activateOptions()
 


### PR DESCRIPTION
This PR limits the size of fuzzing-tested strings to large but reasonable values to avoid unhelpful "timeout" reports